### PR TITLE
Correct CVP Integration Call to get_devices()

### DIFF
--- a/changes/463.fixed
+++ b/changes/463.fixed
@@ -1,0 +1,1 @@
+Fixed call in CVP integration to pass `import_active` config setting to get_devices() function call.

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -69,7 +69,9 @@ class CloudvisionAdapter(DiffSync):
             except ObjectAlreadyExists as err:
                 self.job.logger.warning(f"Error attempting to add CloudVision device. {err}")
 
-        for index, dev in enumerate(cloudvision.get_devices(client=self.conn.comm_channel), start=1):
+        for index, dev in enumerate(
+            cloudvision.get_devices(client=self.conn.comm_channel, import_active=config.import_active), start=1
+        ):
             if self.job.debug:
                 self.job.logger.info(f"Loading {index}° device")
             if dev["hostname"] != "":


### PR DESCRIPTION
This addresses closes issue #463 to have `import_active` config setting passed to get_devices() call.