### PR TITLE
Handle RpcError in CVP

### DIFF
--- a/changes/467.fixed
+++ b/changes/467.fixed
@@ -1,0 +1,1 @@
+Fix get_tags_by_type() to handle possible RpcError Exception being thrown.

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -232,7 +232,7 @@ class CloudvisionAdapter(Adapter):
     def load_device_tags(self, device):
         """Load device tags from CloudVision."""
         system_tags = cloudvision.get_tags_by_type(
-            client=self.conn.comm_channel, creator_type=TAG.models.CREATOR_TYPE_SYSTEM
+            client=self.conn.comm_channel, logger=self.job.logger, creator_type=TAG.models.CREATOR_TYPE_SYSTEM
         )
         dev_tags = [
             tag

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -267,18 +267,21 @@ def get_devices(client, import_active: bool):
     return devices
 
 
-def get_tags_by_type(client, creator_type: int = tag_models.CREATOR_TYPE_USER):
+def get_tags_by_type(client, logger, creator_type: int = tag_models.CREATOR_TYPE_USER):
     """Get tags by creator type from CloudVision."""
-    tag_stub = tag_services.TagServiceStub(client)
-    req = tag_services.TagStreamRequest(partial_eq_filter=[tag_models.Tag(creator_type=creator_type)])
-    responses = tag_stub.GetAll(req)
     tags = []
-    for resp in responses:
-        dev_tag = {
-            "label": resp.value.key.label.value,
-            "value": resp.value.key.value.value,
-        }
-        tags.append(dev_tag)
+    try:
+        tag_stub = tag_services.TagServiceStub(client)
+        req = tag_services.TagStreamRequest(partial_eq_filter=[tag_models.Tag(creator_type=creator_type)])
+        responses = tag_stub.GetAll(req)
+        for resp in responses:
+            dev_tag = {
+                "label": resp.value.key.label.value,
+                "value": resp.value.key.value.value,
+            }
+            tags.append(dev_tag)
+    except grpc.RpcError as err:
+        logger.error(f"Error when pulling Tags: {err}")
     return tags
 
 

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -129,7 +129,7 @@ class TestCloudvisionUtils(TestCase):
         device_tag_stub.TagServiceStub.return_value.GetAll.return_value = [mock_tag]
 
         with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.tag_services", device_tag_stub):
-            results = cloudvision.get_tags_by_type(client=self.client)
+            results = cloudvision.get_tags_by_type(client=self.client, logger=MagicMock())
         expected = [{"label": "test", "value": "test"}]
         self.assertEqual(results, expected)
 


### PR DESCRIPTION
This should close out #467. This simply puts a try/except in get_tags_by_type() to handle possible RpcError's being thrown.