### PR TITLE
Use IOSImage field to grab Aruba DeviceType

### DIFF
--- a/changes/686.changed
+++ b/changes/686.changed
@@ -1,0 +1,1 @@
+Changed SolarWinds integration to use IOSImage field to grab Aruba DeviceTypes.

--- a/nautobot_ssot/integrations/solarwinds/utils/solarwinds.py
+++ b/nautobot_ssot/integrations/solarwinds/utils/solarwinds.py
@@ -280,6 +280,7 @@ class SolarwindsClient:  # pylint: disable=too-many-public-methods, too-many-ins
                 Location AS SNMPLocation,
                 o.Vendor,
                 MachineType AS DeviceType,
+                IOSImage,
                 h.Model,
                 h.ServiceTag,
                 o.NodeID
@@ -304,7 +305,10 @@ class SolarwindsClient:  # pylint: disable=too-many-public-methods, too-many-ins
                     node_details[node_id]["IPAddress"] = result["IPAddress"]
                     node_details[node_id]["SNMPLocation"] = result["SNMPLocation"]
                     node_details[node_id]["Vendor"] = result["Vendor"]
-                    node_details[node_id]["DeviceType"] = result["DeviceType"]
+                    if "aruba" in result["Vendor"].lower():
+                        node_details[node_id]["DeviceType"] = result["IOSImage"].strip("MODEL: ")
+                    else:
+                        node_details[node_id]["DeviceType"] = result["DeviceType"]
                     node_details[node_id]["Model"] = result["Model"]
                     node_details[node_id]["ServiceTag"] = result["ServiceTag"]
                     # making prefix length default of 32 and will updated to the correct value in subsequent query.
@@ -423,7 +427,7 @@ class SolarwindsClient:  # pylint: disable=too-many-public-methods, too-many-ins
                 return ""
 
             if "Aruba" in node["Vendor"]:
-                device_type = device_type.replace("Aruba ", "").strip()
+                device_type = device_type.replace("Aruba", "").strip()
             elif "Cisco" in node["Vendor"]:
                 device_type = device_type.replace("Cisco", "").strip()
                 device_type = device_type.replace("Catalyst ", "C").strip()

--- a/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
+++ b/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
@@ -267,7 +267,7 @@ class TestSolarwindsClientTestCase(TransactionTestCase):  # pylint: disable=too-
         )
         self.job.logger.debug.assert_called_once_with("Processing batch 1 of 1 - Orion.Nodes.")
         self.test_client.query.assert_called_once_with(
-            "\n                SELECT IOSVersion AS Version,\n                o.IPAddress,\n                Location AS SNMPLocation,\n                o.Vendor,\n                MachineType AS DeviceType,\n                h.Model,\n                h.ServiceTag,\n                o.NodeID\n                FROM Orion.Nodes o LEFT JOIN Orion.HardwareHealth.HardwareInfo h ON o.NodeID = h.NodeID\n                WHERE NodeID IN (\n            '1','2')"
+            "\n                SELECT IOSVersion AS Version,\n                o.IPAddress,\n                Location AS SNMPLocation,\n                o.Vendor,\n                MachineType AS DeviceType,\n                IOSImage,\n                h.Model,\n                h.ServiceTag,\n                o.NodeID\n                FROM Orion.Nodes o LEFT JOIN Orion.HardwareHealth.HardwareInfo h ON o.NodeID = h.NodeID\n                WHERE NodeID IN (\n            '1','2')"
         )
         self.assertEqual(
             self.node_details,


### PR DESCRIPTION
Solarwinds & SNMP for some reason pulls the information needed for DeviceType into the Solarwinds IOSImage field. This PR simiply changes the SolarWinds integration to use this field specifically for Aruba devices.
