### PR TITLE
Import Optional from typing directly

### DIFF
--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -13,7 +13,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, MultipleObjectsReturned
 from django.db.models import Model
 from nautobot.extras.models import Relationship, RelationshipAssociation
-from typing_extensions import get_type_hints, Optional
+from typing import Optional
+from typing_extensions import get_type_hints
 
 
 # This type describes a set of parameters to use as a dictionary key for the cache. As such, its needs to be hashable

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -5,7 +5,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import FrozenSet, Tuple, Hashable, DefaultDict, Dict, Type
+from typing import FrozenSet, Tuple, Hashable, DefaultDict, Dict, Type, Optional
 
 import pydantic
 from diffsync import DiffSyncModel, DiffSync
@@ -13,7 +13,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, MultipleObjectsReturned
 from django.db.models import Model
 from nautobot.extras.models import Relationship, RelationshipAssociation
-from typing import Optional
 from typing_extensions import get_type_hints
 
 


### PR DESCRIPTION
Optional has always existed in the typing module, so there is no need to import from typing_extensions, which has only recently added it to the list of importable objects.