### PR TITLE
Fix #497 - compatibility with Nautobot 2.3.

### DIFF
--- a/changes/497.housekeeping
+++ b/changes/497.housekeeping
@@ -1,0 +1,1 @@
+Fixed IPFabric test failures under Django 4.2.

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -374,7 +374,7 @@ class TestNautobotUtils(TestCase):
     @unittest.mock.patch("logging.Logger", autospec=True)
     def test_create_ip_fail_to_get_status_multiple_returned(self, mock_logger, mock_ipaddress, mock_status):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.side_effect = [Status.MultipleObjectsReturned]
+        mock_status.return_value.get.side_effect = [Status.MultipleObjectsReturned]
         logger = mock_logger("nb_job")
         test_ip = create_ip("192.168.0.1", "255.255.255.255", logger=logger)
         mock_ipaddress.assert_not_called()
@@ -392,7 +392,7 @@ class TestNautobotUtils(TestCase):
     @unittest.mock.patch("logging.Logger", autospec=True)
     def test_create_ip_fail_to_get_status_does_not_exist(self, mock_logger, mock_ipaddress, mock_status):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.side_effect = [Status.DoesNotExist]
+        mock_status.return_value.get.side_effect = [Status.DoesNotExist]
         logger = mock_logger("nb_job")
         test_ip = create_ip("192.168.0.1", "255.255.255.255", logger=logger)
         mock_ipaddress.assert_not_called()
@@ -441,7 +441,7 @@ class TestNautobotUtils(TestCase):
         mock_status,
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [DjangoBaseDBError, ("mock_ipaddress", True)]
         logger = mock_logger("nb_job")
@@ -482,7 +482,7 @@ class TestNautobotUtils(TestCase):
         mock_status,
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [ValidationError("failure"), ("mock_ipaddress", True)]
         logger = mock_logger("nb_job")
@@ -525,7 +525,7 @@ class TestNautobotUtils(TestCase):
         mock_status,
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [DjangoBaseDBError, ("mock_ipaddress", True)]
         logger = mock_logger("nb_job")
@@ -573,7 +573,7 @@ class TestNautobotUtils(TestCase):
         mock_status,
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [ValidationError("failure"), ("mock_ipaddress", True)]
         logger = mock_logger("nb_job")
@@ -611,7 +611,7 @@ class TestNautobotUtils(TestCase):
         self, mock_logger, mock_tag_object, mock_prefix, mock_ipaddress_to_interface, mock_ip, mock_status
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.side_effect = [DjangoBaseDBError]
         mock_ip.side_effect = [ValidationError("failure")]
         logger = mock_logger("nb_job")
@@ -638,7 +638,7 @@ class TestNautobotUtils(TestCase):
         self, mock_logger, mock_tag_object, mock_prefix, mock_ipaddress_to_interface, mock_ip, mock_status
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.side_effect = [ValidationError("failure")]
         mock_ip.side_effect = [ValidationError("failure")]
         logger = mock_logger("nb_job")
@@ -665,7 +665,7 @@ class TestNautobotUtils(TestCase):
         self, mock_logger, mock_tag_object, mock_prefix, mock_ipaddress_to_interface, mock_ip, mock_status
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [ValidationError("failure"), DjangoBaseDBError]
         logger = mock_logger("nb_job")
@@ -697,7 +697,7 @@ class TestNautobotUtils(TestCase):
         self, mock_logger, mock_tag_object, mock_prefix, mock_ipaddress_to_interface, mock_ip, mock_status
     ):
         """Test `create_device_type_object` Utility."""
-        mock_status().get.return_value = "mock_status"
+        mock_status.return_value.get.return_value = "mock_status"
         mock_prefix.return_value = ("mock_prefix", False)
         mock_ip.side_effect = [ValidationError("failure"), ValidationError("failure")]
         logger = mock_logger("nb_job")


### PR DESCRIPTION
Correct the mocks in `test_nbutils.py` so that tests pass with Nautobot 2.3.0 prerelease.