### PR TITLE
Service Now Integration - Fixes issue #634

### DIFF
--- a/changes/634.fixed
+++ b/changes/634.fixed
@@ -1,4 +1,1 @@
-ServiceNow Integration
-When running the Nautobot ⟹ ServiceNow job with a site filter set, you expect the job to sync only the specified locations to ServiceNow. 
-However, it appears that the job currently loads only the parent locations, not the specified location itself.
-This is fixed by initializing the locations list with the user-selected location and then loading the parent locations of that selection.
+Fixed load locations on the source adapter for the ServiceNow integration when a site filter is applied.

--- a/changes/634.fixed
+++ b/changes/634.fixed
@@ -1,0 +1,4 @@
+ServiceNow Integration
+When running the Nautobot ⟹ ServiceNow job with a site filter set, you expect the job to sync only the specified locations to ServiceNow. 
+However, it appears that the job currently loads only the parent locations, not the specified location itself.
+This is fixed by initializing the locations list with the user-selected location and then loading the parent locations of that selection.

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
@@ -59,7 +59,7 @@ class NautobotDiffSync(Adapter):
         """Load Nautobot Location objects as DiffSync Location models."""
         if self.site_filter is not None:
             # Load only direct ancestors of the given Site
-            locations = []
+            locations = [self.site_filter]
             ancestor = self.site_filter.parent
             while ancestor is not None:
                 locations.insert(0, ancestor)


### PR DESCRIPTION
### Fixes issue 634

When running the Nautobot ⟹ ServiceNow job with a site filter set, you expect the job to sync only the specified locations to ServiceNow. 
However, it appears that the job currently loads only the parent locations, not the specified location itself.
This is fixed by initializing the locations list with the user-selected location and then loading the parent locations of that selection.