### PR TITLE
Exclude tag requirements when loading DeviceType and InterfaceTemplate

### DIFF
--- a/changes/669.fixed
+++ b/changes/669.fixed
@@ -1,0 +1,1 @@
+Excluded tag requirements when loading DeviceType, InterfaceTemplate

--- a/nautobot_ssot/integrations/aci/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/aci/diffsync/adapters/nautobot.py
@@ -123,8 +123,7 @@ class NautobotAdapter(Adapter):
 
     def load_devicetypes(self):
         """Method to load Device Types from Nautobot."""
-        _tag = Tag.objects.get(name=PLUGIN_CFG.get("tag"))
-        for nbdevicetype in DeviceType.objects.filter(tags=_tag):
+        for nbdevicetype in DeviceType.objects.all():
             _devicetype = self.device_type(
                 model=nbdevicetype.model,
                 part_nbr=nbdevicetype.part_number,
@@ -136,7 +135,7 @@ class NautobotAdapter(Adapter):
 
     def load_interfacetemplates(self):
         """Method to load Interface Templates from Nautobot."""
-        for nbinterfacetemplate in InterfaceTemplate.objects.filter(tags=self.site_tag):
+        for nbinterfacetemplate in InterfaceTemplate.objects.all():
             _interfacetemplate = self.interface_template(
                 name=nbinterfacetemplate.name,
                 device_type=nbinterfacetemplate.device_type.model,


### PR DESCRIPTION
# Closes: #669 

## What's Changed
Remove tag filter when loading DeviceType and InterfaceTemplate into diffsync model.

## To Do

- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation]
