### PR TITLE
Release v2.6.0

### DIFF
--- a/changes/367.added
+++ b/changes/367.added
@@ -1,1 +1,0 @@
-Added support of Roles, Platforms, Manufacturers, DeviceTypes, and Devices to example Jobs.

--- a/changes/367.fixed
+++ b/changes/367.fixed
@@ -1,1 +1,0 @@
-Fixed issues with example Jobs.

--- a/changes/398.changed
+++ b/changes/398.changed
@@ -1,1 +1,0 @@
-Changed Arista Cloud Vision jobs to optionally use ExternalIntegration.

--- a/changes/407.fixed
+++ b/changes/407.fixed
@@ -1,1 +1,0 @@
-+ Fixed logic check for 'hide_example_jobs' when defined, and also set to False.

--- a/changes/409.fixed
+++ b/changes/409.fixed
@@ -1,1 +1,0 @@
-+ Fixes tagging and custom field updates for Nautobot objects synced to/from Infoblox.

--- a/changes/413.fixed
+++ b/changes/413.fixed
@@ -1,1 +1,0 @@
-Fixed method of retrieving objects from IPFabric's technology categories.

--- a/changes/414.changed
+++ b/changes/414.changed
@@ -1,1 +1,0 @@
-Changed IPFabric interface media matching to fall back on interface names.

--- a/changes/418.housekeeping
+++ b/changes/418.housekeeping
@@ -1,1 +1,0 @@
-Unpins multiple dependencies.

--- a/changes/421.housekeeping
+++ b/changes/421.housekeeping
@@ -1,1 +1,0 @@
-Opened prometheus-client dependency range and removed direct drf-spectacular dependency.

--- a/changes/427.housekeeping
+++ b/changes/427.housekeeping
@@ -1,0 +1,1 @@
+Created release for 2.6.0

--- a/docs/admin/release_notes/version_1.6.md
+++ b/docs/admin/release_notes/version_1.6.md
@@ -59,3 +59,19 @@
 ## Housekeeping
 
 - Replicate module and test module structure for contrib code in LTM branch
+
+## v1.6.4 - 2024-04-16
+
+## Fixed
+
+- [243](https://github.com/nautobot/nautobot-app-ssot/pull/243) - Fix Infoblox import_subnet for ltm-1.6 by @jdrew82
+- [261](https://github.com/nautobot/nautobot-app-ssot/pull/261) - Fix Device42 documentation. by @jdrew82
+- [419](https://github.com/nautobot/nautobot-app-ssot/pull/419) - Fix Device42 Plugin Settings for LTM by @jdrew82
+
+## Changed
+
+- [245](https://github.com/nautobot/nautobot-app-ssot/pull/245) - IPFabric integration settings updates by @alhogan
+- [357](https://github.com/nautobot/nautobot-app-ssot/pull/357) - backport contrib changes to LTM by @Kircheneer
+- [361](https://github.com/nautobot/nautobot-app-ssot/pull/361) - Backport of #350 by @Kircheneer
+- [363](https://github.com/nautobot/nautobot-app-ssot/pull/363) - Backport #362 by @Kircheneer
+- [373](https://github.com/nautobot/nautobot-app-ssot/pull/373) - change contrib.NautobotModel.get_from_db to use a PK by @Kircheneer

--- a/docs/admin/release_notes/version_1.6.md
+++ b/docs/admin/release_notes/version_1.6.md
@@ -4,19 +4,19 @@
 
 ## Added
 
-- [221](https://github.com/nautobot/nautobot-plugin-ssot/pull/221) - Add Device42 integration by @jdrew82
-- [222](https://github.com/nautobot/nautobot-plugin-ssot/pull/222) - Add conflicting message link by @snaselj
-- [224](https://github.com/nautobot/nautobot-plugin-ssot/pull/224) - Allow Skipping Conflicting Apps Check by @snaselj
+- [221](https://github.com/nautobot/nautobot-app-ssot/pull/221) - Add Device42 integration by @jdrew82
+- [222](https://github.com/nautobot/nautobot-app-ssot/pull/222) - Add conflicting message link by @snaselj
+- [224](https://github.com/nautobot/nautobot-app-ssot/pull/224) - Allow Skipping Conflicting Apps Check by @snaselj
 
 ## Changed
 
-- [219](https://github.com/nautobot/nautobot-plugin-ssot/pull/219) - Attempt fixing CI error in #214 by @Kircheneer
-- [220](https://github.com/nautobot/nautobot-plugin-ssot/pull/220) - Update ci.yml by @Kircheneer
-- [214](https://github.com/nautobot/nautobot-plugin-ssot/pull/214) - Sync Main to Develop for 1.5.0 by @jdrew82
-- [218](https://github.com/nautobot/nautobot-plugin-ssot/pull/218) - Fixes contrib.NautobotModel not returning objects on update/delete by @Kircheneer
-- [161](https://github.com/nautobot/nautobot-plugin-ssot/pull/161) - Reverts ChatOps dependency removal by @snaselj
-- [213](https://github.com/nautobot/nautobot-plugin-ssot/pull/213) - fix: :bug: Several fixes in the ACI integration by @chadell
-- [205](https://github.com/nautobot/nautobot-plugin-ssot/pull/205) - Migrate PR #164 from Arista Child Repo by @qduk
+- [219](https://github.com/nautobot/nautobot-app-ssot/pull/219) - Attempt fixing CI error in #214 by @Kircheneer
+- [220](https://github.com/nautobot/nautobot-app-ssot/pull/220) - Update ci.yml by @Kircheneer
+- [214](https://github.com/nautobot/nautobot-app-ssot/pull/214) - Sync Main to Develop for 1.5.0 by @jdrew82
+- [218](https://github.com/nautobot/nautobot-app-ssot/pull/218) - Fixes contrib.NautobotModel not returning objects on update/delete by @Kircheneer
+- [161](https://github.com/nautobot/nautobot-app-ssot/pull/161) - Reverts ChatOps dependency removal by @snaselj
+- [213](https://github.com/nautobot/nautobot-app-ssot/pull/213) - fix: :bug: Several fixes in the ACI integration by @chadell
+- [205](https://github.com/nautobot/nautobot-app-ssot/pull/205) - Migrate PR #164 from Arista Child Repo by @qduk
 
 ## v1.6.1 - 2024-02-21
 

--- a/docs/admin/release_notes/version_1.6.md
+++ b/docs/admin/release_notes/version_1.6.md
@@ -4,16 +4,58 @@
 
 ## Added
 
-- [221](https://github.com/nautobot/nautobot-app-ssot/pull/221) - Add Device42 integration by @jdrew82
-- [222](https://github.com/nautobot/nautobot-app-ssot/pull/222) - Add conflicting message link by @snaselj
-- [224](https://github.com/nautobot/nautobot-app-ssot/pull/224) - Allow Skipping Conflicting Apps Check by @snaselj
+- [221](https://github.com/nautobot/nautobot-plugin-ssot/pull/221) - Add Device42 integration by @jdrew82
+- [222](https://github.com/nautobot/nautobot-plugin-ssot/pull/222) - Add conflicting message link by @snaselj
+- [224](https://github.com/nautobot/nautobot-plugin-ssot/pull/224) - Allow Skipping Conflicting Apps Check by @snaselj
 
 ## Changed
 
-- [219](https://github.com/nautobot/nautobot-app-ssot/pull/219) - Attempt fixing CI error in #214 by @Kircheneer
-- [220](https://github.com/nautobot/nautobot-app-ssot/pull/220) - Update ci.yml by @Kircheneer
-- [214](https://github.com/nautobot/nautobot-app-ssot/pull/214) - Sync Main to Develop for 1.5.0 by @jdrew82
-- [218](https://github.com/nautobot/nautobot-app-ssot/pull/218) - Fixes contrib.NautobotModel not returning objects on update/delete by @Kircheneer
-- [161](https://github.com/nautobot/nautobot-app-ssot/pull/161) - Reverts ChatOps dependency removal by @snaselj
-- [213](https://github.com/nautobot/nautobot-app-ssot/pull/213) - fix: :bug: Several fixes in the ACI integration by @chadell
-- [205](https://github.com/nautobot/nautobot-app-ssot/pull/205) - Migrate PR #164 from Arista Child Repo by @qduk
+- [219](https://github.com/nautobot/nautobot-plugin-ssot/pull/219) - Attempt fixing CI error in #214 by @Kircheneer
+- [220](https://github.com/nautobot/nautobot-plugin-ssot/pull/220) - Update ci.yml by @Kircheneer
+- [214](https://github.com/nautobot/nautobot-plugin-ssot/pull/214) - Sync Main to Develop for 1.5.0 by @jdrew82
+- [218](https://github.com/nautobot/nautobot-plugin-ssot/pull/218) - Fixes contrib.NautobotModel not returning objects on update/delete by @Kircheneer
+- [161](https://github.com/nautobot/nautobot-plugin-ssot/pull/161) - Reverts ChatOps dependency removal by @snaselj
+- [213](https://github.com/nautobot/nautobot-plugin-ssot/pull/213) - fix: :bug: Several fixes in the ACI integration by @chadell
+- [205](https://github.com/nautobot/nautobot-plugin-ssot/pull/205) - Migrate PR #164 from Arista Child Repo by @qduk
+
+## v1.6.1 - 2024-02-21
+
+## Fixed
+
+- [243](https://github.com/nautobot/nautobot-app-ssot/pull/243) - Fix Infoblox import_subnet for ltm-1.6 by @jdrew82
+- [261](https://github.com/nautobot/nautobot-app-ssot/pull/261) - Fix Device42 documentation. by @jdrew82
+
+## Changed
+
+- [245](https://github.com/nautobot/nautobot-app-ssot/pull/245) - IPFabric integration settings updates by @alhogan
+
+- [357](https://github.com/nautobot/nautobot-app-ssot/pull/357) - Backport contrib changes to LTM by @Kircheneer
+- [361](https://github.com/nautobot/nautobot-app-ssot/pull/361) - Backport of #350 by @Kircheneer
+- [363](https://github.com/nautobot/nautobot-app-ssot/pull/363) - Backport #362 by @Kircheneer
+
+## v1.6.2 - 2024-03-12
+
+## Fixed
+
+- [386](https://github.com/nautobot/nautobot-app-ssot/pull/386) - Fixes bug in backport of contrib custom relationship handling
+
+## Changed
+
+- [386](https://github.com/nautobot/nautobot-app-ssot/pull/386) - Improves error handling in contrib (backport of #374)
+- [373](https://github.com/nautobot/nautobot-app-ssot/pull/373) - Change contrib.NautobotModel.get_from_db to use a PK (backport of #371)
+
+## v1.6.3 - 2024-03-20
+
+## Fixed
+
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) - Fix custom one-to-many relationships (backport of #393)
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) -
+  Use `typing.get_args` in favor of accessing `__args__` directly (backport of #390)
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) -
+  Fixed issue with generic relationships and `NautobotAdapter.load` (backport of #388)
+- [396](Fixed issue with generic relationships and `NautobotAdapter.load`.) -
+  Allow foreign keys inside of many to many relationships (backport of #377)
+
+## Housekeeping
+
+- Replicate module and test module structure for contrib code in LTM branch

--- a/docs/admin/release_notes/version_1.6.md
+++ b/docs/admin/release_notes/version_1.6.md
@@ -49,12 +49,9 @@
 ## Fixed
 
 - [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) - Fix custom one-to-many relationships (backport of #393)
-- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) -
-  Use `typing.get_args` in favor of accessing `__args__` directly (backport of #390)
-- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) -
-  Fixed issue with generic relationships and `NautobotAdapter.load` (backport of #388)
-- [396](Fixed issue with generic relationships and `NautobotAdapter.load`.) -
-  Allow foreign keys inside of many to many relationships (backport of #377)
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) - Use `typing.get_args` in favor of accessing `__args__` directly (backport of #390)
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) - Fixed issue with generic relationships and `NautobotAdapter.load` (backport of #388)
+- [396](https://github.com/nautobot/nautobot-app-ssot/pull/396) - Allow foreign keys inside of many to many relationships (backport of #377)
 
 ## Housekeeping
 

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -15,8 +15,8 @@
 ### Fixed
 
 - [#367](https://github.com/nautobot/nautobot-app-ssot/issues/367) - Fixed issues with example Jobs.
-- [#407](https://github.com/nautobot/nautobot-app-ssot/issues/407) - + Fixed logic check for 'hide_example_jobs' when defined, and also set to False.
-- [#409](https://github.com/nautobot/nautobot-app-ssot/issues/409) - + Fixes tagging and custom field updates for Nautobot objects synced to/from Infoblox.
+- [#407](https://github.com/nautobot/nautobot-app-ssot/issues/407) - Fixed logic check for 'hide_example_jobs' when defined, and also set to False.
+- [#409](https://github.com/nautobot/nautobot-app-ssot/issues/409) - Fixed tagging and custom field updates for Nautobot objects synced to/from Infoblox.
 - [#413](https://github.com/nautobot/nautobot-app-ssot/issues/413) - Fixed method of retrieving objects from IPFabric's technology categories.
 
 ### Housekeeping

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -1,5 +1,5 @@
 
-# v2.5 Release Notes
+# v2.6 Release Notes
 
 ## [v2.6.0 (2024-04-16)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v2.6.0)
 

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -1,0 +1,25 @@
+
+# v2.5 Release Notes
+
+## [v2.6.0 (2024-04-16)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v2.6.0)
+
+### Added
+
+- [#367](https://github.com/nautobot/nautobot-app-ssot/issues/367) - Added support of Roles, Platforms, Manufacturers, DeviceTypes, and Devices to example Jobs.
+
+### Changed
+
+- [#398](https://github.com/nautobot/nautobot-app-ssot/issues/398) - Changed Arista Cloud Vision jobs to optionally use ExternalIntegration.
+- [#414](https://github.com/nautobot/nautobot-app-ssot/issues/414) - Changed IPFabric interface media matching to fall back on interface names.
+
+### Fixed
+
+- [#367](https://github.com/nautobot/nautobot-app-ssot/issues/367) - Fixed issues with example Jobs.
+- [#407](https://github.com/nautobot/nautobot-app-ssot/issues/407) - + Fixed logic check for 'hide_example_jobs' when defined, and also set to False.
+- [#409](https://github.com/nautobot/nautobot-app-ssot/issues/409) - + Fixes tagging and custom field updates for Nautobot objects synced to/from Infoblox.
+- [#413](https://github.com/nautobot/nautobot-app-ssot/issues/413) - Fixed method of retrieving objects from IPFabric's technology categories.
+
+### Housekeeping
+
+- [#418](https://github.com/nautobot/nautobot-app-ssot/issues/418) - Unpins multiple dependencies.
+- [#421](https://github.com/nautobot/nautobot-app-ssot/issues/421) - Opened prometheus-client dependency range and removed direct drf-spectacular dependency.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.6: "admin/release_notes/version_2.6.md"
           - v2.5: "admin/release_notes/version_2.5.md"
           - v2.4: "admin/release_notes/version_2.4.md"
           - v2.3: "admin/release_notes/version_2.3.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot"
-version = "2.5.0"
+version = "2.6.0"
 description = "Nautobot Single Source of Truth"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Added

- [#367](https://github.com/nautobot/nautobot-app-ssot/issues/367) - Added support of Roles, Platforms, Manufacturers, DeviceTypes, and Devices to example Jobs.

### Changed

- [#398](https://github.com/nautobot/nautobot-app-ssot/issues/398) - Changed Arista Cloud Vision jobs to optionally use ExternalIntegration.
- [#414](https://github.com/nautobot/nautobot-app-ssot/issues/414) - Changed IPFabric interface media matching to fall back on interface names.

### Fixed

- [#367](https://github.com/nautobot/nautobot-app-ssot/issues/367) - Fixed issues with example Jobs.
- [#407](https://github.com/nautobot/nautobot-app-ssot/issues/407) - + Fixed logic check for 'hide_example_jobs' when defined, and also set to False.
- [#409](https://github.com/nautobot/nautobot-app-ssot/issues/409) - + Fixes tagging and custom field updates for Nautobot objects synced to/from Infoblox.
- [#413](https://github.com/nautobot/nautobot-app-ssot/issues/413) - Fixed method of retrieving objects from IPFabric's technology categories.

### Housekeeping

- [#418](https://github.com/nautobot/nautobot-app-ssot/issues/418) - Unpins multiple dependencies.
- [#421](https://github.com/nautobot/nautobot-app-ssot/issues/421) - Opened prometheus-client dependency range and removed direct drf-spectacular dependency.
