### PR TITLE
Fix IPFabric technology calls to us `all`

### DIFF
--- a/changes/413.fixed
+++ b/changes/413.fixed
@@ -1,0 +1,1 @@
+Fixed method of retrieving objects from IPFabric's technology categories.

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
@@ -115,7 +115,7 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
         interfaces = self.client.inventory.interfaces.all()
         vlans = self.client.fetch_all("tables/vlan/site-summary")
         networks = defaultdict(list)
-        for network in self.client.technology.managed_networks.networks.fetch(
+        for network in self.client.technology.managed_networks.networks.all(
             filters={"net": ["empty", False], "siteName": ["empty", False]},
             columns=["net", "siteName"],
         ):
@@ -151,7 +151,7 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
             location_devices = [device for device in devices if device["siteName"] == location.name]
             for device in location_devices:
                 device_name = device["hostname"]
-                stack_members = self.client.technology.platforms.stacks_members.fetch(
+                stack_members = self.client.technology.platforms.stacks_members.all(
                     filters={"master": ["eq", device_name], "siteName": ["eq", location.name]},
                     columns=["master", "member", "memberSn", "pn"],
                 )

--- a/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
@@ -36,8 +36,8 @@ class IPFabricDiffSyncTestCase(TestCase):
             side_effect=(lambda x: VLAN_FIXTURE if x == "tables/vlan/site-summary" else "")
         )
         ipfabric_client.inventory.interfaces.all.return_value = INTERFACE_FIXTURE
-        ipfabric_client.technology.managed_networks.networks.fetch.return_value = NETWORKS_FIXTURE
-        ipfabric_client.technology.platforms.stacks_members.fetch.side_effect = [[] for site in SITE_FIXTURE[:-1]] + [
+        ipfabric_client.technology.managed_networks.networks.all.return_value = NETWORKS_FIXTURE
+        ipfabric_client.technology.platforms.stacks_members.all.side_effect = [[] for site in SITE_FIXTURE[:-1]] + [
             STACKS_FIXTURE
         ]
 

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -331,6 +331,7 @@ class TestNestedRelationships(TestCase):
             top_level = ["vlan_group"]
 
         location_type = dcim_models.LocationType.objects.create(name="Building")
+        location_type.content_types.add(ContentType.objects.get_for_model(ipam_models.VLAN))
         location = dcim_models.Location.objects.create(
             name="Example Building", location_type=location_type, status=extras_models.Status.objects.get(name="Active")
         )


### PR DESCRIPTION
Previously these were using `fetch`, which does not collect all results. Switching this to use `all` will get all relevant data points.