### PR TITLE
Disable saved view for SSOTInfobloxConfig on LTM-2.8

### DIFF
--- a/changes/530.fixed
+++ b/changes/530.fixed
@@ -1,0 +1,1 @@
+Fixed Infoblox Configuration List Bug when on Nautobot 2.3 by disabling SSOTInfobloxConfig from being a saved view.

--- a/nautobot_ssot/integrations/infoblox/models.py
+++ b/nautobot_ssot/integrations/infoblox/models.py
@@ -37,6 +37,7 @@ class SSOTInfobloxConfig(PrimaryModel):  # pylint: disable=too-many-ancestors
     """SSOT Infoblox Configuration model."""
 
     name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
+    is_saved_view_model = False
     description = models.CharField(
         max_length=CHARFIELD_MAX_LENGTH,
         blank=True,


### PR DESCRIPTION
Also closes #530 for 2.8 release train