### PR TITLE
Ensure URL Scheme in POST

### DIFF
--- a/changes/571.fixed
+++ b/changes/571.fixed
@@ -1,0 +1,1 @@
+Fixed requests call that was missing URL scheme.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -56,7 +56,7 @@ class CloudvisionApi:  # pylint: disable=too-many-instance-attributes, too-many-
                 call_creds = grpc.access_token_call_credentials(token)
             elif config.cvp_user != "" and config.cvp_password != "":
                 response = requests.post(
-                    f"{parsed_url.hostname}:{parsed_url.port}/cvpservice/login/authenticate.do",
+                    f"{parsed_url.scheme}://{parsed_url.hostname}:{parsed_url.port}/cvpservice/login/authenticate.do",
                     auth=(config.cvp_user, config.cvp_password),
                     timeout=60,
                     verify=config.verify_ssl,


### PR DESCRIPTION
This PR closes #571 and ensures that the URL scheme is included in the POST call to establish the CVP client.