### PR TITLE
Correct ACI LocationType To Match Job Settings

### DIFF
--- a/changes/597.fixed
+++ b/changes/597.fixed
@@ -1,0 +1,1 @@
+Fixed ACI integration LocationType usage in CRUD operations to match Job device_site or specified APIC Location's LocationType.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #597

## What's Changed
Fixes the ACI integration CRUD operations use of Site LocationType when it should be using whichever LocationType is specified for the Job's device_site Location or APIC Location.

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))