### PR TITLE
use typing.get_type_hints everywhere in favor of __annotations__

### DIFF
--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -266,9 +266,8 @@ class NautobotAdapter(DiffSync):
     ):
         # Introspect type annotations to deduce which fields are of interest
         # for this many-to-many relationship.
-        diffsync_field_type = diffsync_model.__annotations__[parameter_name]
-        # TODO: Why is this different then in the normal case??
-        inner_type = diffsync_field_type.__dict__["__args__"][0].__dict__["__args__"][0]
+        diffsync_field_type = get_type_hints(diffsync_model)[parameter_name]
+        inner_type = diffsync_field_type.__dict__["__args__"][0]
         related_objects_list = []
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         relationship = self.get_from_orm_cache({"label": annotation.name}, Relationship)
@@ -297,7 +296,7 @@ class NautobotAdapter(DiffSync):
                 association, "source" if annotation.side == RelationshipSideEnum.DESTINATION else "destination"
             )
             dictionary_representation = {
-                field_name: getattr(related_object, field_name) for field_name in inner_type.__annotations__
+                field_name: getattr(related_object, field_name) for field_name in get_type_hints(inner_type)
             }
             # Only use those where there is a single field defined, all 'None's will not help us.
             if any(dictionary_representation.values()):
@@ -369,13 +368,13 @@ class NautobotAdapter(DiffSync):
         """
         # Introspect type annotations to deduce which fields are of interest
         # for this many-to-many relationship.
-        diffsync_field_type = diffsync_model.__annotations__[parameter_name]
+        diffsync_field_type = get_type_hints(diffsync_model)[parameter_name]
         inner_type = diffsync_field_type.__dict__["__args__"][0]
         related_objects_list = []
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         for related_object in getattr(database_object, parameter_name).all():
             dictionary_representation = {
-                field_name: getattr(related_object, field_name) for field_name in inner_type.__annotations__
+                field_name: getattr(related_object, field_name) for field_name in get_type_hints(inner_type)
             }
             # Only use those where there is a single field defined, all 'None's will not help us.
             if any(dictionary_representation.values()):

--- a/nautobot_ssot/tests/test_contrib.py
+++ b/nautobot_ssot/tests/test_contrib.py
@@ -917,3 +917,43 @@ class BaseModelIdentifierTest(TestCase):
         diffsync_provider.diffsync = NautobotAdapter(job=None)
 
         self.assertEqual(self.provider, diffsync_provider.get_from_db())
+
+
+class AnnotationsSubclassingTest(TestCase):
+    """Test that annotations work properly with subclassing."""
+
+    def test_annotations_subclassing(self):
+        """Test that annotations work properly with subclassing."""
+
+        class BaseTenantModel(NautobotModel):
+            """Tenant model to be subclassed."""
+
+            _model = tenancy_models.Tenant
+            _modelname = "tenant"
+            _identifiers = ("name",)
+            _attributes = ("tags",)
+
+            name: str
+            tags: List[TagDict]
+
+        class Subclass(BaseTenantModel):
+            """Subclassed model."""
+
+            extra_field: Optional[str] = None
+
+        class Adapter(NautobotAdapter):
+            """Test adapter."""
+
+            tenant = Subclass
+            top_level = ["tenant"]
+
+        tenancy_models.Tenant.objects.create(name="Test Tenant")
+
+        adapter = Adapter(job=None)
+        try:
+            adapter.load()
+        except KeyError as error:
+            if error.args[0] == "tags":
+                self.fail("Don't use `Klass.__annotations__`, prefer `typing.get_type_hints`.")
+            else:
+                raise error


### PR DESCRIPTION
I had an SSoT job break because at least in Python 3.11 `Klass.__annotations__` does not show annotations of parent classes, whereas in 3.8 it does. This PR changes that behaviour to be uniform across all Python versions.