### PR TITLE
Update social media link and icon to reflect Twitter's rebranding to X.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,9 +67,9 @@ extra:
     - icon: "fontawesome/brands/github"
       link: "https://github.com/nautobot/nautobot"
       name: "GitHub Repo"
-    - icon: "fontawesome/brands/twitter"
-      link: "https://twitter.com/networktocode"
-      name: "Network to Code Twitter"
+    - icon: "fontawesome/brands/x-twitter"
+      link: "https://x.com/networktocode"
+      name: "Network to Code X (formerly Twitter)"
 markdown_extensions:
   - "markdown_version_annotations":
       admonition_tag: "???"


### PR DESCRIPTION
This pull request includes a small change to the `mkdocs.yml` file. The change updates the social media link and icon for Network to Code from Twitter to X (formerly Twitter).

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L70-R72): Updated the social media link and icon for Network to Code from Twitter to X (formerly Twitter).