### PR TITLE
Fix Memory Profiling Metrics Error for Prometheus

### DIFF
--- a/changes/666.fixed
+++ b/changes/666.fixed
@@ -1,0 +1,1 @@
+Fix empty memory profiling metrics causing Prometheus error.

--- a/nautobot_ssot/metrics.py
+++ b/nautobot_ssot/metrics.py
@@ -138,8 +138,6 @@ def metric_memory_usage():
                     labels=[operation, ".".join(job.natural_key())],
                     value=value,
                 )
-        else:
-            memory_gauge.add_metric(labels=["", ""], value=0)
 
     yield memory_gauge
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #666 

## What's Changed
Fix the creation of duplicate metrics for memory profiling of SSoT Jobs when the Job has never had memory profiling run. This should resolve the duplicate metric error in Prometheus.
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))