### PR TITLE
IP Fabric Bug - Network has host bits set

### DIFF
--- a/changes/561.fixed
+++ b/changes/561.fixed
@@ -1,0 +1,1 @@
+Bug in IP Fabric that causes some network columns to return host bits set; changed `ip_network` to use `strict=False`.

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
@@ -120,7 +120,8 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
             filters={"net": ["empty", False], "siteName": ["empty", False]},
             columns=["net", "siteName"],
         ):
-            networks[network["siteName"]].append(ipaddress.ip_network(network["net"]))
+            # IPF bug NIM-15635 Fix Version 7.0: 'net' column has host bits set.
+            networks[network["siteName"]].append(ipaddress.ip_network(network["net"], strict=False))
         for location in self.get_all(self.location):
             if location.name is None:
                 continue


### PR DESCRIPTION
Fixes: https://github.com/nautobot/nautobot-app-ssot/issues/561

Set `strict=False` for parsing IP Networks using `ipaddress.ip_network`