### PR TITLE
Allow Exceptions To Fail Job

### DIFF
--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -1,7 +1,6 @@
 """Base Job classes for sync workers."""
 from collections import namedtuple
 from datetime import datetime
-import traceback
 import tracemalloc
 from typing import Iterable, Optional
 
@@ -314,15 +313,7 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
             wrapper_class=structlog.stdlib.BoundLogger,
             cache_logger_on_first_use=True,
         )
-
-        # We need to catch exceptions and handle them, because if they aren't caught here,
-        # they'll be caught by the Nautobot core run_job() function, which will trigger a database
-        # rollback, which will delete our above created Sync record!
-        try:
-            self.sync_data(memory_profiling)
-        except Exception as exc:  # pylint: disable=broad-except
-            stacktrace = traceback.format_exc()
-            self.logger.error(f"An exception occurred: `{type(exc).__name__}: {exc}`\n```\n{stacktrace}\n```")
+        self.sync_data(memory_profiling)
 
 
 # pylint: disable=abstract-method


### PR DESCRIPTION
This PR addresses the issue brought up in #329.

As we now need to allow Exceptions to be thrown to mark a Job as failed we need to remove the try/except block. The rollback also isn't a concern as the atomic transaction wrapper was removed in Nautobot 2.0.