### PR TITLE
Update the ExampleDataSource job to improve memory utilization

### DIFF
--- a/changes/526.changed
+++ b/changes/526.changed
@@ -1,0 +1,2 @@
+Updated the ExampleDataSource job to improve memory utilization with large data sets.
+Changed memory profiling logging output to format bytes into KiB/MiB.

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -112,6 +112,17 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
         - self.job_result (as per Job API)
         """
 
+        def format_size(size):
+            """Format a size in bytes to a human-readable string. Borrowed from stdlib tracemalloc."""
+            for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+                if abs(size) < 100 and unit != "B":
+                    # 3 digits (xx.x UNIT)
+                    return "%.1f %s" % (size, unit)
+                if abs(size) < 10 * 1024 or unit == "TiB":
+                    # 4 or 5 digits (xxxx UNIT)
+                    return "%.0f %s" % (size, unit)
+                size /= 1024
+
         def record_memory_trace(step: str):
             """Helper function to record memory usage and reset tracemalloc stats."""
             memory_final, memory_peak = tracemalloc.get_traced_memory()
@@ -121,8 +132,8 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
             self.logger.info(
                 "Traced memory for %s (Final, Peak): %s, %s",
                 step,
-                tracemalloc._format_size(memory_final, ""),
-                tracemalloc._format_size(memory_peak, ""),
+                format_size(memory_final),
+                format_size(memory_peak),
             )
             tracemalloc.clear_traces()
 

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -112,15 +112,15 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
         - self.job_result (as per Job API)
         """
 
-        def format_size(size):
+        def format_size(size):  # pylint: disable=inconsistent-return-statements
             """Format a size in bytes to a human-readable string. Borrowed from stdlib tracemalloc."""
             for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
                 if abs(size) < 100 and unit != "B":
                     # 3 digits (xx.x UNIT)
-                    return "%.1f %s" % (size, unit)
+                    return "%.1f %s" % (size, unit)  # pylint: disable=consider-using-f-string
                 if abs(size) < 10 * 1024 or unit == "TiB":
                     # 4 or 5 digits (xxxx UNIT)
-                    return "%.0f %s" % (size, unit)
+                    return "%.0f %s" % (size, unit)  # pylint: disable=consider-using-f-string
                 size /= 1024
 
         def record_memory_trace(step: str):

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -118,7 +118,12 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
             setattr(self.sync, f"{step}_memory_final", memory_final)
             setattr(self.sync, f"{step}_memory_peak", memory_peak)
             self.sync.save()
-            self.logger.info("Traced memory for %s (Final, Peak): %s bytes, %s bytes", step, memory_final, memory_peak)
+            self.logger.info(
+                "Traced memory for %s (Final, Peak): %s, %s",
+                step,
+                tracemalloc._format_size(memory_final, ""),
+                tracemalloc._format_size(memory_peak, ""),
+            )
             tracemalloc.clear_traces()
 
         if not self.sync:

--- a/nautobot_ssot/jobs/examples.py
+++ b/nautobot_ssot/jobs/examples.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from typing import TypedDict  # Python>=3.9
 
-from typing import List, Mapping, Optional
+from typing import Generator, List, Optional
 
 import requests
 from diffsync import Adapter
@@ -477,14 +477,13 @@ class NautobotRemote(Adapter):
             "Authorization": f"Token {self.token}",
         }
 
-    def _get_api_data(self, url_path: str) -> Mapping:
+    def _get_api_data(self, url_path: str) -> Generator:
         """Returns data from a url_path using pagination."""
         data = requests.get(f"{self.url}/{url_path}", headers=self.headers, params={"limit": 200}, timeout=60).json()
-        result_data = data["results"]
+        yield from data["results"]
         while data["next"]:
             data = requests.get(data["next"], headers=self.headers, params={"limit": 200}, timeout=60).json()
-            result_data.extend(data["results"])
-        return result_data
+            yield from data["results"]
 
     def load(self):
         """Load data from the remote Nautobot instance."""


### PR DESCRIPTION
This changes the `NautobotRemote` adapter to use a generator to process large lists of data instead of building a large list and returning it.

This also updates the logging output to be more human-readable.

## Before

![image](https://github.com/user-attachments/assets/663ef4bd-f14d-441c-8332-9cc100b58a46)

## After

![image](https://github.com/user-attachments/assets/a7eba0b2-7216-415a-9c6c-7ef3d72f54e7)


Also confirmed with `docker stats` that the container memory utilization only increased by ~110MiB after running the job