### PR TITLE
Fix Wrong Parent Prefix in Citrix ADM

### DIFF
--- a/changes/646.fixed
+++ b/changes/646.fixed
@@ -1,0 +1,1 @@
+Fixed IPAddress assigned wrong parent Prefix in Citrix ADM.

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -297,7 +297,8 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
         for ipaddr in self.get_all(obj="address"):
             for prefix in self.get_all(obj="prefix"):
                 if not is_ip_within(ipaddr.prefix, prefix.prefix):
-                    if is_ip_within(ipaddr.host, prefix.prefix):
+                    host_addr = ipaddr.address.split("/")[0]
+                    if is_ip_within(host_addr, prefix.prefix):
                         if self.job.debug:
                             self.job.logger.debug(
                                 "More specific Prefix %s found for IPAddress %s", prefix.prefix, ipaddr.address

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -296,6 +296,11 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
         """Find more accurate parent Prefix for loaded IPAddresses."""
         for ipaddr in self.get_all(obj="address"):
             for prefix in self.get_all(obj="prefix"):
+                # check if prefixes are both IPv4 or IPv6
+                if (":" in ipaddr.prefix and ":" not in prefix.prefix) or (
+                    ":" in prefix.prefix and ":" not in ipaddr.prefix
+                ):
+                    continue
                 if not is_ip_within(ipaddr.prefix, prefix.prefix):
                     host_addr = ipaddr.address.split("/")[0]
                     if is_ip_within(host_addr, prefix.prefix):

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -9,6 +9,7 @@ from diffsync.exceptions import ObjectNotFound
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.models import ExternalIntegration, Job
 from nautobot.tenancy.models import Tenant
+from netutils.ip import is_ip_within
 
 from nautobot_ssot.integrations.citrix_adm.constants import DEVICETYPE_MAP
 from nautobot_ssot.integrations.citrix_adm.diffsync.models.citrix_adm import (
@@ -291,6 +292,19 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             new_map = self.ip_on_intf(address=address, device=device, port=port, primary=primary, uuid=None)
             self.add(new_map)
 
+    def find_closer_parent_prefix(self) -> None:
+        """Find more accurate parent Prefix for loaded IPAddresses."""
+        for ipaddr in self.get_all(obj="address"):
+            for prefix in self.get_all(obj="prefix"):
+                if not is_ip_within(ipaddr.prefix, prefix.prefix):
+                    if is_ip_within(ipaddr.host, prefix.prefix):
+                        if self.job.debug:
+                            self.job.logger.debug(
+                                "More specific Prefix %s found for IPAddress %s", prefix.prefix, ipaddr.address
+                            )
+                        ipaddr.prefix = prefix.prefix
+                        self.update(ipaddr)
+
     def load(self):
         """Load data from Citrix ADM into DiffSync models."""
         for instance in self.instances:
@@ -321,6 +335,7 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 self.create_port_map()
                 self.load_ports()
                 self.load_addresses()
+                self.find_closer_parent_prefix()
 
                 self.conn.logout()
             else:

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
@@ -255,7 +255,7 @@ class NautobotAddress(Address):
         """Create IP Address in Nautobot from NautobotAddress object."""
         new_ip = IPAddress(
             address=ids["address"],
-            parent=Prefix.objects.filter(network__net_contains=ids["address"].split("/")[0]).last(),
+            parent=Prefix.objects.get(prefix=ids["prefix"]),
             status=Status.objects.get(name="Active"),
             namespace=(
                 Namespace.objects.get_or_create(name=attrs["tenant"])[0]


### PR DESCRIPTION
Closes #646 and addresses the bug in Citrix ADM where the wrong parent Prefix is chosen for an IPAddress and Nautobot won't import the IPAddress.