### PR TITLE
Removing erroneous print statement

### DIFF
--- a/changes/582.fixed
+++ b/changes/582.fixed
@@ -1,0 +1,1 @@
+Fixed erroneous print statement in sync logs.

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -193,7 +193,6 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
             self.logger.info("As `dryrun` is set, skipping the actual data sync.")
         else:
             self.logger.info("Syncing from %s to %s...", self.source_adapter, self.target_adapter)
-            print("I'm executing the sync now")
             self.execute_sync()
             execute_sync_time = datetime.now()
             self.sync.sync_time = execute_sync_time - calculate_diff_time


### PR DESCRIPTION
Stumbled upon a print statement that needs to be removed.