### PR TITLE
Fix tagging and custom field updates for objects synced to/from Infoblox.

### DIFF
--- a/changes/409.fixed
+++ b/changes/409.fixed
@@ -1,0 +1,1 @@
++ Fixes tagging and custom field updates for Nautobot objects synced to/from Infoblox.

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -12,6 +12,7 @@ from nautobot.ipam.models import VLAN as OrmVlan
 from nautobot.ipam.models import VLANGroup as OrmVlanGroup
 from nautobot_ssot.integrations.infoblox.constant import PLUGIN_CFG
 from nautobot_ssot.integrations.infoblox.diffsync.models.base import Network, IPAddress, Vlan, VlanView
+from nautobot_ssot.integrations.infoblox.utils.diffsync import create_tag_sync_from_infoblox
 from nautobot_ssot.integrations.infoblox.utils.nautobot import get_prefix_vlans
 
 
@@ -132,6 +133,7 @@ class NautobotNetwork(Network):
 
         if attrs.get("ext_attrs"):
             process_ext_attrs(diffsync=diffsync, obj=_prefix, extattrs=attrs["ext_attrs"])
+        _prefix.tags.add(create_tag_sync_from_infoblox())
         _prefix.validated_save()
         diffsync.prefix_map[ids["network"]] = _prefix.id
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
@@ -226,6 +228,7 @@ class NautobotIPAddress(IPAddress):
         if attrs.get("ext_attrs"):
             process_ext_attrs(diffsync=diffsync, obj=_ip, extattrs=attrs["ext_attrs"])
         try:
+            _ip.tags.add(create_tag_sync_from_infoblox())
             _ip.validated_save()
             diffsync.ipaddr_map[_ip.address] = _ip.id
             return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
@@ -317,6 +320,7 @@ class NautobotVlan(Vlan):
         if "ext_attrs" in attrs:
             process_ext_attrs(diffsync=diffsync, obj=_vlan, extattrs=attrs["ext_attrs"])
         try:
+            _vlan.tags.add(create_tag_sync_from_infoblox())
             _vlan.validated_save()
             if ids["vlangroup"] not in diffsync.vlan_map:
                 diffsync.vlan_map[ids["vlangroup"]] = {}

--- a/nautobot_ssot/integrations/infoblox/utils/diffsync.py
+++ b/nautobot_ssot/integrations/infoblox/utils/diffsync.py
@@ -1,6 +1,7 @@
 """Utilities for DiffSync related stuff."""
 from django.contrib.contenttypes.models import ContentType
 from django.utils.text import slugify
+from nautobot.ipam.models import IPAddress, Prefix, VLAN
 from nautobot.extras.models import CustomField, Tag
 from nautobot_ssot.integrations.infoblox.constant import TAG_COLOR
 
@@ -15,6 +16,8 @@ def create_tag_sync_from_infoblox():
             "color": TAG_COLOR,
         },
     )
+    for model in [IPAddress, Prefix, VLAN]:
+        tag.content_types.add(ContentType.objects.get_for_model(model))
     return tag
 
 

--- a/nautobot_ssot/tests/infoblox/test_tags_and_cfs.py
+++ b/nautobot_ssot/tests/infoblox/test_tags_and_cfs.py
@@ -1,0 +1,193 @@
+"""Tests covering use of tags and custom fields in the plugin."""
+import datetime
+from unittest.mock import Mock
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from nautobot.extras.models import CustomField, Status, Tag
+from nautobot.ipam.models import VLAN, IPAddress, Prefix, VLANGroup
+
+from nautobot_ssot.integrations.infoblox.diffsync.adapters.infoblox import InfobloxAdapter
+from nautobot_ssot.integrations.infoblox.diffsync.adapters.nautobot import NautobotAdapter
+
+
+class TestTagging(TestCase):
+    """Tests ensuring tagging is applied to objects synced from and to Infoblox."""
+
+    def setUp(self):
+        "Test class set up."
+        self.tag_sync_from_infoblox = Tag.objects.get(name="SSoT Synced from Infoblox")
+        self.tag_sync_to_infoblox = Tag.objects.get(name="SSoT Synced to Infoblox")
+
+    def test_tags_have_correct_content_types_set(self):
+        """Ensure tags have correct content types configured."""
+        for model in (IPAddress, Prefix, VLAN):
+            content_type = ContentType.objects.get_for_model(model)
+            self.assertIn(content_type, self.tag_sync_from_infoblox.content_types.all())
+            self.assertIn(content_type, self.tag_sync_to_infoblox.content_types.all())
+
+    def test_objects_synced_from_infoblox_are_tagged(self):
+        """Ensure objects synced from Infoblox have 'SSoT Synced from Infoblox' tag applied."""
+        nb_diffsync = NautobotAdapter()
+        nb_diffsync.job = Mock()
+        nb_diffsync.load()
+
+        infoblox_adapter = InfobloxAdapter(conn=Mock())
+
+        ds_prefix = infoblox_adapter.prefix(
+            network="10.0.0.0/8",
+            description="Test Network",
+            network_type="network",
+            status="Active",
+        )
+        infoblox_adapter.add(ds_prefix)
+        ds_ipaddress = infoblox_adapter.ipaddress(
+            description="Test IPAddress",
+            address="10.0.0.1",
+            status="Active",
+            dns_name="",
+            prefix="10.0.0.0/8",
+            prefix_length=8,
+            ip_addr_type="host",
+        )
+        infoblox_adapter.add(ds_ipaddress)
+        ds_vlangroup = infoblox_adapter.vlangroup(
+            name="TestVLANGroup",
+            description="",
+        )
+        infoblox_adapter.add(ds_vlangroup)
+        ds_vlan = infoblox_adapter.vlan(
+            vid=750,
+            name="TestVLAN",
+            description="Test VLAN",
+            status="ASSIGNED",
+            vlangroup="TestVLANGroup",
+            ext_attrs={},
+        )
+        infoblox_adapter.add(ds_vlan)
+
+        nb_diffsync.sync_from(infoblox_adapter)
+
+        prefix = Prefix.objects.get(network="10.0.0.0", prefix_length="8")
+        self.assertEqual(prefix.tags.all()[0], self.tag_sync_from_infoblox)
+
+        ipaddress = IPAddress.objects.get(address="10.0.0.1/8")
+        self.assertEqual(ipaddress.tags.all()[0], self.tag_sync_from_infoblox)
+
+        vlan = VLAN.objects.get(vid=750)
+        self.assertEqual(vlan.tags.all()[0], self.tag_sync_from_infoblox)
+
+    def test_objects_synced_to_infoblox_are_tagged(self):
+        """Ensure objects synced to Infoblox have 'SSoT Synced to Infoblox' tag applied."""
+        nb_prefix = Prefix(
+            network="10.0.0.0",
+            prefix_length=8,
+            description="Test Network",
+            type="network",
+            status=Status.objects.get_for_model(Prefix).first(),
+        )
+        nb_prefix.validated_save()
+        nb_ipaddress = IPAddress(
+            description="Test IPAddress",
+            address="10.0.0.1/8",
+            status=Status.objects.get_for_model(IPAddress).first(),
+            type="host",
+        )
+        nb_ipaddress.validated_save()
+        nb_vlangroup = VLANGroup(
+            name="TestVLANGroup",
+        )
+        nb_vlangroup.validated_save()
+        nb_vlan = VLAN(
+            vid=750,
+            name="VL750",
+            description="Test VLAN",
+            status=Status.objects.get_for_model(VLAN).first(),
+            vlan_group=nb_vlangroup,
+        )
+        nb_vlan.validated_save()
+
+        nautobot_adapter = NautobotAdapter()
+        nautobot_adapter.job = Mock()
+        nautobot_adapter.load()
+
+        infoblox_adapter = InfobloxAdapter(conn=Mock())
+        infoblox_adapter.job = Mock()
+        nautobot_adapter.sync_to(infoblox_adapter)
+
+        prefix = Prefix.objects.get(network="10.0.0.0", prefix_length="8")
+        self.assertEqual(prefix.tags.all()[0], self.tag_sync_to_infoblox)
+
+        ipaddress = IPAddress.objects.get(address="10.0.0.1/8")
+        self.assertEqual(ipaddress.tags.all()[0], self.tag_sync_to_infoblox)
+
+        vlan = VLAN.objects.get(vid=750)
+        self.assertEqual(vlan.tags.all()[0], self.tag_sync_to_infoblox)
+
+
+class TestCustomFields(TestCase):
+    """Tests ensuring custom fields are updated for objects synced from and to Infoblox."""
+
+    def setUp(self):
+        """Test class set up."""
+        self.today = datetime.date.today().isoformat()
+        self.cf_synced_to_infoblox = CustomField.objects.get(key="ssot_synced_to_infoblox")
+
+    def test_cfs_have_correct_content_types_set(self):
+        """Ensure cfs have correct content types configured."""
+        for model in (IPAddress, Prefix, VLAN, VLANGroup):
+            content_type = ContentType.objects.get_for_model(model)
+            self.assertIn(content_type, self.cf_synced_to_infoblox.content_types.all())
+
+    def test_cf_updated_for_objects_synced_to_infoblox(self):
+        """Ensure objects synced to Infoblox have cf 'ssot_synced_to_infoblox' correctly updated."""
+        nb_prefix = Prefix(
+            network="10.0.0.0",
+            prefix_length=8,
+            description="Test Network",
+            type="network",
+            status=Status.objects.get_for_model(Prefix).first(),
+        )
+        nb_prefix.validated_save()
+
+        nb_ipaddress = IPAddress(
+            description="Test IPAddress",
+            address="10.0.0.1/8",
+            status=Status.objects.get_for_model(IPAddress).first(),
+            type="host",
+        )
+        nb_ipaddress.validated_save()
+
+        nb_vlangroup = VLANGroup(
+            name="TestVLANGroup",
+        )
+        nb_vlangroup.validated_save()
+        nb_vlan = VLAN(
+            vid=750,
+            name="VL750",
+            description="Test VLAN",
+            status=Status.objects.get_for_model(VLAN).first(),
+            vlan_group=nb_vlangroup,
+        )
+        nb_vlan.validated_save()
+
+        nautobot_adapter = NautobotAdapter()
+        nautobot_adapter.job = Mock()
+        nautobot_adapter.load()
+
+        conn = Mock()
+        infoblox_adapter = InfobloxAdapter(conn=conn)
+        infoblox_adapter.job = Mock()
+        nautobot_adapter.sync_to(infoblox_adapter)
+
+        prefix = Prefix.objects.get(network="10.0.0.0", prefix_length="8")
+        self.assertEqual(prefix.cf["ssot_synced_to_infoblox"], self.today)
+
+        ipaddress = IPAddress.objects.get(address="10.0.0.1/8")
+        self.assertEqual(ipaddress.cf["ssot_synced_to_infoblox"], self.today)
+
+        vlangroup = VLANGroup.objects.get(name="TestVLANGroup")
+        self.assertEqual(vlangroup.cf["ssot_synced_to_infoblox"], self.today)
+
+        vlan = VLAN.objects.get(vid=750)
+        self.assertEqual(vlan.cf["ssot_synced_to_infoblox"], self.today)


### PR DESCRIPTION
This PR fixes object tagging and custom field updates for Nautobot objects synced to/from Infoblox.

- Adds content types to tags defined by Infoblox SSoT.
- Adds VLAN and VLANGroup to objects being tagged, or having custom field updated.
- Fixes custom field access attribute.
- Removes stale code from `NautobotAdapter` `sync_complete()` method.
- Adds tests checking if tagging and custom field logic is correctly executed.