### PR TITLE
fixed invoke check-migrations in ltm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on: # yamllint disable-line rule:truthy rule:comments
   pull_request: ~
 
 env:
-  PLUGIN_NAME: "nautobot-plugin-ssot"
+  PLUGIN_NAME: "nautobot-ssot"
 
 jobs:
   black:

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -19,7 +19,7 @@ services:
   db:
     image: "mysql:8"
     command:
-      - "--default-authentication-plugin=mysql_native_password"
+      - "--max_connections=1000"
     env_file:
       - "development.env"
       - "creds.env"

--- a/tasks.py
+++ b/tasks.py
@@ -111,9 +111,7 @@ def docker_compose(context, command, **kwargs):
     ]
 
     for compose_file in context.nautobot_ssot.compose_files:
-        compose_file_path = os.path.join(
-            context.nautobot_ssot.compose_dir, compose_file
-        )
+        compose_file_path = os.path.join(context.nautobot_ssot.compose_dir, compose_file)
         compose_command_tokens.append(f' -f "{compose_file_path}"')
 
     compose_command_tokens.append(command)
@@ -210,9 +208,7 @@ def restart(context, service=""):
 def stop(context, service=""):
     """Stop specified or all services, if service is not specified, remove all containers."""
     print("Stopping Nautobot...")
-    docker_compose(
-        context, "stop" if service else "down --remove-orphans", service=service
-    )
+    docker_compose(context, "stop" if service else "down --remove-orphans", service=service)
 
 
 @task
@@ -420,9 +416,7 @@ def dbshell(context, query="", input="", output=""):
     if output:
         command += [f"> '{output}'"]
 
-    docker_compose(
-        context, " ".join(command), env=env_vars, pty=not (input or output or query)
-    )
+    docker_compose(context, " ".join(command), env=env_vars, pty=not (input or output or query))
 
 
 @task(
@@ -520,9 +514,7 @@ def backup_db(context, output="dump.sql", readable=True):
     print(50 * "=")
     print("The database backup has been successfully completed and saved to the file:")
     print(output)
-    print(
-        "If you want to import this database backup, please execute the following command:"
-    )
+    print("If you want to import this database backup, please execute the following command:")
     print(f"invoke import-db --input '{output}'")
     print(50 * "=")
 
@@ -551,9 +543,7 @@ def docs(context):
         print("Serving Documentation...")
         run_command(context, command)
     else:
-        print(
-            "Only used when developing locally (i.e. context.nautobot_ssot.local=True)!"
-        )
+        print("Only used when developing locally (i.e. context.nautobot_ssot.local=True)!")
 
 
 # ------------------------------------------------------------------------------
@@ -665,9 +655,7 @@ def unittest(
 @task
 def unittest_coverage(context):
     """Report on code test coverage as measured by 'invoke unittest'."""
-    command = (
-        "coverage report --skip-covered --include 'nautobot_ssot/*' --omit *migrations*"
-    )
+    command = "coverage report --skip-covered --include 'nautobot_ssot/*' --omit *migrations*"
 
     run_command(context, command)
 


### PR DESCRIPTION
This fixes the `invoke check-migrations` command so that upstream testing doesn't fail on this step anymore.