### PR TITLE
Arista CVP Integration Fixes

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -178,7 +178,7 @@ PLUGINS_CONFIG = {
         "aristacv_from_cloudvision_default_device_role": "network",
         "aristacv_from_cloudvision_default_device_role_color": "ff0000",
         "aristacv_from_cloudvision_default_site": "cloudvision_imported",
-        "aristacv_hostname_patterns": [[r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"]],
+        "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
         "aristacv_import_active": is_truthy(os.getenv("NAUTOBOT_ARISTACV_IMPORT_ACTIVE", False)),
         "aristacv_role_mappings": {
             "bb": "backbone",

--- a/nautobot_ssot/integrations/aristacv/constant.py
+++ b/nautobot_ssot/integrations/aristacv/constant.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 def _read_settings() -> dict:
     config = settings.PLUGINS_CONFIG["nautobot_ssot"]
-    return {key[9:]: value for key, value in config.items() if key.startswith("aristacv_")}
+    return config
 
 
 APP_SETTINGS = _read_settings()

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -39,7 +39,9 @@ class CloudvisionAdapter(DiffSync):
         """Load devices from CloudVision."""
         if APP_SETTINGS.get("create_controller"):
             cvp_version = cloudvision.get_cvp_version()
-            cvp_ver_cf = self.cf(name="arista_eos", value=cvp_version, device_name="CloudVision")
+            cvp_ver_cf = self.cf(
+                name="arista_eos", value=cvp_version, device_name="CloudVision"
+            )
             try:
                 self.add(cvp_ver_cf)
             except ObjectAlreadyExists as err:
@@ -57,9 +59,13 @@ class CloudvisionAdapter(DiffSync):
             try:
                 self.add(new_cvp)
             except ObjectAlreadyExists as err:
-                self.job.logger.warning(f"Error attempting to add CloudVision device. {err}")
+                self.job.logger.warning(
+                    f"Error attempting to add CloudVision device. {err}"
+                )
 
-        for index, dev in enumerate(cloudvision.get_devices(client=self.conn.comm_channel), start=1):
+        for index, dev in enumerate(
+            cloudvision.get_devices(client=self.conn.comm_channel), start=1
+        ):
             self.job.logger.info(f"Loading {index}° device")
             if dev["hostname"] != "":
                 new_device = self.device(
@@ -81,7 +87,9 @@ class CloudvisionAdapter(DiffSync):
                 self.load_ip_addresses(dev=new_device)
                 self.load_device_tags(device=new_device)
             else:
-                self.job.logger.warning(f"Device {dev} is missing hostname so won't be imported.")
+                self.job.logger.warning(
+                    f"Device {dev} is missing hostname so won't be imported."
+                )
                 continue
 
     def load_interfaces(self, device):
@@ -91,9 +99,13 @@ class CloudvisionAdapter(DiffSync):
             self.job.logger.debug(f"Chassis type for {device.name} is {chassis_type}.")
         port_info = []
         if chassis_type == "modular":
-            port_info = cloudvision.get_interfaces_chassis(client=self.conn, dId=device.serial)
+            port_info = cloudvision.get_interfaces_chassis(
+                client=self.conn, dId=device.serial
+            )
         elif chassis_type == "fixedSystem":
-            port_info = cloudvision.get_interfaces_fixed(client=self.conn, dId=device.serial)
+            port_info = cloudvision.get_interfaces_fixed(
+                client=self.conn, dId=device.serial
+            )
         elif chassis_type == "Unknown":
             self.job.logger.warning(
                 f"Unable to determine chassis type for {device.name} so will be unable to retrieve interfaces."
@@ -101,13 +113,19 @@ class CloudvisionAdapter(DiffSync):
             return None
 
         if self.job.debug:
-            self.job.logger.debug(f"Device being loaded: {device.name}. Port: {port_info}.")
+            self.job.logger.debug(
+                f"Device being loaded: {device.name}. Port: {port_info}."
+            )
 
         for port in port_info:
             if self.job.debug:
-                self.job.logger.debug(f"Port {port['interface']} being loaded for {device.name}.")
+                self.job.logger.debug(
+                    f"Port {port['interface']} being loaded for {device.name}."
+                )
 
-            port_mode = cloudvision.get_interface_mode(client=self.conn, dId=device.serial, interface=port["interface"])
+            port_mode = cloudvision.get_interface_mode(
+                client=self.conn, dId=device.serial, interface=port["interface"]
+            )
             transceiver = cloudvision.get_interface_transceiver(
                 client=self.conn, dId=device.serial, interface=port["interface"]
             )
@@ -122,7 +140,9 @@ class CloudvisionAdapter(DiffSync):
                 client=self.conn, dId=device.serial, interface=port["interface"]
             )
             port_status = cloudvision.get_interface_status(port_info=port)
-            port_type = cloudvision.get_port_type(port_info=port, transceiver=transceiver)
+            port_type = cloudvision.get_port_type(
+                port_info=port, transceiver=transceiver
+            )
             if port["interface"] != "":
                 new_port = self.port(
                     name=port["interface"],
@@ -153,7 +173,9 @@ class CloudvisionAdapter(DiffSync):
         dev_ip_intfs = cloudvision.get_ip_interfaces(client=self.conn, dId=dev.serial)
         for intf in dev_ip_intfs:
             if self.job.debug:
-                self.job.logger.info(f"Loading interface {intf['interface']} on {dev.name} for {intf['address']}.")
+                self.job.logger.info(
+                    f"Loading interface {intf['interface']} on {dev.name} for {intf['address']}."
+                )
             try:
                 _ = self.get(self.port, {"name": intf["interface"], "device": dev.name})
             except ObjectNotFound:
@@ -167,7 +189,9 @@ class CloudvisionAdapter(DiffSync):
                     enabled=True,
                     mode="access",
                     mtu=65535,
-                    port_type=cloudvision.get_port_type(port_info={"interface": intf["interface"]}, transceiver=""),
+                    port_type=cloudvision.get_port_type(
+                        port_info={"interface": intf["interface"]}, transceiver=""
+                    ),
                     status="Active",
                     uuid=None,
                 )
@@ -212,7 +236,9 @@ class CloudvisionAdapter(DiffSync):
         )
         dev_tags = [
             tag
-            for tag in cloudvision.get_device_tags(client=self.conn.comm_channel, device_id=device.serial)
+            for tag in cloudvision.get_device_tags(
+                client=self.conn.comm_channel, device_id=device.serial
+            )
             if tag in system_tags
         ]
 
@@ -227,11 +253,17 @@ class CloudvisionAdapter(DiffSync):
             if tag["label"] == "mpls" or tag["label"] == "ztp":
                 tag["value"] = bool(distutils.util.strtobool(tag["value"]))
 
-            new_cf = self.cf(name=f"arista_{tag['label']}", value=tag["value"], device_name=device.name)
+            new_cf = self.cf(
+                name=f"arista_{tag['label']}",
+                value=tag["value"],
+                device_name=device.name,
+            )
             try:
                 self.add(new_cf)
             except ObjectAlreadyExists:
-                self.job.logger.warning(f"Duplicate tag encountered for {tag['label']} on device {device.name}")
+                self.job.logger.warning(
+                    f"Duplicate tag encountered for {tag['label']} on device {device.name}"
+                )
 
     def load(self):
         """Load devices and associated data from CloudVision."""

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -243,6 +243,9 @@ class CloudvisionAdapter(DiffSync):
             if tag["label"] == "mpls" or tag["label"] == "ztp":
                 tag["value"] = bool(distutils.util.strtobool(tag["value"]))
 
+            if tag["value"] in ["true", "false"]:
+                tag["value"] = bool(distutils.util.strtobool(tag["value"]))
+
             new_cf = self.cf(
                 name=f"arista_{tag['label']}",
                 value=tag["value"],

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -39,7 +39,7 @@ class CloudvisionAdapter(DiffSync):
 
     def load_devices(self):
         """Load devices from CloudVision."""
-        if APP_SETTINGS.get("create_controller"):
+        if APP_SETTINGS.get("aristacv_create_controller"):
             cvp_version = cloudvision.get_cvp_version()
             cvp_ver_cf = self.cf(name="arista_eos", value=cvp_version, device_name="CloudVision")
             try:

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -64,7 +64,8 @@ class CloudvisionAdapter(DiffSync):
                 self.job.logger.warning(f"Error attempting to add CloudVision device. {err}")
 
         for index, dev in enumerate(cloudvision.get_devices(client=self.conn.comm_channel), start=1):
-            self.job.logger.info(f"Loading {index}° device")
+            if self.job.debug:
+                self.job.logger.info(f"Loading {index}° device")
             if dev["hostname"] != "":
                 new_device = self.device(
                     name=dev["hostname"],

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -188,6 +188,7 @@ class CloudvisionAdapter(DiffSync):
                 self.job.logger.info(
                     f"Attempting to load IP Address {intf['address']} for {intf['interface']} on {dev.name}."
                 )
+            intf_vrf = cloudvision.get_interface_vrf(client=self.conn, dId=dev.serial, interface=intf["interface"])
             if intf["address"] and intf["address"] != "none":
                 prefix = ipaddress.ip_interface(intf["address"]).network.with_prefixlen
                 self.get_or_instantiate(self.namespace, ids={"name": intf_vrf})

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -150,7 +150,7 @@ class NautobotAdapter(DiffSync):
         # if Controller is created we need to ensure all imported Devices have RelationshipAssociation to it.
         if APP_SETTINGS.get("aristacv_create_controller"):
             self.job.logger.info("Creating Relationships between CloudVision and connected Devices.")
-            controller_relation = OrmRelationship.objects.get(name="Controller -> Device")
+            controller_relation = OrmRelationship.objects.get(label="Controller -> Device")
             device_ct = ContentType.objects.get_for_model(OrmDevice)
             cvp = OrmDevice.objects.get(name="CloudVision")
             loaded_devices = source.dict()["device"]

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -132,7 +132,7 @@ class NautobotAdapter(DiffSync):
             for mapping in ip_to_intfs:
                 new_map = self.ipassignment(
                     address=str(ipaddr.address),
-                    namespace=mapping.ip_address.namespace.name,
+                    namespace=mapping.ip_address.parent.namespace.name,
                     device=mapping.device.name,
                     interface=mapping.interface.name,
                     primary=len(mapping.ip_address.primary_ip4_for.all()) > 0

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -133,7 +133,7 @@ class NautobotAdapter(DiffSync):
                 new_map = self.ipassignment(
                     address=str(ipaddr.address),
                     namespace=mapping.ip_address.parent.namespace.name,
-                    device=mapping.device.name,
+                    device=mapping.interface.device.name,
                     interface=mapping.interface.name,
                     primary=len(mapping.ip_address.primary_ip4_for.all()) > 0
                     or len(mapping.ip_address.primary_ip6_for.all()) > 0,

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -110,17 +110,17 @@ class NautobotAdapter(DiffSync):
                 )
                 self.add(new_ns)
             try:
-                self.get(self.prefix, ipaddr.parent.prefix.with_prefixlen)
+                self.get(self.prefix, str(ipaddr.parent.prefix))
             except ObjectNotFound:
                 new_pf = self.prefix(
-                    prefix=ipaddr.parent.prefix.with_prefixlen,
+                    prefix=str(ipaddr.parent.prefix),
                     namespace=ipaddr.parent.namespace.name,
                     uuid=ipaddr.parent.prefix.id,
                 )
                 self.add(new_pf)
             new_ip = self.ipaddr(
                 address=str(ipaddr.address),
-                prefix=ipaddr.parent.prefix.with_prefixlen,
+                prefix=str(ipaddr.parent.prefix),
                 namespace=ipaddr.parent.namespace.name,
                 uuid=ipaddr.id,
             )

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -52,9 +52,7 @@ class NautobotAdapter(DiffSync):
                 )
                 self.add(new_device)
             except ObjectAlreadyExists as err:
-                self.job.logger.warning(
-                    f"Unable to load {dev.name} as it appears to be a duplicate. {err}"
-                )
+                self.job.logger.warning(f"Unable to load {dev.name} as it appears to be a duplicate. {err}")
                 continue
 
             self.load_custom_fields(dev=dev)
@@ -76,9 +74,7 @@ class NautobotAdapter(DiffSync):
 
     def load_interfaces(self):
         """Add Nautobot Interface objects as DiffSync Port models."""
-        for intf in OrmInterface.objects.filter(
-            device__device_type__manufacturer__name="Arista"
-        ):
+        for intf in OrmInterface.objects.filter(device__device_type__manufacturer__name="Arista"):
             new_port = self.port(
                 name=intf.name,
                 device=intf.device.name,
@@ -102,9 +98,7 @@ class NautobotAdapter(DiffSync):
 
     def load_ip_addresses(self):
         """Add Nautobot IPAddress objects as DiffSync IPAddress models."""
-        for ipaddr in OrmIPAddress.objects.filter(
-            interfaces__device__device_type__manufacturer__name__in=["Arista"]
-        ):
+        for ipaddr in OrmIPAddress.objects.filter(interfaces__device__device_type__manufacturer__name__in=["Arista"]):
             try:
                 self.get(self.prefix, ipaddr.parent.prefix.with_prefixlen)
             except ObjectNotFound:
@@ -121,9 +115,7 @@ class NautobotAdapter(DiffSync):
             try:
                 self.add(new_ip)
             except ObjectAlreadyExists as err:
-                self.job.logger.warning(
-                    f"Unable to load {ipaddr.address} as appears to be a duplicate. {err}"
-                )
+                self.job.logger.warning(f"Unable to load {ipaddr.address} as appears to be a duplicate. {err}")
             ip_to_intfs = IPAddressToInterface.objects.filter(ip_address=ipaddr)
             for mapping in ip_to_intfs:
                 new_map = self.ipassignment(
@@ -144,12 +136,8 @@ class NautobotAdapter(DiffSync):
         """
         # if Controller is created we need to ensure all imported Devices have RelationshipAssociation to it.
         if APP_SETTINGS.get("create_controller"):
-            self.job.logger.info(
-                "Creating Relationships between CloudVision and connected Devices."
-            )
-            controller_relation = OrmRelationship.objects.get(
-                name="Controller -> Device"
-            )
+            self.job.logger.info("Creating Relationships between CloudVision and connected Devices.")
+            controller_relation = OrmRelationship.objects.get(name="Controller -> Device")
             device_ct = ContentType.objects.get_for_model(OrmDevice)
             cvp = OrmDevice.objects.get(name="CloudVision")
             loaded_devices = source.dict()["device"]

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -110,7 +110,7 @@ class NautobotAdapter(DiffSync):
                 )
                 self.add(new_ns)
             try:
-                self.get(self.prefix, str(ipaddr.parent.prefix))
+                self.get(self.prefix, {"prefix": str(ipaddr.parent.prefix), "namespace": ipaddr.parent.namespace.name})
             except ObjectNotFound:
                 new_pf = self.prefix(
                     prefix=str(ipaddr.parent.prefix),

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -31,7 +31,7 @@ class NautobotAdapter(DiffSync):
     ipassignment = NautobotIPAssignment
     cf = NautobotCustomField
 
-    top_level = ["device", "prefix", "ipaddr", "ipassigment", "cf"]
+    top_level = ["device", "prefix", "ipaddr", "ipassignment", "cf"]
 
     def __init__(self, *args, job=None, **kwargs):
         """Initialize the Nautobot DiffSync adapter."""

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -135,7 +135,7 @@ class NautobotAdapter(DiffSync):
             source (DiffSync): Source DiffSync DataSource adapter.
         """
         # if Controller is created we need to ensure all imported Devices have RelationshipAssociation to it.
-        if APP_SETTINGS.get("create_controller"):
+        if APP_SETTINGS.get("aristacv_create_controller"):
             self.job.logger.info("Creating Relationships between CloudVision and connected Devices.")
             controller_relation = OrmRelationship.objects.get(name="Controller -> Device")
             device_ct = ContentType.objects.get_for_model(OrmDevice)

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -115,7 +115,7 @@ class NautobotAdapter(DiffSync):
                 new_pf = self.prefix(
                     prefix=str(ipaddr.parent.prefix),
                     namespace=ipaddr.parent.namespace.name,
-                    uuid=ipaddr.parent.prefix.id,
+                    uuid=ipaddr.parent.id,
                 )
                 self.add(new_pf)
             new_ip = self.ipaddr(

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/nautobot.py
@@ -49,7 +49,9 @@ class NautobotAdapter(DiffSync):
                 )
                 self.add(new_device)
             except ObjectAlreadyExists as err:
-                self.job.logger.warning(f"Unable to load {dev.name} as it appears to be a duplicate. {err}")
+                self.job.logger.warning(
+                    f"Unable to load {dev.name} as it appears to be a duplicate. {err}"
+                )
                 continue
 
             self.load_custom_fields(dev=dev)
@@ -59,7 +61,11 @@ class NautobotAdapter(DiffSync):
         for cf_name, cf_value in dev.custom_field_data.items():
             if cf_name.startswith("arista_"):
                 try:
-                    new_cf = self.cf(name=cf_name, value=cf_value if cf_value is not None else "", device_name=dev.name)
+                    new_cf = self.cf(
+                        name=cf_name,
+                        value=cf_value if cf_value is not None else "",
+                        device_name=dev.name,
+                    )
                     self.add(new_cf)
                 except AttributeError as err:
                     self.job.logger.warning(f"Unable to load {cf_name}. {err}")
@@ -67,7 +73,9 @@ class NautobotAdapter(DiffSync):
 
     def load_interfaces(self):
         """Add Nautobot Interface objects as DiffSync Port models."""
-        for intf in OrmInterface.objects.filter(device__device_type__manufacturer__name="Arista"):
+        for intf in OrmInterface.objects.filter(
+            device__device_type__manufacturer__name="Arista"
+        ):
             new_port = self.port(
                 name=intf.name,
                 device=intf.device.name,
@@ -112,7 +120,9 @@ class NautobotAdapter(DiffSync):
             try:
                 self.add(new_ip)
             except ObjectAlreadyExists as err:
-                self.job.logger.warning(f"Unable to load {ipaddr.address} as appears to be a duplicate. {err}")
+                self.job.logger.warning(
+                    f"Unable to load {ipaddr.address} as appears to be a duplicate. {err}"
+                )
 
     def sync_complete(self, source: DiffSync, *args, **kwargs):
         """Perform actions after sync is completed.
@@ -122,8 +132,12 @@ class NautobotAdapter(DiffSync):
         """
         # if Controller is created we need to ensure all imported Devices have RelationshipAssociation to it.
         if APP_SETTINGS.get("create_controller"):
-            self.job.logger.info("Creating Relationships between CloudVision and connected Devices.")
-            controller_relation = OrmRelationship.objects.get(name="Controller -> Device")
+            self.job.logger.info(
+                "Creating Relationships between CloudVision and connected Devices."
+            )
+            controller_relation = OrmRelationship.objects.get(
+                name="Controller -> Device"
+            )
             device_ct = ContentType.objects.get_for_model(OrmDevice)
             cvp = OrmDevice.objects.get(name="CloudVision")
             loaded_devices = source.dict()["device"]

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
@@ -58,6 +58,20 @@ class Port(DiffSyncModel):
     uuid: Optional[UUID]
 
 
+class Prefix(DiffSyncModel):
+    """DiffSync Model for Ringhealth nodes management network."""
+
+    model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
+
+    _modelname = "prefix"
+    _identifiers = ("prefix",)
+    _attributes = ()
+    _children = {}
+
+    prefix: str
+    uuid: Optional[UUID]
+
+
 class IPAddress(DiffSyncModel):
     """IPAddress Model."""
 
@@ -66,6 +80,7 @@ class IPAddress(DiffSyncModel):
     _modelname = "ipaddr"
     _identifiers = (
         "address",
+        "prefix",
         "device",
         "interface",
     )
@@ -73,6 +88,7 @@ class IPAddress(DiffSyncModel):
     _children = {}
 
     address: str
+    prefix: str
     device: str
     interface: str
     uuid: Optional[UUID]

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
@@ -1,7 +1,6 @@
 """DiffSyncModel subclasses for Nautobot-to-AristaCV data sync."""
 from uuid import UUID
 from diffsync import DiffSyncModel
-from diffsync.enum import DiffSyncModelFlags
 from typing import List, Optional
 
 

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
@@ -58,17 +58,30 @@ class Port(DiffSyncModel):
     uuid: Optional[UUID]
 
 
+class Namespace(DiffSyncModel):
+    """Namespace Model."""
+
+    _modelname = "namespace"
+    _identifiers = ("name",)
+    _attributes = ()
+    _children = {}
+
+    name: str
+    uuid: Optional[UUID]
+
+
 class Prefix(DiffSyncModel):
-    """DiffSync Model for Ringhealth nodes management network."""
+    """Prefix Model."""
 
     model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
 
     _modelname = "prefix"
-    _identifiers = ("prefix",)
+    _identifiers = ("prefix", "namespace")
     _attributes = ()
     _children = {}
 
     prefix: str
+    namespace: str
     uuid: Optional[UUID]
 
 
@@ -81,12 +94,14 @@ class IPAddress(DiffSyncModel):
     _identifiers = (
         "address",
         "prefix",
+        "namespace",
     )
     _attributes = ()
     _children = {}
 
     address: str
     prefix: str
+    namespace: str
     uuid: Optional[UUID]
 
 
@@ -96,6 +111,7 @@ class IPAssignment(DiffSyncModel):
     _modelname = "ipassignment"
     _identifiers = (
         "address",
+        "namespace",
         "device",
         "interface",
     )
@@ -103,6 +119,7 @@ class IPAssignment(DiffSyncModel):
     _children = {}
 
     address: str
+    namespace: str
     device: str
     interface: str
     primary: bool

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
@@ -73,8 +73,6 @@ class Namespace(DiffSyncModel):
 class Prefix(DiffSyncModel):
     """Prefix Model."""
 
-    model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
-
     _modelname = "prefix"
     _identifiers = ("prefix", "namespace")
     _attributes = ()
@@ -87,8 +85,6 @@ class Prefix(DiffSyncModel):
 
 class IPAddress(DiffSyncModel):
     """IPAddress Model."""
-
-    model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
 
     _modelname = "ipaddr"
     _identifiers = (

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/base.py
@@ -81,16 +81,31 @@ class IPAddress(DiffSyncModel):
     _identifiers = (
         "address",
         "prefix",
-        "device",
-        "interface",
     )
     _attributes = ()
     _children = {}
 
     address: str
     prefix: str
+    uuid: Optional[UUID]
+
+
+class IPAssignment(DiffSyncModel):
+    """IPAssignment Model."""
+
+    _modelname = "ipassignment"
+    _identifiers = (
+        "address",
+        "device",
+        "interface",
+    )
+    _attributes = ("primary",)
+    _children = {}
+
+    address: str
     device: str
     interface: str
+    primary: bool
     uuid: Optional[UUID]
 
 

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -109,10 +109,16 @@ class CloudvisionCustomField(CustomField):
         for device in attrs["devices"]:
             # Exclude devices that are inactive in CloudVision
             if device in device_ids:
-                cvp.assign_tag_to_device(device_ids[device], ids["name"], attrs["value"])
+                cvp.assign_tag_to_device(
+                    device_ids[device], ids["name"], attrs["value"]
+                )
             else:
-                tag = f"{ids['name']}:{attrs['value']}" if attrs["value"] else ids["name"]
-                diffsync.job.logger.warning(f"{device} is inactive or missing in CloudVision - skipping for tag: {tag}")
+                tag = (
+                    f"{ids['name']}:{attrs['value']}" if attrs["value"] else ids["name"]
+                )
+                diffsync.job.logger.warning(
+                    f"{device} is inactive or missing in CloudVision - skipping for tag: {tag}"
+                )
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs):

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -3,6 +3,7 @@ from nautobot_ssot.integrations.aristacv.constant import APP_SETTINGS
 from nautobot_ssot.integrations.aristacv.diffsync.models.base import (
     Device,
     CustomField,
+    Namespace,
     Prefix,
     IPAddress,
     IPAssignment,
@@ -42,6 +43,26 @@ class CloudvisionPort(Port):
 
     def delete(self):
         """Delete Interface in AristaCV from Port object."""
+        return self
+
+
+class CloudvisionNamespace(Namespace):
+    """Cloudvision Namespace model."""
+
+    @classmethod
+    def create(cls, diffsync, ids, attrs):
+        """Create Namespace in AristaCV from Namespace object."""
+        ...
+        return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs):
+        """Update Namespace in AristaCV from Namespace object."""
+        ...
+        return super().update(attrs)
+
+    def delete(self):
+        """Delete Namespace in AristaCV from Namespace object."""
+        ...
         return self
 
 

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -130,16 +130,10 @@ class CloudvisionCustomField(CustomField):
         for device in attrs["devices"]:
             # Exclude devices that are inactive in CloudVision
             if device in device_ids:
-                cvp.assign_tag_to_device(
-                    device_ids[device], ids["name"], attrs["value"]
-                )
+                cvp.assign_tag_to_device(device_ids[device], ids["name"], attrs["value"])
             else:
-                tag = (
-                    f"{ids['name']}:{attrs['value']}" if attrs["value"] else ids["name"]
-                )
-                diffsync.job.logger.warning(
-                    f"{device} is inactive or missing in CloudVision - skipping for tag: {tag}"
-                )
+                tag = f"{ids['name']}:{attrs['value']}" if attrs["value"] else ids["name"]
+                diffsync.job.logger.warning(f"{device} is inactive or missing in CloudVision - skipping for tag: {tag}")
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs):

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -112,12 +112,12 @@ class CloudvisionCustomField(CustomField):
     def connect_cvp():
         """Connect to Cloudvision gRPC endpoint."""
         return CloudvisionApi(
-            cvp_host=APP_SETTINGS["cvp_host"],
-            cvp_port=APP_SETTINGS.get("cvp_port", "8443"),
-            verify=APP_SETTINGS["verify"],
-            username=APP_SETTINGS["cvp_user"],
-            password=APP_SETTINGS["cvp_password"],
-            cvp_token=APP_SETTINGS["cvp_token"],
+            cvp_host=APP_SETTINGS["aristacv_cvp_host"],
+            cvp_port=APP_SETTINGS.get("aristacv_cvp_port", "8443"),
+            verify=APP_SETTINGS["aristacv_verify"],
+            username=APP_SETTINGS["aristacv_cvp_user"],
+            password=APP_SETTINGS["aristacv_cvp_password"],
+            cvp_token=APP_SETTINGS["aristacv_cvp_token"],
         )
 
     @classmethod

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -5,6 +5,7 @@ from nautobot_ssot.integrations.aristacv.diffsync.models.base import (
     CustomField,
     Prefix,
     IPAddress,
+    IPAssignment,
     Port,
 )
 from nautobot_ssot.integrations.aristacv.utils.cloudvision import CloudvisionApi
@@ -80,6 +81,26 @@ class CloudvisionIPAddress(IPAddress):
 
     def delete(self):
         """Delete IPAddress in AristaCV from IPAddress object."""
+        ...
+        return self
+
+
+class CloudvisionIPAssignment(IPAssignment):
+    """Cloudvision IPAssignment model."""
+
+    @classmethod
+    def create(cls, diffsync, ids, attrs):
+        """Create IPAssignment in AristaCV from IPAssignment object."""
+        ...
+        return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs):
+        """Update IPAssignment in AristaCV from IPAssignment object."""
+        ...
+        return super().update(attrs)
+
+    def delete(self):
+        """Delete IPAssignment in AristaCV from IPAssignment object."""
         ...
         return self
 

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/cloudvision.py
@@ -1,6 +1,12 @@
 """Cloudvision DiffSync models for AristaCV SSoT."""
 from nautobot_ssot.integrations.aristacv.constant import APP_SETTINGS
-from nautobot_ssot.integrations.aristacv.diffsync.models.base import Device, CustomField, IPAddress, Port
+from nautobot_ssot.integrations.aristacv.diffsync.models.base import (
+    Device,
+    CustomField,
+    Prefix,
+    IPAddress,
+    Port,
+)
 from nautobot_ssot.integrations.aristacv.utils.cloudvision import CloudvisionApi
 
 
@@ -35,6 +41,26 @@ class CloudvisionPort(Port):
 
     def delete(self):
         """Delete Interface in AristaCV from Port object."""
+        return self
+
+
+class CloudvisionPrefix(Prefix):
+    """Cloudvision IPAdress model."""
+
+    @classmethod
+    def create(cls, diffsync, ids, attrs):
+        """Create Prefix in AristaCV from Prefix object."""
+        ...
+        return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs):
+        """Update Prefix in AristaCV from Prefix object."""
+        ...
+        return super().update(attrs)
+
+    def delete(self):
+        """Delete Prefix in AristaCV from Prefix object."""
+        ...
         return self
 
 

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -260,7 +260,7 @@ class NautobotPrefix(Prefix):
         _pf = OrmPrefix(
             prefix=ids["prefix"],
             namespace=Namespace.objects.get(name="Global"),
-            status_id=OrmStatus.objects.get(name="Active"),
+            status=OrmStatus.objects.get(name="Active"),
         )
         _pf.validated_save()
         return super().create(diffsync=diffsync, ids=ids, attrs=attrs)

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -240,7 +240,7 @@ class NautobotPort(Port):
 
     def delete(self):
         """Delete Interface in Nautobot."""
-        if APP_SETTINGS.get("delete_devices_on_sync"):
+        if APP_SETTINGS.get("aristacv_delete_devices_on_sync"):
             super().delete()
             if self.diffsync.job.debug:
                 self.diffsync.job.logger.warning(f"Interface {self.name} for {self.device} will be deleted.")

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -274,6 +274,7 @@ class NautobotIPAddress(IPAddress):
         """Create IPAddress in Nautobot."""
         new_ip = OrmIPAddress(
             address=ids["address"],
+            parent=OrmPrefix.objects.get(prefix=ids["prefix"], namespace=Namespace.objects.get(name="Global")),
             status=OrmStatus.objects.get(name="Active"),
         )
         if "loopback" in ids["interface"]:

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -9,6 +9,8 @@ from nautobot.extras.models import Relationship as OrmRelationship
 from nautobot.extras.models import RelationshipAssociation as OrmRelationshipAssociation
 from nautobot.extras.models import Status as OrmStatus
 from nautobot.ipam.models import IPAddress as OrmIPAddress
+from nautobot.ipam.models import Prefix as OrmPrefix
+from nautobot.ipam.models import Namespace
 import distutils
 
 from nautobot_ssot.integrations.aristacv.constant import (
@@ -21,6 +23,7 @@ from nautobot_ssot.integrations.aristacv.diffsync.models.base import (
     CustomField,
     IPAddress,
     Port,
+    Prefix,
 )
 from nautobot_ssot.integrations.aristacv.utils import nautobot
 
@@ -272,6 +275,23 @@ class NautobotPort(Port):
             _port = OrmInterface.objects.get(id=self.uuid)
             _port.delete()
         return self
+
+
+class NautobotPrefix(Prefix):
+    """Nautobot Prefix model."""
+
+    @classmethod
+    def create(cls, diffsync, ids, attrs):
+        """Create Prefix in Nautobot from NautobotPrefix objects."""
+        if diffsync.job.debug:
+            diffsync.job.logger.info(f"Creating Prefix {ids['prefix']}.")
+        _pf = OrmPrefix(
+            prefix=ids["prefix"],
+            namespace=Namespace.objects.get(name="Global"),
+            status_id=OrmStatus.objects.get(name="Active"),
+        )
+        _pf.validated_save()
+        return super().create(diffsync=diffsync, ids=ids, attrs=attrs)
 
 
 class NautobotIPAddress(IPAddress):

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -33,9 +33,7 @@ try:
 
     LIFECYCLE_MGMT = True
 except ImportError:
-    print(
-        "Device Lifecycle app isn't installed so will revert to CustomField for OS version."
-    )
+    print("Device Lifecycle app isn't installed so will revert to CustomField for OS version.")
     LIFECYCLE_MGMT = False
 
 
@@ -68,9 +66,7 @@ class NautobotDevice(Device):
             else:
                 site = nautobot.verify_site("CloudVision")
         else:
-            site = nautobot.verify_site(
-                APP_SETTINGS.get("aristacv_from_cloudvision_default_site", DEFAULT_SITE)
-            )
+            site = nautobot.verify_site(APP_SETTINGS.get("aristacv_from_cloudvision_default_site", DEFAULT_SITE))
 
         if role_code and role_code in role_map:
             role = nautobot.verify_device_role_object(
@@ -81,24 +77,17 @@ class NautobotDevice(Device):
                 ),
             )
         elif "CloudVision" in ids["name"]:
-            role = nautobot.verify_device_role_object(
-                "Controller", DEFAULT_DEVICE_ROLE_COLOR
-            )
+            role = nautobot.verify_device_role_object("Controller", DEFAULT_DEVICE_ROLE_COLOR)
         else:
             role = nautobot.verify_device_role_object(
-                APP_SETTINGS.get(
-                    "aristacv_from_cloudvision_default_device_role", DEFAULT_DEVICE_ROLE
-                ),
+                APP_SETTINGS.get("aristacv_from_cloudvision_default_device_role", DEFAULT_DEVICE_ROLE),
                 APP_SETTINGS.get(
                     "aristacv_from_cloudvision_default_device_role_color",
                     DEFAULT_DEVICE_ROLE_COLOR,
                 ),
             )
 
-        if (
-            APP_SETTINGS.get("aristacv_create_controller")
-            and "CloudVision" in ids["name"]
-        ):
+        if APP_SETTINGS.get("aristacv_create_controller") and "CloudVision" in ids["name"]:
             platform = OrmPlatform.objects.get(name=CLOUDVISION_PLATFORM)
         else:
             platform = OrmPlatform.objects.get(name=ARISTA_PLATFORM)
@@ -121,12 +110,8 @@ class NautobotDevice(Device):
         try:
             new_device.validated_save()
             if LIFECYCLE_MGMT and attrs.get("version"):
-                software_lcm = cls._add_software_lcm(
-                    platform=platform.name, version=attrs["version"]
-                )
-                cls._assign_version_to_device(
-                    diffsync=diffsync, device=new_device, software_lcm=software_lcm
-                )
+                software_lcm = cls._add_software_lcm(platform=platform.name, version=attrs["version"])
+                cls._assign_version_to_device(diffsync=diffsync, device=new_device, software_lcm=software_lcm)
             return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
         except ValidationError as err:
             diffsync.job.logger.warning(f"Unable to create Device {ids['name']}. {err}")
@@ -145,29 +130,19 @@ class NautobotDevice(Device):
         if "serial" in attrs:
             dev.serial = attrs["serial"]
         if "version" in attrs and LIFECYCLE_MGMT:
-            software_lcm = self._add_software_lcm(
-                platform=dev.platform.name, version=attrs["version"]
-            )
-            self._assign_version_to_device(
-                diffsync=self.diffsync, device=dev, software_lcm=software_lcm
-            )
+            software_lcm = self._add_software_lcm(platform=dev.platform.name, version=attrs["version"])
+            self._assign_version_to_device(diffsync=self.diffsync, device=dev, software_lcm=software_lcm)
         try:
             dev.validated_save()
             return super().update(attrs)
         except ValidationError as err:
-            self.diffsync.job.logger.warning(
-                f"Unable to update Device {self.name}. {err}"
-            )
+            self.diffsync.job.logger.warning(f"Unable to update Device {self.name}. {err}")
             return None
 
     def delete(self):
         """Delete device object in Nautobot."""
-        if APP_SETTINGS.get(
-            "aristacv_delete_devices_on_sync", DEFAULT_DELETE_DEVICES_ON_SYNC
-        ):
-            self.diffsync.job.logger.warning(
-                f"Device {self.name} will be deleted per app settings."
-            )
+        if APP_SETTINGS.get("aristacv_delete_devices_on_sync", DEFAULT_DELETE_DEVICES_ON_SYNC):
+            self.diffsync.job.logger.warning(f"Device {self.name} will be deleted per app settings.")
             device = OrmDevice.objects.get(id=self.uuid)
             device.delete()
             super().delete()
@@ -260,9 +235,7 @@ class NautobotPort(Port):
             _port.validated_save()
             return super().update(attrs)
         except ValidationError as err:
-            self.diffsync.job.logger.warning(
-                f"Unable to update port {self.name} for {self.device} with {attrs}: {err}"
-            )
+            self.diffsync.job.logger.warning(f"Unable to update port {self.name} for {self.device} with {attrs}: {err}")
             return None
 
     def delete(self):
@@ -270,9 +243,7 @@ class NautobotPort(Port):
         if APP_SETTINGS.get("delete_devices_on_sync"):
             super().delete()
             if self.diffsync.job.debug:
-                self.diffsync.job.logger.warning(
-                    f"Interface {self.name} for {self.device} will be deleted."
-                )
+                self.diffsync.job.logger.warning(f"Interface {self.name} for {self.device} will be deleted.")
             _port = OrmInterface.objects.get(id=self.uuid)
             _port.delete()
         return self
@@ -319,9 +290,7 @@ class NautobotIPAssignment(IPAssignment):
         """Create IPAddressToInterface in Nautobot."""
         try:
             ipaddr = OrmIPAddress.objects.get(address=ids["address"])
-            intf = OrmInterface.objects.get(
-                name=ids["interface"], device__name=ids["device"]
-            )
+            intf = OrmInterface.objects.get(name=ids["interface"], device__name=ids["device"])
             new_map = IPAddressToInterface(ip_address=ipaddr, interface=intf)
             new_map.validated_save()
             if attrs.get("primary"):
@@ -332,9 +301,7 @@ class NautobotIPAssignment(IPAssignment):
                 intf.device.validated_save()
             return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
         except OrmInterface.DoesNotExist as err:
-            diffsync.job.logger.warning(
-                f"Unable to find Interface {ids['interface']} for {ids['device']}. {err}"
-            )
+            diffsync.job.logger.warning(f"Unable to find Interface {ids['interface']} for {ids['device']}. {err}")
 
     def update(self, attrs):
         """Update IPAddressToInterface in Nautobot."""

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -146,7 +146,7 @@ class NautobotDevice(Device):
         if APP_SETTINGS.get("aristacv_delete_devices_on_sync", DEFAULT_DELETE_DEVICES_ON_SYNC):
             self.diffsync.job.logger.warning(f"Device {self.name} will be deleted per app settings.")
             device = OrmDevice.objects.get(id=self.uuid)
-            device.delete()
+            self.diffsync.objects_to_delete["devices"].append(device)
             super().delete()
         return self
 
@@ -247,7 +247,7 @@ class NautobotPort(Port):
             if self.diffsync.job.debug:
                 self.diffsync.job.logger.warning(f"Interface {self.name} for {self.device} will be deleted.")
             _port = OrmInterface.objects.get(id=self.uuid)
-            _port.delete()
+            self.diffsync.objects_to_delete["interfaces"].append(_port)
         return self
 
 
@@ -269,7 +269,7 @@ class NautobotNamespace(Namespace):
         """Delete Namespace in Nautobot."""
         super().delete()
         _ns = OrmNamespace.objects.get(id=self.uuid)
-        _ns.delete()
+        self.diffsync.objects_to_delete["namespaces"].append(_ns)
         return self
 
 
@@ -289,6 +289,13 @@ class NautobotPrefix(Prefix):
         _pf.validated_save()
         return super().create(diffsync=diffsync, ids=ids, attrs=attrs)
 
+    def delete(self):
+        """Delete Prefix in Nautobot."""
+        super().delete()
+        _pf = OrmPrefix.objects.get(id=self.uuid)
+        self.diffsync.objects_to_delete["prefixes"].append(_pf)
+        return self
+
 
 class NautobotIPAddress(IPAddress):
     """Nautobot IPAddress model."""
@@ -305,6 +312,13 @@ class NautobotIPAddress(IPAddress):
         )
         new_ip.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def delete(self):
+        """Delete IPAddress in Nautobot."""
+        super().delete()
+        ipaddr = OrmIPAddress.objects.get(id=self.uuid)
+        self.diffsync.objects_to_delete["ipaddresses"].append(ipaddr)
+        return self
 
 
 class NautobotIPAssignment(IPAssignment):

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -277,8 +277,6 @@ class NautobotIPAddress(IPAddress):
             parent=OrmPrefix.objects.get(prefix=ids["prefix"], namespace=Namespace.objects.get(name="Global")),
             status=OrmStatus.objects.get(name="Active"),
         )
-        if "loopback" in ids["interface"]:
-            new_ip.role = "loopback"
         new_ip.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
@@ -293,6 +291,9 @@ class NautobotIPAssignment(IPAssignment):
             ipaddr = OrmIPAddress.objects.get(address=ids["address"])
             intf = OrmInterface.objects.get(name=ids["interface"], device__name=ids["device"])
             new_map = IPAddressToInterface(ip_address=ipaddr, interface=intf)
+            if "loopback" in ids["interface"]:
+                ipaddr.role = "loopback"
+                ipaddr.validated_save()
             new_map.validated_save()
             if attrs.get("primary"):
                 if ":" in ids["address"]:

--- a/nautobot_ssot/integrations/aristacv/jobs.py
+++ b/nautobot_ssot/integrations/aristacv/jobs.py
@@ -48,29 +48,31 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
     @classmethod
     def config_information(cls):
         """Dictionary describing the configuration of this DataSource."""
-        if APP_SETTINGS.get("cvp_host"):
+        if APP_SETTINGS.get("aristacv_cvp_host"):
             server_type = "On prem"
-            host = APP_SETTINGS.get("cvp_host")
+            host = APP_SETTINGS.get("aristacv_cvp_host")
         else:
             server_type = "CVaaS"
-            host = APP_SETTINGS.get("cvaas_url")
+            host = APP_SETTINGS.get("aristacv_cvaas_url")
         return {
             "Server type": server_type,
             "CloudVision host": host,
-            "Username": APP_SETTINGS.get("cvp_user"),
-            "Verify": str(APP_SETTINGS.get("verify")),
+            "Username": APP_SETTINGS.get("aristacv_cvp_user"),
+            "Verify": str(APP_SETTINGS.get("aristacv_verify")),
             "Delete devices on sync": APP_SETTINGS.get(
-                "delete_devices_on_sync", str(nautobot.DEFAULT_DELETE_DEVICES_ON_SYNC)
+                "aristacv_delete_devices_on_sync", str(nautobot.DEFAULT_DELETE_DEVICES_ON_SYNC)
             ),
-            "New device default site": APP_SETTINGS.get("from_cloudvision_default_site", nautobot.DEFAULT_SITE),
+            "New device default site": APP_SETTINGS.get(
+                "aristacv_from_cloudvision_default_site", nautobot.DEFAULT_SITE
+            ),
             "New device default role": APP_SETTINGS.get(
-                "from_cloudvision_default_device_role", nautobot.DEFAULT_DEVICE_ROLE
+                "aristacv_from_cloudvision_default_device_role", nautobot.DEFAULT_DEVICE_ROLE
             ),
             "New device default role color": APP_SETTINGS.get(
-                "from_cloudvision_default_device_role_color", nautobot.DEFAULT_DEVICE_ROLE_COLOR
+                "aristacv_from_cloudvision_default_device_role_color", nautobot.DEFAULT_DEVICE_ROLE_COLOR
             ),
-            "Apply import tag": str(APP_SETTINGS.get("apply_import_tag", nautobot.APPLY_IMPORT_TAG)),
-            "Import Active": str(APP_SETTINGS.get("import_active", "True"))
+            "Apply import tag": str(APP_SETTINGS.get("aristacv_apply_import_tag", nautobot.APPLY_IMPORT_TAG)),
+            "Import Active": str(APP_SETTINGS.get("aristacv_import_active", "True"))
             # Password and Token are intentionally omitted!
         }
 
@@ -98,18 +100,18 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
 
     def load_source_adapter(self):
         """Load data from CloudVision into DiffSync models."""
-        if not APP_SETTINGS.get("from_cloudvision_default_site"):
+        if not APP_SETTINGS.get("aristacv_from_cloudvision_default_site"):
             self.logger.error(
                 "App setting `aristacv_from_cloudvision_default_site` is not defined. This setting is required for the App to function."
             )
             raise MissingConfigSetting(setting="aristacv_from_cloudvision_default_site")
-        if not APP_SETTINGS.get("from_cloudvision_default_device_role"):
+        if not APP_SETTINGS.get("aristacv_from_cloudvision_default_device_role"):
             self.logger.error(
                 "App setting `aristacv_from_cloudvision_default_device_role` is not defined. This setting is required for the App to function."
             )
             raise MissingConfigSetting(setting="aristacv_from_cloudvision_default_device_role")
         if self.debug:
-            if APP_SETTINGS.get("delete_devices_on_sync"):
+            if APP_SETTINGS.get("aristacv_delete_devices_on_sync"):
                 self.logger.warning(
                     "Devices not present in Cloudvision but present in Nautobot will be deleted from Nautobot."
                 )
@@ -119,12 +121,12 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
                 )
             self.logger.info("Connecting to CloudVision")
         with CloudvisionApi(
-            cvp_host=APP_SETTINGS["cvp_host"],
-            cvp_port=APP_SETTINGS.get("cvp_port", "8443"),
-            verify=APP_SETTINGS["verify"],
-            username=APP_SETTINGS["cvp_user"],
-            password=APP_SETTINGS["cvp_password"],
-            cvp_token=APP_SETTINGS["cvp_token"],
+            cvp_host=APP_SETTINGS["aristacv_cvp_host"],
+            cvp_port=APP_SETTINGS.get("aristacv_cvp_port", "8443"),
+            verify=APP_SETTINGS["aristacv_verify"],
+            username=APP_SETTINGS["aristacv_cvp_user"],
+            password=APP_SETTINGS["aristacv_cvp_password"],
+            cvp_token=APP_SETTINGS["aristacv_cvp_token"],
         ) as client:
             self.logger.info("Loading data from CloudVision")
             self.source_adapter = CloudvisionAdapter(job=self, conn=client)
@@ -162,17 +164,17 @@ class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
     @classmethod
     def config_information(cls):
         """Dictionary describing the configuration of this DataTarget."""
-        if APP_SETTINGS.get("cvp_host"):
+        if APP_SETTINGS.get("aristacv_cvp_host"):
             return {
                 "Server type": "On prem",
-                "CloudVision host": APP_SETTINGS.get("cvp_host"),
-                "Username": APP_SETTINGS.get("cvp_user"),
-                "Verify": str(APP_SETTINGS.get("verify"))
+                "CloudVision host": APP_SETTINGS.get("aristacv_cvp_host"),
+                "Username": APP_SETTINGS.get("aristacv_cvp_user"),
+                "Verify": str(APP_SETTINGS.get("aristacv_verify"))
                 # Password is intentionally omitted!
             }
         return {
             "Server type": "CVaaS",
-            "CloudVision host": APP_SETTINGS.get("cvaas_url"),
+            "CloudVision host": APP_SETTINGS.get("aristacv_cvaas_url"),
             # Token is intentionally omitted!
         }
 
@@ -190,7 +192,7 @@ class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
     def load_target_adapter(self):
         """Load data from CloudVision into DiffSync models."""
         if self.debug:
-            if APP_SETTINGS.get("delete_devices_on_sync"):
+            if APP_SETTINGS.get("aristacv_delete_devices_on_sync"):
                 self.logger.warning(
                     "Devices not present in Cloudvision but present in Nautobot will be deleted from Nautobot."
                 )
@@ -200,12 +202,12 @@ class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
                 )
             self.logger.info("Connecting to CloudVision")
         with CloudvisionApi(
-            cvp_host=APP_SETTINGS["cvp_host"],
-            cvp_port=APP_SETTINGS.get("cvp_port", "8443"),
-            verify=APP_SETTINGS["verify"],
-            username=APP_SETTINGS["cvp_user"],
-            password=APP_SETTINGS["cvp_password"],
-            cvp_token=APP_SETTINGS["cvp_token"],
+            cvp_host=APP_SETTINGS["aristacv_cvp_host"],
+            cvp_port=APP_SETTINGS.get("aristacv_cvp_port", "8443"),
+            verify=APP_SETTINGS["aristacv_verify"],
+            username=APP_SETTINGS["aristacv_cvp_user"],
+            password=APP_SETTINGS["aristacv_cvp_password"],
+            cvp_token=APP_SETTINGS["aristacv_cvp_token"],
         ) as client:
             self.logger.info("Loading data from CloudVision")
             self.target_adapter = CloudvisionAdapter(job=self, conn=client)

--- a/nautobot_ssot/integrations/aristacv/signals.py
+++ b/nautobot_ssot/integrations/aristacv/signals.py
@@ -102,6 +102,11 @@ def post_migrate_create_custom_fields(apps=global_apps, **kwargs):
             "type": CustomFieldTypeChoices.TYPE_TEXT,
             "label": "Topology Pod",
         },
+        {
+            "key": "arista_vxlanConfigured",
+            "type": CustomFieldTypeChoices.TYPE_BOOLEAN,
+            "label": "VXLAN Configured",
+        },
     ]:
         field, _ = CustomField.objects.update_or_create(
             key=device_cf_dict["key"],

--- a/nautobot_ssot/integrations/aristacv/signals.py
+++ b/nautobot_ssot/integrations/aristacv/signals.py
@@ -15,7 +15,7 @@ def register_signals(sender):
     post_migrate.connect(post_migrate_create_manufacturer)
     post_migrate.connect(post_migrate_create_platform)
 
-    if APP_SETTINGS.get("create_controller"):
+    if APP_SETTINGS.get("aristacv_create_controller"):
         post_migrate.connect(post_migrate_create_controller_relationship)
 
 
@@ -129,7 +129,7 @@ def post_migrate_create_platform(apps=global_apps, **kwargs):
         },
     )
 
-    if APP_SETTINGS.get("create_controller"):
+    if APP_SETTINGS.get("aristacv_create_controller"):
         Platform.objects.get_or_create(
             name="Arista EOS-CloudVision",
             manufacturer=Manufacturer.objects.get(name="Arista"),

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -97,7 +97,7 @@ class CloudvisionApi:  # pylint: disable=too-many-instance-attributes, too-many-
             self.metadata = ((self.AUTH_KEY_PATH, self.cvp_token),)
         # Set up credentials for CVaaS using supplied token.
         else:
-            self.cvp_url = APP_SETTINGS.get("cvaas_url", "www.arista.io:443")
+            self.cvp_url = APP_SETTINGS.get("aristacv_cvaas_url", "www.arista.io:443")
             call_creds = grpc.access_token_call_credentials(self.cvp_token)
             channel_creds = grpc.ssl_channel_credentials()
         conn_creds = grpc.composite_channel_credentials(channel_creds, call_creds)
@@ -269,7 +269,7 @@ class CloudvisionApi:  # pylint: disable=too-many-instance-attributes, too-many-
 def get_devices(client):
     """Get devices from CloudVision inventory."""
     device_stub = services.DeviceServiceStub(client)
-    if APP_SETTINGS.get("import_active"):
+    if APP_SETTINGS.get("aristacv_import_active"):
         req = services.DeviceStreamRequest(
             partial_eq_filter=[models.Device(streaming_status=models.STREAMING_STATUS_ACTIVE)]
         )
@@ -675,7 +675,11 @@ def get_cvp_version():
     """
     client = CvpClient()
     try:
-        client.connect([APP_SETTINGS["cvp_host"]], APP_SETTINGS["cvp_user"], APP_SETTINGS["cvp_password"])
+        client.connect(
+            [APP_SETTINGS["aristacv_cvp_host"]],
+            APP_SETTINGS["aristacv_cvp_user"],
+            APP_SETTINGS["aristacv_cvp_password"],
+        )
         version = client.api.get_cvp_info()
         if "version" in version:
             return version["version"]

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -640,6 +640,25 @@ def get_interface_description(client: CloudvisionApi, dId: str, interface: str):
     return ""
 
 
+def get_interface_vrf(client: CloudvisionApi, dId: str, interface: str) -> str:
+    """Gets interface VRF.
+
+    Args:
+        client (CloudvisionApi): Cloudvision connection.
+        dId (str): Device ID to determine type for.
+        interface (str): Name of interface to get mode information for.
+    """
+    pathElts = ["Sysdb", "l3", "intf", "config", "intfConfig", interface]
+    query = [create_query([(pathElts, [])], dId)]
+    query = unfreeze_frozen_dict(query)
+
+    for batch in client.get(query):
+        for notif in batch["notifications"]:
+            if notif["updates"].get("vrf"):
+                return notif["updates"]["vrf"]["value"]
+    return "Global"
+
+
 def get_ip_interfaces(client: CloudvisionApi, dId: str):
     """Gets interfaces with IP Addresses configured from specified device.
 

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -698,7 +698,7 @@ def get_cvp_version():
             client.connect(
                 nodes=[APP_SETTINGS["aristacv_cvaas_url"]],
                 username="",
-                password="",
+                password="",  # nosec: B106
                 is_cvaas=True,
                 api_token=APP_SETTINGS.get("aristacv_cvp_token"),
             )

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -49,11 +49,11 @@ class CloudvisionApi:  # pylint: disable=too-many-instance-attributes, too-many-
     def __init__(
         self,
         cvp_host: str,
-        cvp_port: str = None,
+        cvp_port: str = "",
         verify: bool = True,
-        username: str = None,
-        password: str = None,
-        cvp_token: str = None,
+        username: str = "",
+        password: str = "",
+        cvp_token: str = "",
     ):
         """Create Cloudvision API connection."""
         self.metadata = None

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -694,14 +694,24 @@ def get_cvp_version():
     """
     client = CvpClient()
     try:
-        client.connect(
-            [APP_SETTINGS["aristacv_cvp_host"]],
-            APP_SETTINGS["aristacv_cvp_user"],
-            APP_SETTINGS["aristacv_cvp_password"],
-        )
-        version = client.api.get_cvp_info()
-        if "version" in version:
-            return version["version"]
+        if APP_SETTINGS.get("aristacv_cvp_token") and not APP_SETTINGS.get("aristacv_cvp_host"):
+            client.connect(
+                nodes=[APP_SETTINGS["aristacv_cvaas_url"]],
+                username="",
+                password="",
+                is_cvaas=True,
+                api_token=APP_SETTINGS.get("aristacv_cvp_token"),
+            )
+        else:
+            client.connect(
+                nodes=[APP_SETTINGS["aristacv_cvp_host"]],
+                username=APP_SETTINGS.get("aristacv_cvp_user"),
+                password=APP_SETTINGS.get("aristacv_cvp_password"),
+                is_cvaas=False,
+            )
     except CvpLoginError as err:
         raise AuthFailure(error_code="Failed Login", message=f"Unable to login to CloudVision Portal. {err}") from err
+    version = client.api.get_cvp_info()
+    if "version" in version:
+        return version["version"]
     return ""

--- a/nautobot_ssot/integrations/aristacv/utils/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/utils/nautobot.py
@@ -60,8 +60,8 @@ def verify_device_role_object(role_name, role_color):
         role_obj = Role.objects.get(name=role_name)
     except Role.DoesNotExist:
         role_obj = Role.objects.create(name=role_name, color=role_color)
-        role_obj.content_types.add(ContentType.objects.get_for_model(Device))
-        role_obj.validated_save()
+    role_obj.content_types.add(ContentType.objects.get_for_model(Device))
+    role_obj.validated_save()
     return role_obj
 
 

--- a/nautobot_ssot/integrations/aristacv/utils/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/utils/nautobot.py
@@ -107,7 +107,7 @@ def parse_hostname(hostname: str):
     Args:
         hostname (str): Device hostname to be parsed for site and role.
     """
-    hostname_patterns = APP_SETTINGS.get("hostname_patterns")
+    hostname_patterns = APP_SETTINGS.get("aristacv_hostname_patterns")
 
     site, role = None, None
     for pattern in hostname_patterns:
@@ -129,7 +129,7 @@ def get_site_from_map(site_code: str):
     Returns:
         str|None: Name of Site if site code found else None.
     """
-    site_map = APP_SETTINGS.get("site_mappings")
+    site_map = APP_SETTINGS.get("aristacv_site_mappings")
     site_name = None
     if site_code in site_map:
         site_name = site_map[site_code]
@@ -145,7 +145,7 @@ def get_role_from_map(role_code: str):
     Returns:
         str|None: Name of Device Role if role code found else None.
     """
-    role_map = APP_SETTINGS.get("role_mappings")
+    role_map = APP_SETTINGS.get("aristacv_role_mappings")
     role_name = None
     if role_code in role_map:
         role_name = role_map[role_code]

--- a/nautobot_ssot/integrations/device42/signals.py
+++ b/nautobot_ssot/integrations/device42/signals.py
@@ -26,3 +26,4 @@ def nautobot_database_ready_callback(sender, *, apps, **kwargs):
     loc_type = LocationType.objects.update_or_create(name="Site")[0]
     for obj_type in [Site, RackGroup, Rack, Device, VirtualChassis, Prefix, VLAN]:
         loc_type.content_types.add(ContentType.objects.get_for_model(obj_type))
+    loc_type.save()

--- a/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
@@ -1,9 +1,12 @@
 """Unit tests for the Cloudvision DiffSync adapter class."""
+import ipaddress
 from unittest.mock import MagicMock, patch
 
 from nautobot.extras.models import JobResult
 from nautobot.core.testing import TransactionTestCase
-from nautobot_ssot.integrations.aristacv.diffsync.adapters.cloudvision import CloudvisionAdapter
+from nautobot_ssot.integrations.aristacv.diffsync.adapters.cloudvision import (
+    CloudvisionAdapter,
+)
 from nautobot_ssot.integrations.aristacv.jobs import CloudVisionDataSource
 from nautobot_ssot.tests.aristacv.fixtures import fixtures
 
@@ -50,7 +53,10 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
     )
     def test_load_devices(self):
         """Test the load_devices() adapter method."""
-        with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.get_devices", self.cloudvision.get_devices):
+        with patch(
+            "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_devices",
+            self.cloudvision.get_devices,
+        ):
             with patch(
                 "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_device_type",
                 self.cloudvision.get_device_type,
@@ -75,7 +81,8 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
         mock_device.device_model.return_value = "DCS-7280CR2-60"
 
         with patch(
-            "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_device_type", self.cloudvision.get_device_type
+            "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_device_type",
+            self.cloudvision.get_device_type,
         ):
             with patch(
                 "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interfaces_fixed",
@@ -116,6 +123,9 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
             ):
                 self.cvp.load_ip_addresses(dev=mock_device)
         self.assertEqual(
-            {f"{ipaddr['address']}__mock_device__{ipaddr['interface']}" for ipaddr in fixtures.IP_INTF_FIXTURE},
+            {
+                f"{ipaddr['address']}__{ipaddress.ip_interface(ipaddr['address']).network.with_prefixlen}"
+                for ipaddr in fixtures.IP_INTF_FIXTURE
+            },
             {ipaddr.get_unique_id() for ipaddr in self.cvp.get_all("ipaddr")},
         )

--- a/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
@@ -49,7 +49,7 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
 
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
-        {"create_controller": False},
+        {"aristacv_create_controller": False},
     )
     def test_load_devices(self):
         """Test the load_devices() adapter method."""

--- a/nautobot_ssot/tests/aristacv/test_jobs.py
+++ b/nautobot_ssot/tests/aristacv/test_jobs.py
@@ -104,15 +104,15 @@ class CloudVisionDataSourceJobTest(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "cvp_host": "https://localhost",
-            "cvp_user": "admin",
-            "verify": True,
-            "delete_devices_on_sync": True,
-            "from_cloudvision_default_site": "HQ",
-            "from_cloudvision_default_device_role": "Router",
-            "from_cloudvision_default_device_role_color": "ff0000",
-            "apply_import_tag": True,
-            "import_active": True,
+            "aristacv_cvp_host": "https://localhost",
+            "aristacv_cvp_user": "admin",
+            "aristacv_verify": True,
+            "aristacv_delete_devices_on_sync": True,
+            "aristacv_from_cloudvision_default_site": "HQ",
+            "aristacv_from_cloudvision_default_device_role": "Router",
+            "aristacv_from_cloudvision_default_device_role_color": "ff0000",
+            "aristacv_apply_import_tag": True,
+            "aristacv_import_active": True,
         },
     )
     def test_config_information_on_prem(self):
@@ -133,8 +133,8 @@ class CloudVisionDataSourceJobTest(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "cvaas_url": "https://www.arista.io",
-            "cvp_user": "admin",
+            "aristacv_cvaas_url": "https://www.arista.io",
+            "aristacv_cvp_user": "admin",
         },
     )
     def test_config_information_cvaas(self):

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -37,7 +37,7 @@ class TestCloudvisionUtils(TestCase):
 
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
-        {"import_active": False},
+        {"aristacv_import_active": False},
     )
     def test_get_all_devices(self):
         """Test get_devices function for active and inactive devices."""
@@ -71,7 +71,7 @@ class TestCloudvisionUtils(TestCase):
 
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
-        {"import_active": True},
+        {"aristacv_import_active": True},
     )
     def test_get_active_devices(self):
         """Test get_devices function for active devices."""

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -19,6 +19,10 @@ class TestCloudvisionApi(TestCase):
         with self.assertRaises(cloudvision.AuthFailure):
             cloudvision.CloudvisionApi(cvp_host="https://localhost", username="", password="", verify=True)  # nosec
 
+    @patch.dict(
+        "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
+        {"aristacv_cvaas_url": "www.arista.io:443"},
+    )
     def test_auth_cvass_with_token(self):
         """Test that authentication against CVaaS with token works."""
         client = cloudvision.CloudvisionApi(cvp_host=None, cvp_token="1234567890abcdef")  # nosec

--- a/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
@@ -105,9 +105,9 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
-            "site_mappings": {"ams01": "Amsterdam"},
-            "role_mappings": {"leaf": "leaf"},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+            "aristacv_site_mappings": {"ams01": "Amsterdam"},
+            "aristacv_role_mappings": {"leaf": "leaf"},
         },
     )
     def test_parse_hostname(self):
@@ -120,9 +120,9 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-.+-\d+"],
-            "site_mappings": {"ams01": "Amsterdam"},
-            "role_mappings": {},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-.+-\d+"],
+            "aristacv_site_mappings": {"ams01": "Amsterdam"},
+            "aristacv_role_mappings": {},
         },
     )
     def test_parse_hostname_only_site(self):
@@ -135,9 +135,9 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r".+-(?P<role>\w+)-\d+"],
-            "site_mappings": {},
-            "role_mappings": {"leaf": "leaf"},
+            "aristacv_hostname_patterns": [r".+-(?P<role>\w+)-\d+"],
+            "aristacv_site_mappings": {},
+            "aristacv_role_mappings": {"leaf": "leaf"},
         },
     )
     def test_parse_hostname_only_role(self):
@@ -150,8 +150,8 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
-            "site_mappings": {"ams01": "Amsterdam"},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+            "aristacv_site_mappings": {"ams01": "Amsterdam"},
         },
     )
     def test_get_site_from_map_success(self):
@@ -163,8 +163,8 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
-            "site_mappings": {},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+            "aristacv_site_mappings": {},
         },
     )
     def test_get_site_from_map_fail(self):
@@ -176,8 +176,8 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
-            "role_mappings": {"edge": "Edge Router"},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+            "aristacv_role_mappings": {"edge": "Edge Router"},
         },
     )
     def test_get_role_from_map_success(self):
@@ -189,8 +189,8 @@ class TestNautobotUtils(TestCase):
     @patch.dict(
         "nautobot_ssot.integrations.aristacv.constant.APP_SETTINGS",
         {
-            "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
-            "role_mappings": {},
+            "aristacv_hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+            "aristacv_role_mappings": {},
         },
     )
     def test_get_role_from_map_fail(self):

--- a/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
@@ -30,7 +30,7 @@ class TestNautobotUtils(TransactionTestCase):  # pylint: disable=too-many-instan
         self.site = Location.objects.create(
             name="Test Site",
             status=self.status_active,
-            location_type=LocationType.objects.get_or_create(name="Site")[0],
+            location_type=LocationType.objects.get(name="Site"),
         )
         self.site.validated_save()
         _dt = DeviceType.objects.create(model="CSR1000v", manufacturer=self.cisco_manu)


### PR DESCRIPTION
This PR includes a variety of fixes for the Arista Cloudvision integration:

- Fixes PLUGINS_CONFIG settings to use `aristacv_` prepending.
- Adds Prefix DiffSync model to track parent prefix for IPAddresses.
- Adds IPAssignment DiffSync model to track IPAddress to Interface mappings.
