### PR TITLE
Add Missing Acknowledgements and Code Owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /nautobot_ssot/integrations/aci/ @chadell @nautobot/plugin-ssot
 /nautobot_ssot/integrations/aristacv/ @qduk @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/bootstrap/ @bile0026 @nautobot/plugin-ssot
+/nautobot_ssot/integrations/citrix_adm/ @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/device42/ @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/dna_center/ @jdrew82 @nautobot/plugin-ssot
 /nautobot_ssot/integrations/infoblox/ @qduk @jdrew82 @nautobot/plugin-ssot

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The SSoT framework includes a number of integrations with external Systems of Re
 
 * Cisco ACI
 * Bootstrap
+* Citrix ADM
 * Arista CloudVision
 * Device42
 * Cisco DNA Center
@@ -117,6 +118,12 @@ This project includes code originally written in separate Nautobot apps, which h
     [@dnewood](https://github.com/dnewood),
     [@progala](https://github.com/progala),
     [@ubajze](https://github.com/ubajze)
+- [nautobot-plugin-ssot-bootstrap](https://github.com/nautobot/nautobot-plugin-ssot-bootstrap):
+    Thanks
+    [@bile0026](https://github.com/bile0026)
+- [nautobot-plugin-ssot-citrix-adm](https://github.com/nautobot/nautobot-plugin-ssot-citrix-adm):
+    Thanks
+    [@jdrew82](https://github.com/jdrew82)
 - [nautobot-plugin-ssot-arista-cloudvision](https://github.com/nautobot/nautobot-plugin-ssot-arista-cloudvision):
     Thanks
     [@burnyd](https://github.com/burnyd),
@@ -154,6 +161,12 @@ This project includes code originally written in separate Nautobot apps, which h
     [@pke11y](https://github.com/pke11y),
     [@ubajze](https://github.com/ubajze)
     [@whitej6](https://github.com/whitej6),
+- [nautobot-plugin-ssot-device42](https://github.com/nautobot/nautobot-plugin-ssot-itential):
+    Thanks
+    [@jtdub](https://github.com/jtdub)
+- [nautobot-plugin-ssot-meraki](https://github.com/nautobot/nautobot-plugin-ssot-meraki):
+    Thanks
+    [@jdrew82](https://github.com/jdrew82)
 - [nautobot-plugin-ssot-servicenow](https://github.com/nautobot/nautobot-plugin-ssot-servicenow):
     Thanks
     [@chadell](https://github.com/chadell),

--- a/changes/605.documentation
+++ b/changes/605.documentation
@@ -1,0 +1,1 @@
+Add missing acknowledgements for a few integrations.

--- a/changes/605.housekeeping
+++ b/changes/605.housekeeping
@@ -1,0 +1,1 @@
+Add code owner for Citrix ADM integration.


### PR DESCRIPTION
I noticed that our documentation had missed some acknowledgements for integrations and also the code owner for the Citrix integration.