### PR TITLE
fixes custom field contrib functionality

### DIFF
--- a/docs/dev/jobs.md
+++ b/docs/dev/jobs.md
@@ -112,6 +112,9 @@ As you can see when looking at the [source code](https://github.com/nautobot/nau
 
 The above example shows the simplest field type (an attribute on the model), however, to build a production implementation you will need to understand how to identify different variants of fields by following the [modeling docs](../user/modeling.md).
 
+!!! warn
+    Currently, only normal fields, forwards foreign key fields and custom fields may be used in identifiers. Anything else is unsupported and will likely fail in unintuitive ways.
+
 ### Step 2.1 - Creating the Nautobot Adapter
 
 Having created all your models, creating the Nautobot side adapter is very straight-forward:

--- a/docs/user/modeling.md
+++ b/docs/user/modeling.md
@@ -41,7 +41,7 @@ class ProviderModel(NautobotModel):
     _attributes = ("test_custom_field",)
 
     name: str
-    test_custom_field: Annotated[str, CustomFieldAnnotation(name="Test Custom Field")]
+    test_custom_field: Annotated[str, CustomFieldAnnotation(key="Test Custom Field")]
 ```
 
 !!! note

--- a/docs/user/modeling.md
+++ b/docs/user/modeling.md
@@ -41,7 +41,7 @@ class ProviderModel(NautobotModel):
     _attributes = ("test_custom_field",)
 
     name: str
-    test_custom_field: Annotated[str, CustomFieldAnnotation(key="Test Custom Field")]
+    test_custom_field: Annotated[str, CustomFieldAnnotation(key="test_custom_field")]
 ```
 
 !!! note

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -502,8 +502,8 @@ class NautobotModel(DiffSyncModel):
                     is_custom_field = True
             if not is_custom_field:
                 parameters[key] = value
-        if custom_field_lookup:
-            parameters["_custom_field_data__contains"] = custom_field_lookup
+        for key, value in custom_field_lookup.items():
+            parameters[f"_custom_field_data__{key}"] = value
         try:
             return self.diffsync.get_from_orm_cache(parameters, self._model)
         except self._model.DoesNotExist as error:

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -92,7 +92,7 @@ class CustomFieldAnnotation:
             is_global: Annotated[bool, CustomFieldAnnotation(key="is_global")
         ```
 
-        This then maps the model field 'is_global' to the custom field with the key 'Is Global'.
+        This then maps the model field 'is_global' to the custom field with the key 'is_global'.
     """
 
     # TODO: Delete on 3.0, keep around for backwards compatibility for now
@@ -505,7 +505,7 @@ class NautobotModel(DiffSyncModel):
         if custom_field_lookup:
             parameters["_custom_field_data__contains"] = custom_field_lookup
         try:
-            return self.diffsync.get_from_orm_cache(**parameters, self._model)
+            return self.diffsync.get_from_orm_cache(parameters, self._model)
         except self._model.DoesNotExist as error:
             raise ValueError(
                 f"No such {self._model._meta.verbose_name} instance with lookup parameters {parameters}."

--- a/nautobot_ssot/tests/test_contrib.py
+++ b/nautobot_ssot/tests/test_contrib.py
@@ -858,3 +858,60 @@ class CacheTests(TestCase):
             tenant_group_queries = [query["sql"] for query in ctx.captured_queries if query_filter in query["sql"]]
             # One query per tenant to get the tenant group, one to pre-populate the cache, and another query per tenant during `clean`.
             self.assertEqual(6, len(tenant_group_queries))
+
+
+class BaseModelIdentifierTest(TestCase):
+    """Test cases for testing various things as identifiers for models."""
+
+    @classmethod
+    def setUpTestData(cls):
+        custom_field_label = "Preferred ice cream flavour"
+        cls.custom_field = extras_models.CustomField.objects.create(
+            label=custom_field_label, description="The preferred flavour of ice cream for the reps for this provider"
+        )
+        cls.custom_field.content_types.add(ContentType.objects.get_for_model(circuits_models.Provider))
+        provider_name = "Link Inc."
+        provider_flavour = "Vanilla"
+        cls.provider = circuits_models.Provider.objects.create(
+            name=provider_name, _custom_field_data={cls.custom_field.key: provider_flavour}
+        )
+
+    def test_custom_field_in_identifiers_backwards_compatibility(self):
+        """Test the case where `CustomFieldAnnotation.name` is used rather than `CustomFieldAnnotation.key`."""
+        custom_field_key = self.custom_field.key
+
+        class _ProviderTestModel(NautobotModel):
+            _model = circuits_models.Provider
+            _modelname = "provider"
+            _identifiers = ("name", "flavour")
+            _attributes = ()
+
+            name: str
+            flavour: Annotated[str, CustomFieldAnnotation(name=custom_field_key)]  # Note the `name=`
+
+        diffsync_provider = _ProviderTestModel(
+            name=self.provider.name,
+            flavour=self.provider._custom_field_data[self.custom_field.key],  # pylint: disable=protected-access
+        )
+
+        self.assertEqual(self.provider, diffsync_provider.get_from_db())
+
+    def test_custom_field_in_identifiers(self):
+        """Test the basic case where a custom field is part of the identifiers of a diffsync model."""
+        custom_field_key = self.custom_field.key
+
+        class _ProviderTestModel(NautobotModel):
+            _model = circuits_models.Provider
+            _modelname = "provider"
+            _identifiers = ("name", "flavour")
+            _attributes = ()
+
+            name: str
+            flavour: Annotated[str, CustomFieldAnnotation(key=custom_field_key)]
+
+        diffsync_provider = _ProviderTestModel(
+            name=self.provider.name,
+            flavour=self.provider._custom_field_data[self.custom_field.key],  # pylint: disable=protected-access
+        )
+
+        self.assertEqual(self.provider, diffsync_provider.get_from_db())

--- a/nautobot_ssot/tests/test_contrib.py
+++ b/nautobot_ssot/tests/test_contrib.py
@@ -893,6 +893,7 @@ class BaseModelIdentifierTest(TestCase):
             name=self.provider.name,
             flavour=self.provider._custom_field_data[self.custom_field.key],  # pylint: disable=protected-access
         )
+        diffsync_provider.diffsync = NautobotAdapter(job=None)
 
         self.assertEqual(self.provider, diffsync_provider.get_from_db())
 
@@ -913,5 +914,6 @@ class BaseModelIdentifierTest(TestCase):
             name=self.provider.name,
             flavour=self.provider._custom_field_data[self.custom_field.key],  # pylint: disable=protected-access
         )
+        diffsync_provider.diffsync = NautobotAdapter(job=None)
 
         self.assertEqual(self.provider, diffsync_provider.get_from_db())


### PR DESCRIPTION
Supersedes #291 
- Rename `CustomFieldAnnotation.name` to `CustomFieldAnnotation.key`
  - Keep around backwards compatibility for using `name`
- Clarify supported types of fields for identifiers
- Add tests for custom fields in identifiers