### PR TITLE
Ssot snow delete function

### DIFF
--- a/nautobot_ssot/integrations/servicenow/jobs.py
+++ b/nautobot_ssot/integrations/servicenow/jobs.py
@@ -22,7 +22,6 @@ class ServiceNowDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
 
     debug = BooleanVar(description="Enable for more verbose logging.", default=True)
 
-    # Uncomment below code to enable delete functionality in job
     delete_records = BooleanVar(
         description="Delete synced records from ServiceNow if not present in Nautobot",
         default=False,

--- a/nautobot_ssot/integrations/servicenow/jobs.py
+++ b/nautobot_ssot/integrations/servicenow/jobs.py
@@ -20,13 +20,13 @@ name = "SSoT - ServiceNow"  # pylint: disable=invalid-name
 class ServiceNowDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
     """Job syncing data from Nautobot to ServiceNow."""
 
-    debug = BooleanVar(description="Enable for more verbose logging.")
+    debug = BooleanVar(description="Enable for more verbose logging.", default=True)
 
-    # TODO: not yet implemented
-    # delete_records = BooleanVar(
-    #     description="Delete records from ServiceNow if not present in Nautobot",
-    #     default=False,
-    # )
+    # Uncomment below code to enable delete functionality in job
+    delete_records = BooleanVar(
+        description="Delete synced records from ServiceNow if not present in Nautobot",
+        default=False,
+    )
 
     site_filter = ObjectVar(
         description="Only sync records belonging to a single Site.",

--- a/nautobot_ssot/integrations/servicenow/jobs.py
+++ b/nautobot_ssot/integrations/servicenow/jobs.py
@@ -20,12 +20,9 @@ name = "SSoT - ServiceNow"  # pylint: disable=invalid-name
 class ServiceNowDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
     """Job syncing data from Nautobot to ServiceNow."""
 
-    debug = BooleanVar(description="Enable for more verbose logging.", default=True)
+    debug = BooleanVar(description="Enable for more verbose logging.")
 
-    delete_records = BooleanVar(
-        description="Delete synced records from ServiceNow if not present in Nautobot",
-        default=False,
-    )
+    delete_records = BooleanVar(description="Delete synced records from ServiceNow if not present in Nautobot")
 
     site_filter = ObjectVar(
         description="Only sync records belonging to a single Site.",


### PR DESCRIPTION
Added delete functionality to ServiceNowCRUDMixin in models.py. Disabled cacheing functionality in models.py as it was causing unpredictable results when testing deleting records from ServiceNow. Tested this code with a ServiceNow personal development environment and everything worked as intended in the current format. 

I was unsure as to whether the delete functionality should be available by default in the ServiceNow job but it is currently available by default. Please contact me with any questions/concerns. 