### PR TITLE
Fix Citrix ADM Removing Used SoftwareVersions

### DIFF
--- a/changes/648.fixed
+++ b/changes/648.fixed
@@ -1,1 +1,2 @@
 Fixed Citrix ADM deleting SoftwareVersion in use with ValidatedSoftware.
+Fixed Meraki deleting SoftwareVersion in use with ValidatedSoftware.

--- a/changes/648.fixed
+++ b/changes/648.fixed
@@ -1,0 +1,1 @@
+Fixed Citrix ADM deleting SoftwareVersion in use with ValidatedSoftware.

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
@@ -79,8 +79,14 @@ class NautobotOSVersion(OSVersion):
     def delete(self):
         """Delete SoftwareVersion in Nautobot from NautobotOSVersion object."""
         ver = SoftwareVersion.objects.get(id=self.uuid)
-        super().delete()
-        ver.delete()
+        if hasattr(ver, "validatedsoftwarelcm_set"):
+            if ver.validatedsoftwarelcm_set.count() != 0:
+                self.adapter.job.logger.warning(
+                    f"SoftwareVersion {ver.version} for {ver.platform.name} is used with a ValidatedSoftware so won't be deleted."
+                )
+        else:
+            super().delete()
+            ver.delete()
         return self
 
 

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -114,10 +114,16 @@ class NautobotOSVersion(OSVersion):
         return super().create(adapter=adapter, ids=ids, attrs=attrs)
 
     def delete(self):
-        """Delete DeviceType in Nautobot from NautobotHardware object."""
-        super().delete()
+        """Delete SoftwareVersion in Nautobot from NautobotOSVersion object."""
         osversion = SoftwareVersion.objects.get(id=self.uuid)
-        osversion.delete()
+        if hasattr(osversion, "validatedsoftwarelcm_set"):
+            if osversion.validatedsoftwarelcm_set.count() != 0:
+                self.adapter.job.logger.warning(
+                    f"SoftwareVersion {osversion.version} for {osversion.platform.name} is used with a ValidatedSoftware so won't be deleted."
+                )
+        else:
+            super().delete()
+            osversion.delete()
         return self
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -768,7 +768,8 @@ def pylint(context):
     else:
         print("No migrations directory found, skipping migrations checks.")
 
-    raise Exit(code=exit_code)
+    if exit_code == 1:
+        raise Exit(code=exit_code)
 
 
 @task(aliases=("a",))
@@ -812,7 +813,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         if not run_command(context, command, warn=True):
             exit_code = 1
 
-    raise Exit(code=exit_code)
+    if exit_code == 1:
+        raise Exit(code=exit_code)
 
 
 @task


### PR DESCRIPTION
This PR closes #648 and fixes the issue with deleting a SoftwareVersion that is used with a ValidatedSoftware. I found that this same issue was also possible with Meraki integration so replicated the check there.