### PR TITLE
add support for lookups that span relationships in TypedDict

### DIFF
--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -204,7 +204,10 @@ class NautobotAdapter(DiffSync):
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         for related_object in getattr(database_object, parameter_name).all():
             dictionary_representation = {
-                field_name: getattr(related_object, field_name) for field_name in inner_type.__annotations__
+                field_name: NautobotAdapter._handle_foreign_key(related_object, field_name)
+                if "__" in field_name
+                else getattr(related_object, field_name)
+                for field_name in inner_type.__annotations__
             }
             # Only use those where there is a single field defined, all 'None's will not help us.
             if any(dictionary_representation.values()):

--- a/nautobot_ssot/tests/test_contrib.py
+++ b/nautobot_ssot/tests/test_contrib.py
@@ -132,6 +132,7 @@ class IPAddressDict(TypedDict):
 
     host: str
     mask_length: int
+    status__name: str
 
 
 class NautobotInterface(NautobotModel):
@@ -215,7 +216,10 @@ class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):
 
         self.assertEqual(
             diffsync_interface.ip_addresses,
-            [{"host": "192.0.2.1", "mask_length": 24}, {"host": "192.0.2.2", "mask_length": 24}],
+            [
+                {"host": "192.0.2.1", "mask_length": 24, "status__name": "Active"},
+                {"host": "192.0.2.2", "mask_length": 24, "status__name": "Active"},
+            ],
         )
 
     @skip("TODO: Update for 2.0")


### PR DESCRIPTION
This PR addresses https://github.com/nautobot/nautobot-plugin-ssot/issues/295 by adding support for lookups that span relationships in TypedDict