### PR TITLE
Fix hostname_mapping in Citrix ADM

### DIFF
--- a/changes/607.fixed
+++ b/changes/607.fixed
@@ -1,0 +1,1 @@
+Fix hostname_mapping functionailty in Citrix ADM integration.

--- a/changes/607.housekeeping
+++ b/changes/607.housekeeping
@@ -1,0 +1,1 @@
+Remove redundant parse_hostname_for_role() function in Meraki integration that was missed in 599.

--- a/nautobot_ssot/integrations/citrix_adm/jobs.py
+++ b/nautobot_ssot/integrations/citrix_adm/jobs.py
@@ -55,7 +55,7 @@ class CitrixAdmDataSource(DataSource, Job):  # pylint: disable=too-many-instance
     hostname_mapping = StringVar(
         label="Hostname Mapping",
         description="List of tuples containing Device hostname regex patterns to assign to specified Role. ex: [('.*ilb.*', 'Internal Load-Balancer')]",
-        default={},
+        default=[],
         required=False,
     )
     tenant = ObjectVar(model=Tenant, queryset=Tenant.objects.all(), display_field="display_name", required=False)

--- a/nautobot_ssot/integrations/citrix_adm/jobs.py
+++ b/nautobot_ssot/integrations/citrix_adm/jobs.py
@@ -1,11 +1,13 @@
 """Jobs for Citrix ADM SSoT integration."""
 
+from ast import literal_eval
+
 from diffsync.enum import DiffSyncFlags
 from django.templatetags.static import static
 from django.urls import reverse
 from nautobot.core.celery import register_jobs
 from nautobot.dcim.models import Location, LocationType
-from nautobot.extras.jobs import BooleanVar, Job, JSONVar, MultiObjectVar, ObjectVar
+from nautobot.extras.jobs import BooleanVar, Job, JSONVar, MultiObjectVar, ObjectVar, StringVar
 from nautobot.extras.models import ExternalIntegration
 from nautobot.tenancy.models import Tenant
 
@@ -50,9 +52,9 @@ class CitrixAdmDataSource(DataSource, Job):  # pylint: disable=too-many-instance
         default={},
         required=False,
     )
-    hostname_mapping = JSONVar(
+    hostname_mapping = StringVar(
         label="Hostname Mapping",
-        description="Mapping of Device hostname to Role. Ex: {'router01': 'router'}.",
+        description="List of tuples containing Device hostname regex patterns to assign to specified Role. ex: [('.*ilb.*', 'Internal Load-Balancer')]",
         default={},
         required=False,
     )
@@ -135,7 +137,7 @@ class CitrixAdmDataSource(DataSource, Job):  # pylint: disable=too-many-instance
         self.dc_loctype = kwargs["dc_loctype"]
         self.parent_location = kwargs["parent_location"]
         self.location_map = kwargs["location_map"]
-        self.hostname_mapping = kwargs["hostname_mapping"]
+        self.hostname_mapping = literal_eval(kwargs["hostname_mapping"])
         self.validate_job_settings()
         self.memory_profiling = memory_profiling
         super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -16,7 +16,8 @@ from nautobot_ssot.integrations.meraki.diffsync.models.meraki import (
     MerakiPrefix,
     MerakiPrefixLocation,
 )
-from nautobot_ssot.integrations.meraki.utils.meraki import get_role_from_devicetype, parse_hostname_for_role
+from nautobot_ssot.integrations.meraki.utils.meraki import get_role_from_devicetype
+from nautobot_ssot.utils import parse_hostname_for_role
 
 
 class MerakiAdapter(Adapter):
@@ -97,7 +98,9 @@ class MerakiAdapter(Adapter):
                     if self.job.hostname_mapping and len(self.job.hostname_mapping) > 0:
                         if self.job.debug:
                             self.job.logger.debug(f"Parsing hostname for device {dev['name']} to determine role.")
-                        role = parse_hostname_for_role(dev_hostname=dev["name"], hostname_map=self.job.hostname_mapping)
+                        role = parse_hostname_for_role(
+                            device_hostname=dev["name"], hostname_map=self.job.hostname_mapping, default_role="Unknown"
+                        )
                     elif self.job.devicetype_mapping and len(self.job.devicetype_mapping) > 0:
                         if self.job.debug:
                             self.job.logger.debug(f"Parsing device model for device {dev['name']} to determine role.")

--- a/nautobot_ssot/integrations/meraki/utils/meraki.py
+++ b/nautobot_ssot/integrations/meraki/utils/meraki.py
@@ -1,7 +1,5 @@
 """Utility functions for working with Meraki."""
 
-import re
-
 import meraki
 
 
@@ -203,24 +201,6 @@ class DashboardClient:
                 f"Meraki API error: {err}\nstatus code = {err.status}\nreason = {err.reason}\nerror = {err.message}"
             )
         return ports
-
-
-def parse_hostname_for_role(dev_hostname: str, hostname_map: dict) -> str:
-    """Parse device hostname to get Device Role.
-
-    Args:
-        dev_hostname (str): Hostname of Device to determine role of.
-        hostname_map (dict): Dictionary of hostname's mapped to their Role.
-
-    Returns:
-        str: Name of DeviceRole. Defaults to Unknown.
-    """
-    dev_role = "Unknown"
-    for entry in hostname_map:
-        match = re.match(pattern=entry[0], string=dev_hostname)
-        if match:
-            dev_role = entry[1]
-    return dev_role
 
 
 def get_role_from_devicetype(dev_model: str, devicetype_map: dict) -> str:


### PR DESCRIPTION
This PR fixes the hostname_mapping functionality in the Citrix ADM integration. I found when used in client that I had used JSONVar when I meant a StringVar as it's a list of tuples. This also does a bit of housekeeping to remove a duplicate `parse_hostname_for_role()` that I had missed in the Meraki integration.