### PR TITLE
opens prometheus-client dependency range and removes direkt drf-spect…

### DIFF
--- a/changes/421.housekeeping
+++ b/changes/421.housekeeping
@@ -1,0 +1,1 @@
+Opened prometheus-client dependency range and removed direct drf-spectacular dependency.

--- a/poetry.lock
+++ b/poetry.lock
@@ -5382,4 +5382,4 @@ servicenow = ["Jinja2", "PyYAML", "ijson", "oauthlib", "python-magic", "pytz", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "b969e8a60b22f2df8aa86eb1a633b4d266441eb6cc3d74f726880dc92a91cf4e"
+content-hash = "cd710f5c319a47e01c925b15ded4986b7dd40575ee65813234016f2511ffbbc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ cvprac = { version = "^1.2.2", optional = true }
 dnspython = { version = "^2.1.0", optional = true }
 nautobot-device-lifecycle-mgmt = { version = "^2.0.0", optional = true }
 packaging = ">=21.3, <24"
-prometheus-client = "^0.17.1"
+prometheus-client = ">=0.17.1"
 ijson = { version = ">=2.5.1", optional = true }
 ipfabric = { version = "~6.0.9", optional = true }
 ipfabric-diagrams = { version = "~6.0.2", optional = true }
@@ -50,7 +50,6 @@ pytz = { version = ">=2019.3", optional = true }
 requests = { version = ">=2.21.0", optional = true }
 requests-oauthlib = { version = ">=1.3.0", optional = true }
 six = { version = ">=1.13.0", optional = true }
-drf-spectacular = "^0.26.3"
 httpx = { version = ">=0.23.3", optional = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
…acular dependency.

This should fix the upstream CI that's currently failing: https://github.com/nautobot/nautobot-app-ssot/actions/runs/8641403014/job/23690873680