### PR TITLE
Various Bugfixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 /nautobot_ssot/integrations/aristacv/ @qduk @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/bootstrap/ @bile0026 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/device42/ @jdrew82 @nautobot/plugin-ssot
+/nautobot_ssot/integrations/dna_center/ @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/infoblox/ @qduk @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/ipfabric/ @alhogan @nautobot/plugin-ssot
+/nautobot_ssot/integrations/itential/ @jtdub @nautobot/plugin-ssot
+/nautobot_ssot/integrations/meraki/ @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/servicenow/ @glennmatthews @qduk @nautobot/plugin-ssot

--- a/changes/593.added
+++ b/changes/593.added
@@ -1,1 +1,2 @@
 Added ability to rename Network in Meraki and Datacenter in DNA Center integrations using location_map.
+Added support for SoftwareVersion in Bootstrap integration.

--- a/changes/593.added
+++ b/changes/593.added
@@ -1,0 +1,1 @@
+Added ability to rename Network in Meraki and Datacenter in DNA Center integrations using location_map.

--- a/changes/593.fixed
+++ b/changes/593.fixed
@@ -1,0 +1,1 @@
+Fixed Meraki loading of Nautobot Prefixes that have multiple Locations assigned.

--- a/changes/593.fixed
+++ b/changes/593.fixed
@@ -1,1 +1,2 @@
 Fixed Meraki loading of Nautobot Prefixes that have multiple Locations assigned.
+Fixed DNA Center loading incorrect location names for Devices.

--- a/changes/593.fixed
+++ b/changes/593.fixed
@@ -1,2 +1,3 @@
 Fixed Meraki loading of Nautobot Prefixes that have multiple Locations assigned.
 Fixed DNA Center loading incorrect location names for Devices.
+Fixed KeyError being thrown when port is missing from uplink_settings dict in Meraki integration.

--- a/changes/593.fixed
+++ b/changes/593.fixed
@@ -1,3 +1,4 @@
 Fixed Meraki loading of Nautobot Prefixes that have multiple Locations assigned.
 Fixed DNA Center loading incorrect location names for Devices.
 Fixed KeyError being thrown when port is missing from uplink_settings dict in Meraki integration.
+Fixed error in Bootstrap integration in loading ValidatedSoftwareLCM when SoftwareLCM doesn't exist.

--- a/changes/593.fixed
+++ b/changes/593.fixed
@@ -2,3 +2,4 @@ Fixed Meraki loading of Nautobot Prefixes that have multiple Locations assigned.
 Fixed DNA Center loading incorrect location names for Devices.
 Fixed KeyError being thrown when port is missing from uplink_settings dict in Meraki integration.
 Fixed error in Bootstrap integration in loading ValidatedSoftwareLCM when SoftwareLCM doesn't exist.
+Fixed DoesNotExist thrown when attempting to load ContentType that doesn't exist in Bootstrap integration.

--- a/changes/593.housekeeping
+++ b/changes/593.housekeeping
@@ -1,0 +1,1 @@
+Add code owners for DNA Center, Meraki, and Itential integrations.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -1266,7 +1266,7 @@ class NautobotAdapter(Adapter):
                     if nb_validated_software.custom_field_data["system_of_record"] is not None
                     else ""
                 )
-            if getattr(nb_validated_software.software, "device_platform"):
+            if hasattr(nb_validated_software.software, "device_platform"):
                 platform = nb_validated_software.software.device_platform.name
             else:
                 platform = nb_validated_software.software.platform.name

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -95,15 +95,6 @@ except (ImportError, RuntimeError):
 
 try:
     # noqa: F401
-    from nautobot.dcim.models import SoftwareVersion as ORMSoftware
-
-    SOFTWARE_VERSION_FOUND = True
-except (ImportError, RuntimeError):
-    SOFTWARE_VERSION_FOUND = False
-
-
-try:
-    # noqa: F401
     from nautobot_device_lifecycle_mgmt.models import (
         SoftwareImageLCM as ORMSoftwareImage,
     )
@@ -1261,59 +1252,44 @@ class NautobotAdapter(Adapter):
         for nb_validated_software in ORMValidatedSoftware.objects.all():
             if self.job.debug:
                 self.job.logger.debug(f"Loading Nautobot ValidatedSoftwareLCM {nb_validated_software}")
-            try:
-                _software = ORMSoftware.objects.get(
-                    version=nb_validated_software.software.version,
-                    device_platform=nb_validated_software.software.device_platform.id,
-                )
-                self.get(
-                    self.validated_software,
-                    {
-                        "software": {nb_validated_software.software},
-                        "valid_since": {nb_validated_software.start},
-                        "valid_until": {nb_validated_software.end},
-                    },
-                )
-            except ObjectNotFound:
-                _val_software = ORMValidatedSoftware.objects.get(
-                    software=_software,
-                    start=nb_validated_software.start,
-                    end=nb_validated_software.end,
-                )
-                _tags = sorted(list(_val_software.tags.all().values_list("name", flat=True)))
-                _devices = sorted(list(_val_software.devices.all().values_list("name", flat=True)))
-                _device_types = sorted(list(_val_software.device_types.all().values_list("model", flat=True)))
-                _device_roles = sorted(list(_val_software.device_roles.all().values_list("name", flat=True)))
-                _inventory_items = sorted(list(_val_software.inventory_items.all().values_list("name", flat=True)))
-                _object_tags = sorted(list(_val_software.object_tags.all().values_list("name", flat=True)))
-                _sor = ""
-                if "system_of_record" in nb_validated_software.custom_field_data:
-                    _sor = (
-                        nb_validated_software.custom_field_data["system_of_record"]
-                        if nb_validated_software.custom_field_data["system_of_record"] is not None
-                        else ""
-                    )
-                new_validated_software = self.validated_software(
-                    software=f"{nb_validated_software.software.device_platform} - {nb_validated_software.software.version}",
-                    software_version=nb_validated_software.software.version,
-                    platform=nb_validated_software.software.device_platform.name,
-                    valid_since=nb_validated_software.start,
-                    valid_until=nb_validated_software.end,
-                    preferred_version=nb_validated_software.preferred,
-                    devices=_devices,
-                    device_types=_device_types,
-                    device_roles=_device_roles,
-                    inventory_items=_inventory_items,
-                    object_tags=_object_tags,
-                    tags=_tags,
-                    system_of_record=_sor,
-                    uuid=nb_validated_software.id,
-                )
 
-                if not check_sor_field(nb_validated_software):
-                    new_validated_software.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
+            _tags = sorted(list(nb_validated_software.tags.all().values_list("name", flat=True)))
+            _devices = sorted(list(nb_validated_software.devices.all().values_list("name", flat=True)))
+            _device_types = sorted(list(nb_validated_software.device_types.all().values_list("model", flat=True)))
+            _device_roles = sorted(list(nb_validated_software.device_roles.all().values_list("name", flat=True)))
+            _inventory_items = sorted(list(nb_validated_software.inventory_items.all().values_list("name", flat=True)))
+            _object_tags = sorted(list(nb_validated_software.object_tags.all().values_list("name", flat=True)))
+            _sor = ""
+            if "system_of_record" in nb_validated_software.custom_field_data:
+                _sor = (
+                    nb_validated_software.custom_field_data["system_of_record"]
+                    if nb_validated_software.custom_field_data["system_of_record"] is not None
+                    else ""
+                )
+            new_validated_software, _ = self.get_or_instantiate(
+                self.validated_software,
+                ids={
+                    "software": {nb_validated_software.software},
+                    "valid_since": {nb_validated_software.start},
+                    "valid_until": {nb_validated_software.end},
+                },
+                attrs={
+                    "software_version": nb_validated_software.software.version,
+                    "platform": nb_validated_software.software.device_platform.name,
+                    "preferred_version": nb_validated_software.preferred,
+                    "devices": _devices,
+                    "device_types": _device_types,
+                    "device_roles": _device_roles,
+                    "inventory_items": _inventory_items,
+                    "object_tags": _object_tags,
+                    "tags": _tags,
+                    "system_of_record": _sor,
+                    "uuid": nb_validated_software.id,
+                },
+            )
 
-                self.add(new_validated_software)
+            if not check_sor_field(nb_validated_software):
+                new_validated_software.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
 
     def load(self):
         """Load data from Nautobot into DiffSync models."""
@@ -1377,6 +1353,6 @@ class NautobotAdapter(Adapter):
         if SOFTWARE_IMAGE_LIFECYCLE_MGMT:
             if settings.PLUGINS_CONFIG["nautobot_ssot"]["bootstrap_models_to_sync"]["software_image"]:
                 self.load_software_image()
-        if VALID_SOFTWARE_LIFECYCLE_MGMT and (SOFTWARE_LIFECYCLE_MGMT or SOFTWARE_VERSION_FOUND):
+        if VALID_SOFTWARE_LIFECYCLE_MGMT:
             if settings.PLUGINS_CONFIG["nautobot_ssot"]["bootstrap_models_to_sync"]["validated_software"]:
                 self.load_validated_software()

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -1273,9 +1273,9 @@ class NautobotAdapter(Adapter):
             new_validated_software, _ = self.get_or_instantiate(
                 self.validated_software,
                 ids={
-                    "software": {nb_validated_software.software},
-                    "valid_since": {nb_validated_software.start},
-                    "valid_until": {nb_validated_software.end},
+                    "software": str(nb_validated_software.software),
+                    "valid_since": nb_validated_software.start,
+                    "valid_until": nb_validated_software.end,
                 },
                 attrs={
                     "software_version": nb_validated_software.software.version,

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -95,6 +95,15 @@ except (ImportError, RuntimeError):
 
 try:
     # noqa: F401
+    from nautobot.dcim.models import SoftwareVersion as ORMSoftware
+
+    SOFTWARE_VERSION_FOUND = True
+except (ImportError, RuntimeError):
+    SOFTWARE_VERSION_FOUND = False
+
+
+try:
+    # noqa: F401
     from nautobot_device_lifecycle_mgmt.models import (
         SoftwareImageLCM as ORMSoftwareImage,
     )
@@ -1368,6 +1377,6 @@ class NautobotAdapter(Adapter):
         if SOFTWARE_IMAGE_LIFECYCLE_MGMT:
             if settings.PLUGINS_CONFIG["nautobot_ssot"]["bootstrap_models_to_sync"]["software_image"]:
                 self.load_software_image()
-        if VALID_SOFTWARE_LIFECYCLE_MGMT:
+        if VALID_SOFTWARE_LIFECYCLE_MGMT and (SOFTWARE_LIFECYCLE_MGMT or SOFTWARE_VERSION_FOUND):
             if settings.PLUGINS_CONFIG["nautobot_ssot"]["bootstrap_models_to_sync"]["validated_software"]:
                 self.load_validated_software()

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -1266,6 +1266,10 @@ class NautobotAdapter(Adapter):
                     if nb_validated_software.custom_field_data["system_of_record"] is not None
                     else ""
                 )
+            if getattr(nb_validated_software.software, "device_platform"):
+                platform = nb_validated_software.software.device_platform.name
+            else:
+                platform = nb_validated_software.software.platform.name
             new_validated_software, _ = self.get_or_instantiate(
                 self.validated_software,
                 ids={
@@ -1275,7 +1279,7 @@ class NautobotAdapter(Adapter):
                 },
                 attrs={
                     "software_version": nb_validated_software.software.version,
-                    "platform": nb_validated_software.software.device_platform.name,
+                    "platform": platform,
                     "preferred_version": nb_validated_software.preferred,
                     "devices": _devices,
                     "device_types": _device_types,

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -236,7 +236,10 @@ class NautobotRole(Role):
         _content_types = []
         adapter.job.logger.info(f'Creating Nautobot Role: {ids["name"]}')
         for _model in attrs["content_types"]:
-            _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            try:
+                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            except ContentType.DoesNotExist:
+                adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
         _new_role = ORMRole(
             name=ids["name"],
             weight=attrs["weight"],
@@ -264,7 +267,10 @@ class NautobotRole(Role):
         if "content_types" in attrs:
             for _model in attrs["content_types"]:
                 self.adapter.job.logger.debug(f"Looking up {_model} in content types.")
-                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                try:
+                    _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                except ContentType.DoesNotExist:
+                    self.adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
             _update_role.content_types.set(_content_types)
         if not check_sor_field(_update_role):
             _update_role.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
@@ -394,7 +400,10 @@ class NautobotLocationType(LocationType):
         adapter.job.logger.info(f'Creating Nautobot LocationType: {ids["name"]}')
         _parent = None
         for _model in attrs["content_types"]:
-            _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            try:
+                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            except ContentType.DoesNotExist:
+                adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
         if "parent" in attrs:
             try:
                 _parent = ORMLocationType.objects.get(name=attrs["parent"])
@@ -411,7 +420,10 @@ class NautobotLocationType(LocationType):
         _new_location_type.validated_save()
         for _model in attrs["content_types"]:
             adapter.job.logger.debug(f"Looking up {_model} in content types.")
-            _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            try:
+                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            except ContentType.DoesNotExist:
+                adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
         _new_location_type.content_types.set(_content_types)
         _new_location_type.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
         _new_location_type.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
@@ -438,7 +450,10 @@ class NautobotLocationType(LocationType):
         if "content_types" in attrs:
             for _model in attrs["content_types"]:
                 self.adapter.job.logger.debug(f"Looking up {_model} in content types.")
-                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                try:
+                    _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                except ContentType.DoesNotExist:
+                    self.adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
             _update_location_type.content_types.set(_content_types)
         if not check_sor_field(_update_location_type):
             _update_location_type.custom_field_data.update(
@@ -2106,7 +2121,10 @@ class NautobotTag(Tag):
         adapter.job.logger.info(f'Creating Nautobot Tag: {ids["name"]}')
         for _model in attrs["content_types"]:
             adapter.job.logger.debug(f"Looking up {_model} in content types.")
-            _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            try:
+                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+            except ContentType.DoesNotExist:
+                adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
         _new_tag = ORMTag(
             name=ids["name"],
             color=attrs["color"],
@@ -2129,7 +2147,10 @@ class NautobotTag(Tag):
             _content_types = []
             for _model in attrs["content_types"]:
                 self.adapter.job.logger.debug(f"Looking up {_model} in content types.")
-                _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                try:
+                    _content_types.append(lookup_content_type_for_taggable_model_path(_model))
+                except ContentType.DoesNotExist:
+                    self.adapter.job.logger.error(f"Unable to find ContentType for {_model}.")
             _update_tag.content_types.set(_content_types)
         if attrs.get("description"):
             _update_tag.description = attrs["description"]

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2414,7 +2414,7 @@ class NautobotValidatedSoftware(ValidatedSoftware):
             _software = ORMSoftwareVersion.objects.get(version=attrs["software_version"], platform=_platform)
         else:
             adapter.job.logger.error(
-                f"Model to represent Software version not found so skipping creation of ValidatedSoftware for {self.software}."
+                f"Model to represent Software version not found so skipping creation of ValidatedSoftware {attrs['software_version']} for {attrs['platform']}."
             )
             return None
         _new_validated_software = ORMValidatedSoftware(

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -95,6 +95,8 @@ try:
         SoftwareVersion as ORMSoftwareVersion,
     )
 
+    from nautobot_ssot.integrations.bootstrap.diffsync.models.base import Software
+
     SOFTWARE_VERSION_FOUND = True
 except (ImportError, RuntimeError):
     SOFTWARE_VERSION_FOUND = False
@@ -2214,336 +2216,346 @@ class NautobotGraphQLQuery(GraphQLQuery):
             self.adapter.job.logger.warning(f"Unable to find GraphQLQuery {self.name} for deletion. {err}")
 
 
-class NautobotSoftware(Software):
-    """Nautobot implementation of Bootstrap Software model."""
+if SOFTWARE_LIFECYCLE_MGMT or SOFTWARE_VERSION_FOUND:
 
-    @classmethod
-    def create(cls, adapter, ids, attrs):
-        """Create Software in Nautobot from NautobotSoftware object."""
-        _tags = []
-        for tag in attrs["tags"]:
-            _tags.append(ORMTag.objects.get(name=tag))
-        _platform = ORMPlatform.objects.get(name=ids["platform"])
-        if SOFTWARE_LIFECYCLE_MGMT:
-            _new_software = ORMSoftware(
-                version=ids["version"],
-                alias=attrs["alias"],
-                device_platform=_platform,
-                end_of_support=attrs["eos_date"],
-                long_term_support=attrs["long_term_support"],
-                pre_release=attrs["pre_release"],
-                documentation_url=attrs["documentation_url"],
-            )
-        elif SOFTWARE_VERSION_FOUND:
-            _new_software = ORMSoftwareVersion(
-                version=ids["version"],
-                alias=attrs["alias"],
-                platform=_platform,
-                end_of_support_date=attrs["eos_date"],
-                long_term_support=attrs["long_term_support"],
-                pre_release=attrs["pre_release"],
-                documentation_url=attrs["documentation_url"],
-            )
-        else:
-            adapter.job.logger.error(
-                f"Software model not found so skipping creation of {ids['version']} for {ids['platform']}."
-            )
-            return None
-        adapter.job.logger.info(f'Creating Nautobot Software object {ids["platform"]} - {ids["version"]}.')
-        if attrs.get("tags"):
-            _new_software.validated_save()
-            _new_software.tags.clear()
-            for tag in attrs["tags"]:
-                _new_software.tags.add(ORMTag.objects.get(name=tag))
-        _new_software.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
-        _new_software.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
-        _new_software.validated_save()
-        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+    class NautobotSoftware(Software):
+        """Nautobot implementation of Bootstrap Software model."""
 
-    def update(self, attrs):
-        """Update Software in Nautobot from NautobotSoftware object."""
-        _platform = ORMPlatform.objects.get(name=self.platform)
-        if SOFTWARE_IMAGE_LIFECYCLE_MGMT:
-            _update_software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
-        elif SOFTWARE_VERSION_FOUND:
-            _update_software = ORMSoftwareVersion.objects.get(version=self.version, platform=_platform)
-        else:
-            self.adapter.job.logger.error(f"Software model not found so skipping update of {self}.")
-            return None
-        self.adapter.job.logger.info(f"Updating Software: {self.platform} - {self.version}.")
-        if "alias" in attrs:
-            _update_software.alias = attrs["alias"]
-        if attrs.get("release_date"):
-            _update_software.release_date = attrs["release_date"]
-        if attrs.get("eos_date"):
-            _update_software.end_of_support = attrs["eos_date"]
-        if attrs.get("long_term_support"):
-            _update_software.long_term_support = attrs["long_term_support"]
-        if attrs.get("pre_release"):
-            _update_software.pre_release = attrs["pre_release"]
-        if attrs.get("documentation_url"):
-            _update_software.documentation_url = attrs["documentation_url"]
-        if not attrs.get("documentation_url"):
-            if attrs.get("documentation_url") == "":
-                _update_software.documentation_url = ""
-        if attrs.get("tags"):
-            _update_software.tags.clear()
-            for tag in attrs["tags"]:
-                _update_software.tags.add(ORMTag.objects.get(name=tag))
-        if not check_sor_field(_update_software):
-            _update_software.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
-        _update_software.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
-        _update_software.validated_save()
-        return super().update(attrs)
-
-    def delete(self):
-        """Delete Software in Nautobot from NautobotSoftware object."""
-        try:
-            _platform = ORMPlatform.objects.get(name=self.platform)
-            _software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
-            super().delete()
-            _software.delete()
-            return self
-        except ORMSoftware.DoesNotExist as err:
-            self.adapter.job.logger.warning(
-                f"Unable to find Software {self.platform} - {self.version} for deletion. {err}"
-            )
-
-
-class NautobotSoftwareImage(SoftwareImage):
-    """Nautobot implementation of Bootstrap SoftwareImage model."""
-
-    @classmethod
-    def create(cls, adapter, ids, attrs):
-        """Create SoftwareImage in Nautobot from NautobotSoftwareImage object."""
-        if not SOFTWARE_IMAGE_LIFECYCLE_MGMT:
-            adapter.job.logger.error(
-                f"SoftwareImageLCM model not found so skipping creation of {attrs['software_version']} for {attrs['platform']}."
-            )
-            return None
-        _tags = []
-        if attrs["tags"] is not None:
+        @classmethod
+        def create(cls, adapter, ids, attrs):
+            """Create Software in Nautobot from NautobotSoftware object."""
+            _tags = []
             for tag in attrs["tags"]:
                 _tags.append(ORMTag.objects.get(name=tag))
-        _platform = ORMPlatform.objects.get(name=attrs["platform"])
-        _software = ORMSoftware.objects.get(version=attrs["software_version"], device_platform=_platform)
-        _new_soft_image = ORMSoftwareImage(
-            software=_software,
-            image_file_name=attrs["file_name"],
-            image_file_checksum=attrs["image_file_checksum"],
-            hashing_algorithm=attrs["hashing_algorithm"],
-            download_url=attrs["download_url"],
-            default_image=attrs["default_image"],
-        )
-        if attrs.get("tags"):
-            _new_soft_image.validated_save()
-            _new_soft_image.tags.clear()
-            for tag in attrs["tags"]:
-                _new_soft_image.tags.add(ORMTag.objects.get(name=tag))
-        _new_soft_image.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
-        _new_soft_image.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
-        _new_soft_image.validated_save()
-        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+            _platform = ORMPlatform.objects.get(name=ids["platform"])
+            if SOFTWARE_LIFECYCLE_MGMT:
+                _new_software = ORMSoftware(
+                    version=ids["version"],
+                    alias=attrs["alias"],
+                    device_platform=_platform,
+                    end_of_support=attrs["eos_date"],
+                    long_term_support=attrs["long_term_support"],
+                    pre_release=attrs["pre_release"],
+                    documentation_url=attrs["documentation_url"],
+                )
+            elif SOFTWARE_VERSION_FOUND:
+                _new_software = ORMSoftwareVersion(
+                    version=ids["version"],
+                    alias=attrs["alias"],
+                    platform=_platform,
+                    end_of_support_date=attrs["eos_date"],
+                    long_term_support=attrs["long_term_support"],
+                    pre_release=attrs["pre_release"],
+                    documentation_url=attrs["documentation_url"],
+                )
+            else:
+                adapter.job.logger.error(
+                    f"Software model not found so skipping creation of {ids['version']} for {ids['platform']}."
+                )
+                return None
+            adapter.job.logger.info(f'Creating Nautobot Software object {ids["platform"]} - {ids["version"]}.')
+            if attrs.get("tags"):
+                _new_software.validated_save()
+                _new_software.tags.clear()
+                for tag in attrs["tags"]:
+                    _new_software.tags.add(ORMTag.objects.get(name=tag))
+            _new_software.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
+            _new_software.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
+            _new_software.validated_save()
+            return super().create(adapter=adapter, ids=ids, attrs=attrs)
 
-    def update(self, attrs):
-        """Update SoftwareImage in Nautobot from NautobotSoftwareImage object."""
-        if not SOFTWARE_IMAGE_LIFECYCLE_MGMT:
-            self.adapter.job.logger.error(
-                f"SoftwareImageLCM model not found so skipping update of {self.software_version} for {self.platform}."
-            )
-            return None
-        self.adapter.job.logger.info(f"Updating Software Image: {self.platform} - {self.software_version}.")
-        _platform = ORMPlatform.objects.get(name=self.platform)
-        _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
-        _update_soft_image = ORMSoftwareImage.objects.get(software=_software)
-        if attrs.get("platform"):
-            _update_soft_image.platform = _platform
-        if attrs.get("software_version"):
-            _update_soft_image.software_version = attrs["software_version"]
-        if attrs.get("file_name"):
-            _update_soft_image.image_file_name = attrs["file_name"]
-        if attrs.get("image_file_checksum"):
-            _update_soft_image.image_file_checksum = attrs["image_file_checksum"]
-        if attrs.get("hashing_algorithm"):
-            _update_soft_image.hashing_algorithm = attrs["hashing_algorithm"]
-        if attrs.get("download_url"):
-            _update_soft_image.download_url = attrs["download_url"]
-        if attrs.get("default_image"):
-            _update_soft_image.default_image = attrs["default_image"]
-        if attrs.get("tags"):
-            _update_soft_image.tags.clear()
+        def update(self, attrs):
+            """Update Software in Nautobot from NautobotSoftware object."""
+            _platform = ORMPlatform.objects.get(name=self.platform)
+            if SOFTWARE_IMAGE_LIFECYCLE_MGMT:
+                _update_software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
+            elif SOFTWARE_VERSION_FOUND:
+                _update_software = ORMSoftwareVersion.objects.get(version=self.version, platform=_platform)
+            else:
+                self.adapter.job.logger.error(f"Software model not found so skipping update of {self}.")
+                return None
+            self.adapter.job.logger.info(f"Updating Software: {self.platform} - {self.version}.")
+            if "alias" in attrs:
+                _update_software.alias = attrs["alias"]
+            if attrs.get("release_date"):
+                _update_software.release_date = attrs["release_date"]
+            if attrs.get("eos_date"):
+                _update_software.end_of_support = attrs["eos_date"]
+            if attrs.get("long_term_support"):
+                _update_software.long_term_support = attrs["long_term_support"]
+            if attrs.get("pre_release"):
+                _update_software.pre_release = attrs["pre_release"]
+            if attrs.get("documentation_url"):
+                _update_software.documentation_url = attrs["documentation_url"]
+            if not attrs.get("documentation_url"):
+                if attrs.get("documentation_url") == "":
+                    _update_software.documentation_url = ""
+            if attrs.get("tags"):
+                _update_software.tags.clear()
+                for tag in attrs["tags"]:
+                    _update_software.tags.add(ORMTag.objects.get(name=tag))
+            if not check_sor_field(_update_software):
+                _update_software.custom_field_data.update(
+                    {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
+                )
+            _update_software.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
+            _update_software.validated_save()
+            return super().update(attrs)
+
+        def delete(self):
+            """Delete Software in Nautobot from NautobotSoftware object."""
+            try:
+                _platform = ORMPlatform.objects.get(name=self.platform)
+                _software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
+                super().delete()
+                _software.delete()
+                return self
+            except ORMSoftware.DoesNotExist as err:
+                self.adapter.job.logger.warning(
+                    f"Unable to find Software {self.platform} - {self.version} for deletion. {err}"
+                )
+
+
+if SOFTWARE_IMAGE_LIFECYCLE_MGMT:
+
+    class NautobotSoftwareImage(SoftwareImage):
+        """Nautobot implementation of Bootstrap SoftwareImage model."""
+
+        @classmethod
+        def create(cls, adapter, ids, attrs):
+            """Create SoftwareImage in Nautobot from NautobotSoftwareImage object."""
+            if not SOFTWARE_IMAGE_LIFECYCLE_MGMT:
+                adapter.job.logger.error(
+                    f"SoftwareImageLCM model not found so skipping creation of {attrs['software_version']} for {attrs['platform']}."
+                )
+                return None
+            _tags = []
             if attrs["tags"] is not None:
                 for tag in attrs["tags"]:
-                    _update_soft_image.tags.add(ORMTag.objects.get(name=tag))
-        if not check_sor_field(_update_soft_image):
-            _update_soft_image.custom_field_data.update(
-                {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
-            )
-        _update_soft_image.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
-        _update_soft_image.validated_save()
-        return super().update(attrs)
-
-    def delete(self):
-        """Delete SoftwareImage in Nautobot from NautobotSoftwareImage object."""
-        try:
-            _platform = ORMPlatform.objects.get(name=self.platform)
-            _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
-            _soft_image = ORMSoftwareImage.objects.get(software=_software)
-            super().delete()
-            _soft_image.delete()
-            return self
-        except ORMSoftwareImage.DoesNotExist as err:
-            self.adapter.job.logger.warning(f"Unable to find SoftwareImage {self.software} for deletion. {err}")
-
-
-class NautobotValidatedSoftware(ValidatedSoftware):
-    """Nautobot implementation of Bootstrap ValidatedSoftware model."""
-
-    @classmethod
-    def create(cls, adapter, ids, attrs):
-        """Create ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
-        _devices = []  # noqa: F841
-        _device_types = []  # noqa: F841
-        _device_roles = []  # noqa: F841
-        _inventory_items = []  # noqa: F841
-        _object_tags = []  # noqa: F841
-        _platform = ORMPlatform.objects.get(name=attrs["platform"])
-        if SOFTWARE_LIFECYCLE_MGMT:
+                    _tags.append(ORMTag.objects.get(name=tag))
+            _platform = ORMPlatform.objects.get(name=attrs["platform"])
             _software = ORMSoftware.objects.get(version=attrs["software_version"], device_platform=_platform)
-        elif SOFTWARE_VERSION_FOUND:
-            _software = ORMSoftwareVersion.objects.get(version=attrs["software_version"], platform=_platform)
-        else:
-            adapter.job.logger.error(
-                f"Model to represent Software version not found so skipping creation of ValidatedSoftware {attrs['software_version']} for {attrs['platform']}."
+            _new_soft_image = ORMSoftwareImage(
+                software=_software,
+                image_file_name=attrs["file_name"],
+                image_file_checksum=attrs["image_file_checksum"],
+                hashing_algorithm=attrs["hashing_algorithm"],
+                download_url=attrs["download_url"],
+                default_image=attrs["default_image"],
             )
-            return None
-        _new_validated_software = ORMValidatedSoftware(
-            software=_software,
-            start=ids["valid_since"] if not None else datetime.today().date(),
-            end=ids["valid_until"],
-            preferred=attrs["preferred_version"],
-        )
-        _new_validated_software.custom_field_data.update(
-            {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
-        )
-        _new_validated_software.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
-        _new_validated_software.validated_save()
-        if "devices" in attrs:
-            if attrs["devices"]:
-                for _dev in attrs["devices"]:
-                    _devices.append(ORMDevice.objects.get(name=_dev))
-                _new_validated_software.devices.set(_devices)
-        if "device_types" in attrs:
-            if attrs["device_types"]:
-                for _dev_type in attrs["device_types"]:
-                    _device_types.append(ORMDeviceType.objects.get(model=_dev_type))
-                _new_validated_software.device_types.set(_device_types)
-        if "device_roles" in attrs:
-            if attrs["device_roles"]:
-                for _dev_role in attrs["device_roles"]:
-                    _device_roles.append(ORMRole.objects.get(name=_dev_role))
-                _new_validated_software.device_roles.set(_device_roles)
-        if "inventory_items" in attrs:
-            if attrs["inventory_items"]:
-                for _inv_item in attrs["inventory_items"]:
-                    _inventory_items.append(ORMInventoryItem.objects.get(name=_inv_item))
-                _new_validated_software.inventory_items.set(_inventory_items)
-        if "object_tags" in attrs:
-            if attrs["object_tags"]:
-                for _obj_tag in attrs["object_tags"]:
-                    _object_tags.append(ORMTag.objects.get(name=_obj_tag))
-                _new_validated_software.object_tags.set(_object_tags)
-        if "tags" in attrs:
-            if attrs["tags"] is not None:
-                for _tag in attrs["tags"]:
-                    _new_validated_software.tags.add(ORMTag.objects.get(name=_tag))
-        _new_validated_software.validated_save()
-        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+            if attrs.get("tags"):
+                _new_soft_image.validated_save()
+                _new_soft_image.tags.clear()
+                for tag in attrs["tags"]:
+                    _new_soft_image.tags.add(ORMTag.objects.get(name=tag))
+            _new_soft_image.custom_field_data.update({"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")})
+            _new_soft_image.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
+            _new_soft_image.validated_save()
+            return super().create(adapter=adapter, ids=ids, attrs=attrs)
 
-    def update(self, attrs):
-        """Update ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
-        _tags = []  # noqa: F841
-        _devices = []  # noqa: F841
-        _device_types = []  # noqa: F841
-        _device_roles = []  # noqa: F841
-        _inventory_items = []  # noqa: F841
-        _object_tags = []  # noqa: F841
-        _platform = ORMPlatform.objects.get(name=self.platform)
-        if SOFTWARE_LIFECYCLE_MGMT:
-            _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
-        elif SOFTWARE_VERSION_FOUND:
-            _software = ORMSoftwareVersion.objects.get(version=self.software_version, platform=_platform)
-        else:
-            self.adapter.job.logger.error(
-                f"Model to represent Software version not found so skipping update of ValidatedSoftware for {self.software}."
-            )
-            return None
-        self.adapter.job.logger.info(f"Updating Validated Software - {self} with attrs {attrs}.")
-        _update_validated_software = ORMValidatedSoftware.objects.get(
-            software=_software, start=self.valid_since, end=self.valid_until
-        )
-        if attrs.get("preferred_version"):
-            _update_validated_software.preferred_version = attrs["preferred_version"]
-        if "tags" in attrs:
-            _update_validated_software.tags.clear()
-            if attrs["tags"] is not None:
-                for _tag in attrs["tags"]:
-                    _update_validated_software.tags.add(ORMTag.objects.get(name=_tag))
-        if "devices" in attrs:
-            # FIXME: There might be a better way to handle this that's easier on the database.
-            _update_validated_software.devices.clear()
-            if attrs["devices"]:
-                for _dev in attrs["devices"]:
-                    _devices.append(ORMDevice.objects.get(name=_dev))
-                _update_validated_software.devices.set(_devices)
-        if "device_types" in attrs:
-            # FIXME: There might be a better way to handle this that's easier on the database.
-            _update_validated_software.device_types.clear()
-            if attrs["device_types"]:
-                for _dev_type in attrs["device_types"]:
-                    _device_types.append(ORMDeviceType.objects.get(model=_dev_type))
-                _update_validated_software.device_types.set(_device_types)
-        if "device_roles" in attrs:
-            # FIXME: There might be a better way to handle this that's easier on the database.
-            _update_validated_software.device_roles.clear()
-            if attrs["device_roles"]:
-                for _dev_role in attrs["device_roles"]:
-                    _device_roles.append(ORMRole.objects.get(name=_dev_role))
-                _update_validated_software.device_roles.set(_device_roles)
-        if "inventory_items" in attrs:
-            # FIXME: There might be a better way to handle this that's easier on the database.
-            _update_validated_software.inventory_items.clear()
-            if attrs["inventory_items"]:
-                for _inv_item in attrs["inventory_items"]:
-                    _inventory_items.append(ORMInventoryItem.objects.get(name=_inv_item))
-                _update_validated_software.inventory_items.set(_inventory_items)
-        if "object_tags" in attrs:
-            # FIXME: There might be a better way to handle this that's easier on the database.
-            _update_validated_software.object_tags.clear()
-            if attrs["object_tags"]:
-                for _obj_tag in attrs["object_tags"]:
-                    _object_tags.append(ORMTag.objects.get(name=_obj_tag))
-                _update_validated_software.object_tags.set(_object_tags)
-        if not check_sor_field(_update_validated_software):
-            _update_validated_software.custom_field_data.update(
-                {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
-            )
-        _update_validated_software.custom_field_data.update(
-            {"last_synced_from_sor": datetime.today().date().isoformat()}
-        )
-        _update_validated_software.validated_save()
-        return super().update(attrs)
-
-    def delete(self):
-        """Delete ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
-        try:
+        def update(self, attrs):
+            """Update SoftwareImage in Nautobot from NautobotSoftwareImage object."""
+            if not SOFTWARE_IMAGE_LIFECYCLE_MGMT:
+                self.adapter.job.logger.error(
+                    f"SoftwareImageLCM model not found so skipping update of {self.software_version} for {self.platform}."
+                )
+                return None
+            self.adapter.job.logger.info(f"Updating Software Image: {self.platform} - {self.software_version}.")
             _platform = ORMPlatform.objects.get(name=self.platform)
             _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
-            _validated_software = ORMValidatedSoftware.objects.get(
+            _update_soft_image = ORMSoftwareImage.objects.get(software=_software)
+            if attrs.get("platform"):
+                _update_soft_image.platform = _platform
+            if attrs.get("software_version"):
+                _update_soft_image.software_version = attrs["software_version"]
+            if attrs.get("file_name"):
+                _update_soft_image.image_file_name = attrs["file_name"]
+            if attrs.get("image_file_checksum"):
+                _update_soft_image.image_file_checksum = attrs["image_file_checksum"]
+            if attrs.get("hashing_algorithm"):
+                _update_soft_image.hashing_algorithm = attrs["hashing_algorithm"]
+            if attrs.get("download_url"):
+                _update_soft_image.download_url = attrs["download_url"]
+            if attrs.get("default_image"):
+                _update_soft_image.default_image = attrs["default_image"]
+            if attrs.get("tags"):
+                _update_soft_image.tags.clear()
+                if attrs["tags"] is not None:
+                    for tag in attrs["tags"]:
+                        _update_soft_image.tags.add(ORMTag.objects.get(name=tag))
+            if not check_sor_field(_update_soft_image):
+                _update_soft_image.custom_field_data.update(
+                    {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
+                )
+            _update_soft_image.custom_field_data.update({"last_synced_from_sor": datetime.today().date().isoformat()})
+            _update_soft_image.validated_save()
+            return super().update(attrs)
+
+        def delete(self):
+            """Delete SoftwareImage in Nautobot from NautobotSoftwareImage object."""
+            try:
+                _platform = ORMPlatform.objects.get(name=self.platform)
+                _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
+                _soft_image = ORMSoftwareImage.objects.get(software=_software)
+                super().delete()
+                _soft_image.delete()
+                return self
+            except ORMSoftwareImage.DoesNotExist as err:
+                self.adapter.job.logger.warning(f"Unable to find SoftwareImage {self.software} for deletion. {err}")
+
+
+if VALID_SOFTWARE_LIFECYCLE_MGMT:
+
+    class NautobotValidatedSoftware(ValidatedSoftware):
+        """Nautobot implementation of Bootstrap ValidatedSoftware model."""
+
+        @classmethod
+        def create(cls, adapter, ids, attrs):
+            """Create ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
+            _devices = []  # noqa: F841
+            _device_types = []  # noqa: F841
+            _device_roles = []  # noqa: F841
+            _inventory_items = []  # noqa: F841
+            _object_tags = []  # noqa: F841
+            _platform = ORMPlatform.objects.get(name=attrs["platform"])
+            if SOFTWARE_LIFECYCLE_MGMT:
+                _software = ORMSoftware.objects.get(version=attrs["software_version"], device_platform=_platform)
+            elif SOFTWARE_VERSION_FOUND:
+                _software = ORMSoftwareVersion.objects.get(version=attrs["software_version"], platform=_platform)
+            else:
+                adapter.job.logger.error(
+                    f"Model to represent Software version not found so skipping creation of ValidatedSoftware {attrs['software_version']} for {attrs['platform']}."
+                )
+                return None
+            _new_validated_software = ORMValidatedSoftware(
+                software=_software,
+                start=ids["valid_since"] if not None else datetime.today().date(),
+                end=ids["valid_until"],
+                preferred=attrs["preferred_version"],
+            )
+            _new_validated_software.custom_field_data.update(
+                {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
+            )
+            _new_validated_software.custom_field_data.update(
+                {"last_synced_from_sor": datetime.today().date().isoformat()}
+            )
+            _new_validated_software.validated_save()
+            if "devices" in attrs:
+                if attrs["devices"]:
+                    for _dev in attrs["devices"]:
+                        _devices.append(ORMDevice.objects.get(name=_dev))
+                    _new_validated_software.devices.set(_devices)
+            if "device_types" in attrs:
+                if attrs["device_types"]:
+                    for _dev_type in attrs["device_types"]:
+                        _device_types.append(ORMDeviceType.objects.get(model=_dev_type))
+                    _new_validated_software.device_types.set(_device_types)
+            if "device_roles" in attrs:
+                if attrs["device_roles"]:
+                    for _dev_role in attrs["device_roles"]:
+                        _device_roles.append(ORMRole.objects.get(name=_dev_role))
+                    _new_validated_software.device_roles.set(_device_roles)
+            if "inventory_items" in attrs:
+                if attrs["inventory_items"]:
+                    for _inv_item in attrs["inventory_items"]:
+                        _inventory_items.append(ORMInventoryItem.objects.get(name=_inv_item))
+                    _new_validated_software.inventory_items.set(_inventory_items)
+            if "object_tags" in attrs:
+                if attrs["object_tags"]:
+                    for _obj_tag in attrs["object_tags"]:
+                        _object_tags.append(ORMTag.objects.get(name=_obj_tag))
+                    _new_validated_software.object_tags.set(_object_tags)
+            if "tags" in attrs:
+                if attrs["tags"] is not None:
+                    for _tag in attrs["tags"]:
+                        _new_validated_software.tags.add(ORMTag.objects.get(name=_tag))
+            _new_validated_software.validated_save()
+            return super().create(adapter=adapter, ids=ids, attrs=attrs)
+
+        def update(self, attrs):
+            """Update ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
+            _tags = []  # noqa: F841
+            _devices = []  # noqa: F841
+            _device_types = []  # noqa: F841
+            _device_roles = []  # noqa: F841
+            _inventory_items = []  # noqa: F841
+            _object_tags = []  # noqa: F841
+            _platform = ORMPlatform.objects.get(name=self.platform)
+            if SOFTWARE_LIFECYCLE_MGMT:
+                _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
+            elif SOFTWARE_VERSION_FOUND:
+                _software = ORMSoftwareVersion.objects.get(version=self.software_version, platform=_platform)
+            else:
+                self.adapter.job.logger.error(
+                    f"Model to represent Software version not found so skipping update of ValidatedSoftware for {self.software}."
+                )
+                return None
+            self.adapter.job.logger.info(f"Updating Validated Software - {self} with attrs {attrs}.")
+            _update_validated_software = ORMValidatedSoftware.objects.get(
                 software=_software, start=self.valid_since, end=self.valid_until
             )
-            super().delete()
-            _validated_software.delete()
-            return self
-        except ORMValidatedSoftware.DoesNotExist as err:
-            self.adapter.job.logger.warning(f"Unable to find ValidatedSoftware {self} for deletion. {err}")
+            if attrs.get("preferred_version"):
+                _update_validated_software.preferred_version = attrs["preferred_version"]
+            if "tags" in attrs:
+                _update_validated_software.tags.clear()
+                if attrs["tags"] is not None:
+                    for _tag in attrs["tags"]:
+                        _update_validated_software.tags.add(ORMTag.objects.get(name=_tag))
+            if "devices" in attrs:
+                # FIXME: There might be a better way to handle this that's easier on the database.
+                _update_validated_software.devices.clear()
+                if attrs["devices"]:
+                    for _dev in attrs["devices"]:
+                        _devices.append(ORMDevice.objects.get(name=_dev))
+                    _update_validated_software.devices.set(_devices)
+            if "device_types" in attrs:
+                # FIXME: There might be a better way to handle this that's easier on the database.
+                _update_validated_software.device_types.clear()
+                if attrs["device_types"]:
+                    for _dev_type in attrs["device_types"]:
+                        _device_types.append(ORMDeviceType.objects.get(model=_dev_type))
+                    _update_validated_software.device_types.set(_device_types)
+            if "device_roles" in attrs:
+                # FIXME: There might be a better way to handle this that's easier on the database.
+                _update_validated_software.device_roles.clear()
+                if attrs["device_roles"]:
+                    for _dev_role in attrs["device_roles"]:
+                        _device_roles.append(ORMRole.objects.get(name=_dev_role))
+                    _update_validated_software.device_roles.set(_device_roles)
+            if "inventory_items" in attrs:
+                # FIXME: There might be a better way to handle this that's easier on the database.
+                _update_validated_software.inventory_items.clear()
+                if attrs["inventory_items"]:
+                    for _inv_item in attrs["inventory_items"]:
+                        _inventory_items.append(ORMInventoryItem.objects.get(name=_inv_item))
+                    _update_validated_software.inventory_items.set(_inventory_items)
+            if "object_tags" in attrs:
+                # FIXME: There might be a better way to handle this that's easier on the database.
+                _update_validated_software.object_tags.clear()
+                if attrs["object_tags"]:
+                    for _obj_tag in attrs["object_tags"]:
+                        _object_tags.append(ORMTag.objects.get(name=_obj_tag))
+                    _update_validated_software.object_tags.set(_object_tags)
+            if not check_sor_field(_update_validated_software):
+                _update_validated_software.custom_field_data.update(
+                    {"system_of_record": os.getenv("SYSTEM_OF_RECORD", "Bootstrap")}
+                )
+            _update_validated_software.custom_field_data.update(
+                {"last_synced_from_sor": datetime.today().date().isoformat()}
+            )
+            _update_validated_software.validated_save()
+            return super().update(attrs)
+
+        def delete(self):
+            """Delete ValidatedSoftware in Nautobot from NautobotValidatedSoftware object."""
+            try:
+                _platform = ORMPlatform.objects.get(name=self.platform)
+                _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
+                _validated_software = ORMValidatedSoftware.objects.get(
+                    software=_software, start=self.valid_since, end=self.valid_until
+                )
+                super().delete()
+                _validated_software.delete()
+                return self
+            except ORMValidatedSoftware.DoesNotExist as err:
+                self.adapter.job.logger.warning(f"Unable to find ValidatedSoftware {self} for deletion. {err}")

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -63,7 +63,7 @@ class DnaCenterAdapter(Adapter):
         if locations:
             # to ensure we process locations in the appropriate order we need to split them into their own list of locations
             self.dnac_location_map = self.build_dnac_location_map(locations)
-            areas, buildings, floors = self.parse_and_sort_locations(locations)
+            _, buildings, floors = self.parse_and_sort_locations(locations)
             self.load_buildings(buildings)
             self.load_floors(floors)
         else:
@@ -172,6 +172,8 @@ class DnaCenterAdapter(Adapter):
                 _area = self.job.location_map[bldg_name]["parent"]
                 if "area_parent" in self.job.location_map[bldg_name]:
                     _area_parent = self.job.location_map[bldg_name]["area_parent"]
+                if "name" in self.job.location_map[bldg_name]:
+                    bldg_name = self.job.location_map[bldg_name]
             elif location["parentId"] in self.dnac_location_map:
                 _area = self.dnac_location_map[location["parentId"]]["name"]
                 _area_parent = self.dnac_location_map[location["parentId"]]["parent"]

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -222,8 +222,8 @@ class DnaCenterAdapter(Adapter):
                 self.job.logger.warning(f"Parent to {location['name']} can't be found so will be skipped.")
                 continue
             if bldg_name in self.job.location_map and "name" in self.job.location_map[bldg_name]:
-                bldg_name = self.job.location_map[bldg_name]["name"]
                 area_name = self.job.location_map[bldg_name]["parent"]
+                bldg_name = self.job.location_map[bldg_name]["name"]
             floor_name = f"{bldg_name} - {location['name']}"
             try:
                 parent = self.get(self.building, {"name": bldg_name, "area": area_name})

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -39,11 +39,11 @@ class DnaCenterAdapter(Adapter):
 
     top_level = ["area", "building", "device", "prefix", "ipaddress", "ip_on_intf"]
 
-    def __init__(self, *args, job=None, sync=None, client: DnaCenterClient, tenant: Tenant, **kwargs):
+    def __init__(self, *args, job, sync=None, client: DnaCenterClient, tenant: Tenant, **kwargs):
         """Initialize DNA Center.
 
         Args:
-            job (object, optional): DNA Center job. Defaults to None.
+            job (Union[DataSource, DataTarget]): DNA Center job.
             sync (object, optional): DNA Center DiffSync. Defaults to None.
             client (DnaCenterClient): DNA Center API client connection object.
             tenant (Tenant): Tenant to attach to imported objects. Can be set to None for no Tenant to be attached.

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -173,7 +173,7 @@ class DnaCenterAdapter(Adapter):
                 if "area_parent" in self.job.location_map[bldg_name]:
                     _area_parent = self.job.location_map[bldg_name]["area_parent"]
                 if "name" in self.job.location_map[bldg_name]:
-                    bldg_name = self.job.location_map[bldg_name]
+                    bldg_name = self.job.location_map[bldg_name]["name"]
             elif location["parentId"] in self.dnac_location_map:
                 _area = self.dnac_location_map[location["parentId"]]["name"]
                 _area_parent = self.dnac_location_map[location["parentId"]]["parent"]

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
@@ -184,14 +184,20 @@ class NautobotAdapter(Adapter):
                     pass
                 if dlm_version != version:
                     version = None
+            bldg_name, floor_name = None, None
+            if dev.location.location_type == self.job.floor_loctype:
+                floor_name = dev.location.name
+                bldg_name = dev.location.parent.name
+            if dev.location.location_type == self.job.building_loctype:
+                bldg_name = dev.location.name
             new_dev = self.device(
                 name=dev.name,
                 status=dev.status.name,
                 role=dev.role.name,
                 vendor=dev.device_type.manufacturer.name,
                 model=dev.device_type.model,
-                site=dev.location.parent.name if dev.location.parent else None,
-                floor=dev.location.name if dev.location else None,
+                site=bldg_name,
+                floor=floor_name,
                 serial=dev.serial,
                 version=version,
                 platform=dev.platform.network_driver if dev.platform else "",

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -54,10 +54,13 @@ class MerakiAdapter(Adapter):
     def load_networks(self):
         """Load networks from Meraki dashboard into DiffSync models."""
         for net in self.conn.get_org_networks():
+            network_name = net["name"]
             parent_name = None
             if self.job.network_loctype.parent:
                 if self.job.parent_location:
                     parent_name = self.job.parent_location.name
+                elif self.job.location_map and network_name in self.job.location_map:
+                    parent_name = self.job.location_map[network_name]["parent"]
                 elif self.job.location_map and net in self.job.location_map:
                     parent_name = self.job.location_map[net]["parent"]
                 else:
@@ -67,7 +70,7 @@ class MerakiAdapter(Adapter):
                     continue
             self.get_or_instantiate(
                 self.network,
-                ids={"name": net["name"], "parent": parent_name},
+                ids={"name": network_name, "parent": parent_name},
                 attrs={
                     "timezone": net["timeZone"],
                     "notes": net["notes"].rstrip() if net.get("notes") else "",

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -61,8 +61,8 @@ class MerakiAdapter(Adapter):
                     parent_name = self.job.parent_location.name
                 elif self.job.location_map and network_name in self.job.location_map:
                     parent_name = self.job.location_map[network_name]["parent"]
-                elif self.job.location_map and net in self.job.location_map:
-                    parent_name = self.job.location_map[net]["parent"]
+                    if "name" in self.job.location_map[network_name]:
+                        network_name = self.job.location_map[network_name]
                 else:
                     self.job.logger.error(
                         f"Parent Location is required for {self.job.network_loctype.name} but can't determine parent to be assigned to {net}."

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -162,42 +162,43 @@ class MerakiAdapter(Adapter):
                 for link in uplinks:
                     if link["interface"] == port and link["status"] == "active":
                         uplink_status = "Active"
-            port_uplink_settings = uplink_settings[port]
-            new_port, loaded = self.get_or_instantiate(
-                self.port,
-                ids={"name": port, "device": device.name},
-                attrs={
-                    "management": True,
-                    "enabled": port_uplink_settings["enabled"],
-                    "port_type": "1000base-t",
-                    "port_status": uplink_status,
-                    "tagging": port_uplink_settings["vlanTagging"]["enabled"],
-                    "uuid": None,
-                },
-            )
-            if loaded:
-                self.add(new_port)
-                device.add_child(new_port)
-                if port_uplink_settings["svis"]["ipv4"]["assignmentMode"] == "static":
-                    port_svis = port_uplink_settings["svis"]["ipv4"]
-                    prefix = ipaddress_interface(ip=port_svis["address"], attr="network.with_prefixlen")
-                    self.load_prefix(prefix=prefix)
-                    self.load_prefix_location(
-                        prefix=prefix,
-                        location=self.conn.network_map[network_id]["name"],
-                    )
-                    self.load_ipaddress(
-                        address=port_svis["address"],
-                        prefix=prefix,
-                    )
-                    self.load_ipassignment(
-                        address=port_svis["address"],
-                        dev_name=device.name,
-                        port=port,
-                        primary=bool(uplink_status == "Active" and not primary_found),
-                    )
-                if uplink_status == "Active":
-                    primary_found = True
+            if uplink_settings.get(port):
+                port_uplink_settings = uplink_settings[port]
+                new_port, loaded = self.get_or_instantiate(
+                    self.port,
+                    ids={"name": port, "device": device.name},
+                    attrs={
+                        "management": True,
+                        "enabled": port_uplink_settings["enabled"],
+                        "port_type": "1000base-t",
+                        "port_status": uplink_status,
+                        "tagging": port_uplink_settings["vlanTagging"]["enabled"],
+                        "uuid": None,
+                    },
+                )
+                if loaded:
+                    self.add(new_port)
+                    device.add_child(new_port)
+                    if port_uplink_settings["svis"]["ipv4"]["assignmentMode"] == "static":
+                        port_svis = port_uplink_settings["svis"]["ipv4"]
+                        prefix = ipaddress_interface(ip=port_svis["address"], attr="network.with_prefixlen")
+                        self.load_prefix(prefix=prefix)
+                        self.load_prefix_location(
+                            prefix=prefix,
+                            location=self.conn.network_map[network_id]["name"],
+                        )
+                        self.load_ipaddress(
+                            address=port_svis["address"],
+                            prefix=prefix,
+                        )
+                        self.load_ipassignment(
+                            address=port_svis["address"],
+                            dev_name=device.name,
+                            port=port,
+                            primary=bool(uplink_status == "Active" and not primary_found),
+                        )
+                    if uplink_status == "Active":
+                        primary_found = True
         if lan_ports:
             self.process_lan_ports(device, lan_ports)
 

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -203,7 +203,7 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     )
                     if loaded and self.tenant:
                         pf_loc.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
-            if getattr(prefix, "location"):
+            elif getattr(prefix, "location"):
                 pf_loc, loaded = self.get_or_instantiate(
                     self.prefixlocation,
                     ids={"prefix": str(prefix.prefix), "location": prefix.location.name},

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -19,7 +19,7 @@ from nautobot.dcim.models import (
     SoftwareVersion,
 )
 from nautobot.extras.models import Note, Role, Status
-from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix
+from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix, PrefixLocationAssignment
 from nautobot.tenancy.models import Tenant
 
 from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import (
@@ -303,10 +303,8 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             self.job.logger.info("Performing bulk create of Prefixes in Nautobot")
             Prefix.objects.bulk_create(self.objects_to_create["prefixes"], batch_size=250)
         if len(self.objects_to_create["prefix_locs"]) > 0:
-            self.job.logger.info("Performing assignment of Locations to Prefixes in Nautobot")
-            for pair in self.objects_to_create["prefix_locs"]:
-                update_pf = Prefix.objects.get(id=pair[0])
-                update_pf.locations.add(pair[1])
+            self.job.logger.info("Performing bulk create of PrefixLocationAssignments in Nautobot")
+            PrefixLocationAssignment.objects.bulk_create(self.objects_to_create["prefix_locs"], batch_size=250)
         if len(self.objects_to_create["ipaddrs"]) > 0:
             self.job.logger.info("Performing bulk create of IP Addresses in Nautobot")
             IPAddress.objects.bulk_create(self.objects_to_create["ipaddrs"], batch_size=250)

--- a/nautobot_ssot/integrations/meraki/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/base.py
@@ -103,13 +103,26 @@ class Prefix(DiffSyncModel):
 
     _modelname = "prefix"
     _identifiers = ("prefix", "namespace")
-    _attributes = ("location", "tenant")
+    _attributes = ("tenant",)
     _children = {}
 
     prefix: str
     namespace: str
-    location: str
     tenant: Optional[str] = None
+
+    uuid: Optional[UUID] = None
+
+
+class PrefixLocation(DiffSyncModel):
+    """DiffSync model for tracking Locations assigned to Prefixes in Meraki."""
+
+    _modelname = "prefixlocation"
+    _identifiers = ("prefix", "location")
+    _attributes = ()
+    _children = {}
+
+    prefix: str
+    location: str
 
     uuid: Optional[UUID] = None
 

--- a/nautobot_ssot/integrations/meraki/diffsync/models/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/meraki.py
@@ -10,6 +10,7 @@ from nautobot_ssot.integrations.meraki.diffsync.models.base import (
     OSVersion,
     Port,
     Prefix,
+    PrefixLocation,
 )
 
 
@@ -112,6 +113,23 @@ class MerakiPrefix(Prefix):
 
     def delete(self):
         """Delete Prefix in Meraki from MerakiPrefix object."""
+        return self
+
+
+class MerakiPrefixLocation(PrefixLocation):
+    """Meraki implementation of PrefixLocation DiffSync model."""
+
+    @classmethod
+    def create(cls, adapter, ids, attrs):
+        """Create PrefixLocation in Meraki from MerakiPrefixLocation object."""
+        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+
+    def update(self, attrs):
+        """Update PrefixLocation in Meraki from MerakiPrefixLocation object."""
+        return super().update(attrs)
+
+    def delete(self):
+        """Delete PrefixLocation in Meraki from MerakiPrefixLocation object."""
         return self
 
 

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -6,7 +6,7 @@ from nautobot.dcim.models import Device as NewDevice
 from nautobot.dcim.models import DeviceType, Interface, Location, SoftwareVersion
 from nautobot.extras.models import Note, Role
 from nautobot.ipam.models import IPAddress as OrmIPAddress
-from nautobot.ipam.models import IPAddressToInterface
+from nautobot.ipam.models import IPAddressToInterface, PrefixLocationAssignment
 from nautobot.ipam.models import Prefix as OrmPrefix
 
 from nautobot_ssot.integrations.meraki.diffsync.models.base import (
@@ -18,6 +18,7 @@ from nautobot_ssot.integrations.meraki.diffsync.models.base import (
     OSVersion,
     Port,
     Prefix,
+    PrefixLocation,
 )
 
 
@@ -261,7 +262,7 @@ class NautobotPort(Port):
 
 
 class NautobotPrefix(Prefix):
-    """Nautobot implementation of Meraki Port model."""
+    """Nautobot implementation of Meraki Prefix model."""
 
     @classmethod
     def create(cls, adapter, ids, attrs):
@@ -272,8 +273,6 @@ class NautobotPrefix(Prefix):
             status_id=adapter.status_map["Active"],
             tenant_id=adapter.tenant_map[attrs["tenant"]] if attrs.get("tenant") else None,
         )
-        if attrs.get("location"):
-            adapter.objects_to_create["prefix_locs"].append((new_pf.id, adapter.site_map[attrs["location"]]))
         new_pf.custom_field_data["system_of_record"] = "Meraki SSoT"
         new_pf.custom_field_data["last_synced_from_sor"] = datetime.today().date().isoformat()
         adapter.objects_to_create["prefixes"].append(new_pf)
@@ -283,11 +282,6 @@ class NautobotPrefix(Prefix):
     def update(self, attrs):
         """Update Prefix in Nautobot from NautobotPrefix object."""
         prefix = OrmPrefix.objects.get(id=self.uuid)
-        if "location" in attrs:
-            if attrs.get("location"):
-                prefix.locations.add(self.adapter.site_map[attrs["location"]])
-            else:
-                prefix.locations.remove(self.adapter.site_map[self.location])
         if "tenant" in attrs:
             if attrs.get("tenant"):
                 prefix.tenant_id = self.adapter.tenant_map[attrs["tenant"]]
@@ -303,6 +297,26 @@ class NautobotPrefix(Prefix):
         del_pf = OrmPrefix.objects.get(id=self.uuid)
         super().delete()
         self.adapter.objects_to_delete["prefixes"].append(del_pf)
+        return self
+
+
+class NautobotPrefixLocation(PrefixLocation):
+    """Nautobot implementation of Meraki PrefixLocation model."""
+
+    @classmethod
+    def create(cls, adapter, ids, attrs):
+        """Create PrefixLocationAssignment in Nautobot from NautobotPrefixLocation object."""
+        new_assignment = PrefixLocationAssignment(
+            prefix_id=adapter.prefix_map[ids["prefix"]], location_id=adapter.site_map[ids["location"]]
+        )
+        adapter.objects_to_create["prefix_locs"].append(new_assignment)
+        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+
+    def delete(self):
+        """Delete Prefix in Nautobot from NautobotPrefix object."""
+        del_pf = PrefixLocationAssignment.objects.get(id=self.uuid)
+        super().delete()
+        del_pf.delete()
         return self
 
 

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -307,7 +307,7 @@ class NautobotPrefixLocation(PrefixLocation):
     def create(cls, adapter, ids, attrs):
         """Create PrefixLocationAssignment in Nautobot from NautobotPrefixLocation object."""
         new_assignment = PrefixLocationAssignment(
-            prefix_id=adapter.prefix_map[ids["prefix"]], location_id=adapter.site_map[ids["location"]]
+            prefix_id=adapter.prefix_map[ids["prefix"]], location=adapter.site_map[ids["location"]]
         )
         adapter.objects_to_create["prefix_locs"].append(new_assignment)
         return super().create(adapter=adapter, ids=ids, attrs=attrs)

--- a/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
@@ -336,6 +336,8 @@ class TestDnaCenterAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
 
     def test_load_floors(self):
         """Test Nautobot SSoT for Cisco DNA Center load_floors() function."""
+        self.job.location_map = {}
+        self.dna_center.get = MagicMock()
         self.dna_center.load_floors(floors=EXPECTED_FLOORS)
         floor_expected = [
             "Building1 - Floor1__Building1",

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -44,18 +44,17 @@ class TestNautobotPrefix(TransactionTestCase):  # pylint: disable=too-many-insta
         self.adapter.tenant_map = {"Test": self.test_tenant.id, "Update": self.update_tenant.id}
         self.adapter.status_map = {"Active": self.status_active.id}
         self.adapter.prefix_map = {}
-        self.adapter.objects_to_create = {"prefixes": [], "prefix_locs": []}
+        self.adapter.objects_to_create = {"prefixes": []}
         self.adapter.objects_to_delete = {"prefixes": []}
 
     def test_create(self):
         """Validate the NautobotPrefix create() method creates a Prefix."""
         self.prefix.delete()
         ids = {"prefix": "10.0.0.0/24", "namespace": "Test"}
-        attrs = {"location": "Test", "tenant": "Test"}
+        attrs = {"tenant": "Test"}
         result = NautobotPrefix.create(self.adapter, ids, attrs)
         self.assertIsInstance(result, NautobotPrefix)
         self.assertEqual(len(self.adapter.objects_to_create["prefixes"]), 1)
-        self.assertEqual(len(self.adapter.objects_to_create["prefix_locs"]), 1)
         subnet = self.adapter.objects_to_create["prefixes"][0]
         self.assertEqual(str(subnet.prefix), ids["prefix"])
         self.assertEqual(self.adapter.prefix_map[ids["prefix"]], subnet.id)
@@ -66,15 +65,13 @@ class TestNautobotPrefix(TransactionTestCase):  # pylint: disable=too-many-insta
         test_pf = NautobotPrefix(
             prefix="10.0.0.0/24",
             namespace="Test",
-            location="Test",
             tenant="Test",
             uuid=self.prefix.id,
         )
         test_pf.adapter = self.adapter
-        update_attrs = {"location": "Update", "tenant": "Update"}
+        update_attrs = {"tenant": "Update"}
         actual = NautobotPrefix.update(self=test_pf, attrs=update_attrs)
         self.prefix.refresh_from_db()
-        self.assertEqual(self.prefix.location, self.update_site)
         self.assertEqual(self.prefix.tenant, self.update_tenant)
         self.assertEqual(actual, test_pf)
 
@@ -84,7 +81,6 @@ class TestNautobotPrefix(TransactionTestCase):  # pylint: disable=too-many-insta
         test_pf = NautobotPrefix(
             prefix="10.0.0.0/24",
             namespace="Test",
-            location="Test",
             tenant="Test",
             uuid=self.prefix.id,
         )


### PR DESCRIPTION
- Fixes bug where multiple locations assigned to a Prefix would cause Meraki integration to fail.
- Added ability to Meraki and DNA Center integrations to allow renaming of imported locations using `name` key in location map option.
- Fixed DNA Center loading incorrect names for buildings and floors in Nautobot adapter.
- Added missing code owners for DNA Center, Meraki, and Itential integrations.
- Fixed KeyError being thrown when port is missing from uplink_settings dict in Meraki integration.
- Fixed bug in Bootstrap integration that occurs when loading ValidatedSoftware in a system where SoftwareLCM doesn't exist.