### PR TITLE
use typing.get_args in contrib in favor of accessing __args__

### DIFF
--- a/changes/390.changed
+++ b/changes/390.changed
@@ -1,0 +1,1 @@
+Use typing.get_args in contrib in favor of accessing __args__.

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 
-from typing import FrozenSet, Tuple, Hashable, DefaultDict, Dict, Type
+from typing import FrozenSet, Tuple, Hashable, DefaultDict, Dict, Type, get_args
 
 import pydantic
 from diffsync import DiffSync
@@ -187,7 +187,7 @@ class NautobotAdapter(DiffSync):
         # Introspect type annotations to deduce which fields are of interest
         # for this many-to-many relationship.
         diffsync_field_type = get_type_hints(diffsync_model)[parameter_name]
-        inner_type = diffsync_field_type.__dict__["__args__"][0]
+        inner_type = get_args(diffsync_field_type)[0]
         related_objects_list = []
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         relationship = self.get_from_orm_cache({"label": annotation.name}, Relationship)
@@ -288,8 +288,7 @@ class NautobotAdapter(DiffSync):
         """
         # Introspect type annotations to deduce which fields are of interest
         # for this many-to-many relationship.
-        diffsync_field_type = get_type_hints(diffsync_model)[parameter_name]
-        inner_type = diffsync_field_type.__dict__["__args__"][0]
+        inner_type = get_args(get_type_hints(diffsync_model)[parameter_name])[0]
         related_objects_list = []
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         for related_object in getattr(database_object, parameter_name).all():


### PR DESCRIPTION
This should provide a more consistent and bug-free experience as we are directly utilizing a standard library API.