### PR TITLE
improves error message for contrib validated save

### DIFF
--- a/changes/590.changed
+++ b/changes/590.changed
@@ -1,0 +1,1 @@
+Improved error message for validated save in contrib model.

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -229,7 +229,9 @@ class NautobotModel(DiffSyncModel):
         try:
             obj.validated_save()
         except ValidationError as error:
-            raise ObjectCrudException(f"Validated save failed for Django object. Parameters: {parameters}") from error
+            raise ObjectCrudException(
+                f"Validated save failed for Django object:\n{error}\nParameters: {parameters}"
+            ) from error
 
         # Handle relationship association creation. This needs to be after object creation, because relationship
         # association objects rely on both sides already existing.


### PR DESCRIPTION
Without this the actual error message is swallowed, making it very hard to debug validation errors.