### PR TITLE
adds catching of ValueError on validated_save in contrib

### DIFF
--- a/changes/703.fixed
+++ b/changes/703.fixed
@@ -1,0 +1,1 @@
+Added catching of `ValueError` on `validated_save` in contrib models.

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -228,7 +228,7 @@ class NautobotModel(DiffSyncModel):
         # Save the object to the database
         try:
             obj.validated_save()
-        except ValidationError as error:
+        except (ValidationError, ValueError) as error:
             raise ObjectCrudException(
                 f"Validated save failed for Django object:\n{error}\nParameters: {parameters}"
             ) from error


### PR DESCRIPTION
Had this in an environment where the MTU for an interface was empty, it didn't raise a validation error but rather a value error.