### PR TITLE
Fix Device Floor Name to Match Loaded

### DIFF
--- a/changes/650.fixed
+++ b/changes/650.fixed
@@ -1,0 +1,1 @@
+Fixed Device floor name being incorrectly defined and including Building name when it shouldn't.

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -376,7 +376,7 @@ class DnaCenterAdapter(Adapter):
                 if loc_data.get("floor") and loc_data["building"] not in loc_data["floor"]:
                     floor_name = f"{loc_data['building']} - {loc_data['floor']}"
                 elif loc_data.get("floor"):
-                    floor_name = f"{loc_data['building']} - {loc_data['floor']}"
+                    floor_name = loc_data["floor"]
                 else:
                     floor_name = None
                 new_dev = self.device(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #650

## What's Changed

Corrected the names of Floors used in loading Devices to match format when Floors are loaded. This fixes the issue where Devices were being assigned to the wrong Floors by mistake.

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))