### PR TITLE
Preserve ACI Tag color and device types settings

### DIFF
--- a/changes/654.fixed
+++ b/changes/654.fixed
@@ -1,0 +1,2 @@
+Fixed ACI signal initializing Tags without ContentType or Color being populated
+Fixed ACI signal initializing Tag throwing duplicate key exception.

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -4,7 +4,6 @@
 import logging
 import random
 
-from django.contrib.contenttypes.models import ContentType
 from nautobot.core.signals import nautobot_database_ready
 from nautobot.extras.choices import CustomFieldTypeChoices
 
@@ -24,6 +23,7 @@ def register_signals(sender):
 
 def _ensure_tag(apps, name, color):
     """Ensure tag exists and properly configured."""
+    ContentType = apps.get_model("contenttypes", "ContentType")
     tag = apps.get_model("extras", "Tag")
     _tag = tag.objects.get_or_create(name=name)[0]
     _tag.color == color

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -47,8 +47,8 @@ def aci_create_tag(apps, **kwargs):
         for key in apics:
             if ("SITE" in key or "STAGE" in key) and not tag.objects.filter(name=apics[key]).exists():
                 _ensure_tag(
-                    apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)])
-                )  # noqa: S311
+                    apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)]) # noqa: S311
+                )
 
 
 def aci_create_manufacturer(apps, **kwargs):

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -47,7 +47,9 @@ def aci_create_tag(apps, **kwargs):
         for key in apics:
             if ("SITE" in key or "STAGE" in key) and not tag.objects.filter(name=apics[key]).exists():
                 _ensure_tag(
-                    apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)]) # noqa: S311
+                    apps=apps,
+                    name=apics[key],
+                    color="".join([random.choice("ABCDEF0123456789") for i in range(6)]),  # noqa: S311
                 )
 
 

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -27,7 +27,7 @@ def _ensure_tag(apps, name, color):
     tag = apps.get_model("extras", "Tag")
     _tag = tag.objects.get_or_create(name=name)[0]
     if _tag.color != color:
-        _tag.color == color  # pylint: disable=pointless-statement
+        _tag.color = color
         _tag.validated_save()
     for content_type in ContentType.objects.all():
         if content_type not in _tag.content_types.all():

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -26,11 +26,12 @@ def _ensure_tag(apps, name, color):
     ContentType = apps.get_model("contenttypes", "ContentType")
     tag = apps.get_model("extras", "Tag")
     _tag = tag.objects.get_or_create(name=name)[0]
-    _tag.color == color
+    if _tag.color != color:
+        _tag.color == color
+        _tag.validated_save()
     for content_type in ContentType.objects.all():
         if content_type not in _tag.content_types.all():
             _tag.content_types.add(content_type)
-    _tag.validated_save()
 
 
 def aci_create_tag(apps, **kwargs):

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -27,7 +27,7 @@ def _ensure_tag(apps, name, color):
     tag = apps.get_model("extras", "Tag")
     _tag = tag.objects.get_or_create(name=name)[0]
     if _tag.color != color:
-        _tag.color == color
+        _tag.color == color  # pylint: disable=pointless-statement
         _tag.validated_save()
     for content_type in ContentType.objects.all():
         if content_type not in _tag.content_types.all():

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -4,6 +4,7 @@
 import logging
 import random
 
+from django.contrib.contenttypes.models import ContentType
 from nautobot.core.signals import nautobot_database_ready
 from nautobot.extras.choices import CustomFieldTypeChoices
 
@@ -20,36 +21,30 @@ def register_signals(sender):
     nautobot_database_ready.connect(device_custom_fields, sender=sender)
     nautobot_database_ready.connect(interface_custom_fields, sender=sender)
 
+def _ensure_tag(apps, name, color):
+    """Ensure tag exists and properly configured."""
+    tag = apps.get_model("extras", "Tag")
+    _tag = tag.objects.get_or_create(name=name)[0]
+    _tag.color == color
+    for content_type in ContentType.objects.all():
+        if content_type not in _tag.content_types.all():
+            _tag.content_types.add(content_type)
+    _tag.validated_save()
 
 def aci_create_tag(apps, **kwargs):
     """Add a tag."""
     tag = apps.get_model("extras", "Tag")
     logger.info("Creating tags for ACI, interface status and Sites")
+    _ensure_tag(apps=apps, name=PLUGIN_CFG.get("tag"), color=PLUGIN_CFG.get("tag_color"))
+    _ensure_tag(apps=apps, name=PLUGIN_CFG.get("tag_up"), color=PLUGIN_CFG.get("tag_up_color"))
+    _ensure_tag(apps=apps, name=PLUGIN_CFG.get("tag_down"), color=PLUGIN_CFG.get("tag_down_color"))
+    _ensure_tag(apps=apps, name="ACI_MULTISITE", color="03a9f4")
 
-    tag.objects.update_or_create(
-        name=PLUGIN_CFG.get("tag"),
-        color=PLUGIN_CFG.get("tag_color"),
-    )
-    tag.objects.update_or_create(
-        name=PLUGIN_CFG.get("tag_up"),
-        color=PLUGIN_CFG.get("tag_up_color"),
-    )
-    tag.objects.update_or_create(
-        name=PLUGIN_CFG.get("tag_down"),
-        color=PLUGIN_CFG.get("tag_down_color"),
-    )
-    tag.objects.update_or_create(
-        name="ACI_MULTISITE",
-        color="03a9f4",
-    )
     apics = PLUGIN_CFG.get("apics")
     if apics:
         for key in apics:
             if ("SITE" in key or "STAGE" in key) and not tag.objects.filter(name=apics[key]).exists():
-                tag.objects.update_or_create(
-                    name=apics[key],
-                    color="".join([random.choice("ABCDEF0123456789") for i in range(6)]),  # noqa: S311
-                )
+                _ensure_tag(apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)]))  # noqa: S311
 
 
 def aci_create_manufacturer(apps, **kwargs):

--- a/nautobot_ssot/integrations/aci/signals.py
+++ b/nautobot_ssot/integrations/aci/signals.py
@@ -21,6 +21,7 @@ def register_signals(sender):
     nautobot_database_ready.connect(device_custom_fields, sender=sender)
     nautobot_database_ready.connect(interface_custom_fields, sender=sender)
 
+
 def _ensure_tag(apps, name, color):
     """Ensure tag exists and properly configured."""
     tag = apps.get_model("extras", "Tag")
@@ -30,6 +31,7 @@ def _ensure_tag(apps, name, color):
         if content_type not in _tag.content_types.all():
             _tag.content_types.add(content_type)
     _tag.validated_save()
+
 
 def aci_create_tag(apps, **kwargs):
     """Add a tag."""
@@ -44,7 +46,9 @@ def aci_create_tag(apps, **kwargs):
     if apics:
         for key in apics:
             if ("SITE" in key or "STAGE" in key) and not tag.objects.filter(name=apics[key]).exists():
-                _ensure_tag(apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)]))  # noqa: S311
+                _ensure_tag(
+                    apps=apps, name=apics[key], color="".join([random.choice("ABCDEF0123456789") for i in range(6)])
+                )  # noqa: S311
 
 
 def aci_create_manufacturer(apps, **kwargs):


### PR DESCRIPTION
# Closes: #654 

## What's Changed
Avoid duplicate key exception on startup by only passing tag name during tag enforcement.
Ensure tag content_types and color are properly configured.


## To Do
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))

