### PR TITLE
Fix ACI LocationType Bug

### DIFF
--- a/nautobot_ssot/integrations/aci/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aci/diffsync/models/nautobot.py
@@ -1,7 +1,6 @@
 """Nautobot Models for Cisco ACI integration with SSoT app."""
 
 import logging
-from diffsync.exceptions import ObjectNotCreated
 from django.contrib.contenttypes.models import ContentType
 from nautobot.tenancy.models import Tenant as OrmTenant
 from nautobot.dcim.models import DeviceType as OrmDeviceType

--- a/nautobot_ssot/integrations/aci/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aci/diffsync/models/nautobot.py
@@ -348,13 +348,8 @@ class NautobotIPAddress(IPAddress):
         obj_id = None
         if attrs["device"] and attrs["interface"]:
             try:
-                obj_id = OrmDevice.objects.get(
-                    name=_device,
-                    location=Location.objects.get(
-                        name=ids["site"], location_type=LocationType.objects.get(name="Site")
-                    ),
-                ).interfaces.get(name=_interface)
-            except ObjectNotCreated:
+                intf = OrmInterface.objects.get(name=_interface, device__name=_device)
+            except OrmInterface.DoesNotExist:
                 diffsync.job.logger.warning(f"{_device} missing interface {_interface} to assign {ids['address']}")
         if ids["tenant"]:
             tenant_name = OrmTenant.objects.get(name=ids["tenant"])


### PR DESCRIPTION
There's a bug in ACI where it's performing a `get_or_create` for LocationType of Site when trying to get a Location but this is wrong as `get_or_create` returns a tuple when we only want the first item from the tuple. As the Site LocationType is created in signals we should be able to just do a get for it.

This also fixes the calls that were using `get_identifiers()` which is unnecessary as that var is on the self variable.