### PR TITLE
Fix Meraki Missing AP Interfaces

### DIFF
--- a/changes/717.fixed
+++ b/changes/717.fixed
@@ -1,0 +1,1 @@
+Fixed missing import of Interfaces and IPAddresses for uplink Interfaces on small selection of APs in Meraki.

--- a/nautobot_ssot/integrations/meraki/utils/meraki.py
+++ b/nautobot_ssot/integrations/meraki/utils/meraki.py
@@ -1,4 +1,5 @@
 """Utility functions for working with Meraki."""
+from typing import List
 
 import meraki
 
@@ -93,6 +94,26 @@ class DashboardClient:
                 f"Meraki API error: {err}\nstatus code = {err.status}\nreason = {err.reason}\nerror = {err.message}"
             )
         return settings_map
+
+    def get_org_uplink_addresses_by_device(self, serial: str) -> List[dict]:
+        """Retrieve uplink addresses for specified device serial.
+
+        Args:
+            serial (str): Serial of device to retrieve uplink addresses for.
+
+        Returns:
+            List[dict]: List of dictionaries of uplink addresses for device with specified serial.
+        """
+        addresses = []
+        try:
+            addresses = self.conn.organizations.getOrganizationDevicesUplinksAddressesByDevice(
+                organizationId=self.org_id, serial=serial
+            )
+        except meraki.APIError as err:
+            self.logger.logger.warning(
+                f"Meraki API error: {err}\nstatus code = {err.status}\nreason = {err.reason}\nerror = {err.message}"
+            )
+        return addresses
 
     def get_org_switchports(self) -> dict:
         """Retrieve all ports for switches in specified organization ID.

--- a/nautobot_ssot/tests/meraki/fixtures/fixtures.py
+++ b/nautobot_ssot/tests/meraki/fixtures/fixtures.py
@@ -23,6 +23,9 @@ GET_MANAGEMENT_PORTS_SENT_FIXTURE = load_json("./nautobot_ssot/tests/meraki/fixt
 GET_MANAGEMENT_PORTS_RECV_FIXTURE = load_json("./nautobot_ssot/tests/meraki/fixtures/get_management_ports_recv.json")
 GET_ORG_SWITCHPORTS_SENT_FIXTURE = load_json("./nautobot_ssot/tests/meraki/fixtures/get_org_switchports_sent.json")
 GET_ORG_SWITCHPORTS_RECV_FIXTURE = load_json("./nautobot_ssot/tests/meraki/fixtures/get_org_switchports_recv.json")
+GET_ORG_UPLINK_ADDRESSES_BY_DEVICE_FIXTURE = load_json(
+    "./nautobot_ssot/tests/meraki/fixtures/get_org_uplink_addresses_by_device.json"
+)
 GET_ORG_UPLINK_STATUSES_SENT_FIXTURE = load_json(
     "./nautobot_ssot/tests/meraki/fixtures/get_org_uplink_statuses_sent.json"
 )

--- a/nautobot_ssot/tests/meraki/fixtures/get_org_uplink_addresses_by_device.json
+++ b/nautobot_ssot/tests/meraki/fixtures/get_org_uplink_addresses_by_device.json
@@ -1,0 +1,44 @@
+[
+    {
+        "mac": "3f:3a:e0:bc:75:d7",
+        "name": "HQ AP",
+        "network": {
+            "id": "L_165471703274884707"
+        },
+        "productType": "appliance",
+        "serial": "L6XI-2BIN-EUTI",
+        "tags": [],
+        "uplinks": [
+            {
+                "interface": "cellular",
+                "addresses": []
+            },
+            {
+                "interface": "wan1",
+                "addresses": [
+                    {
+                        "protocol": "ipv4",
+                        "address": "10.5.52.3",
+                        "gateway": "10.5.52.1",
+                        "assignmentMode": "static",
+                        "nameservers": {
+                            "addresses": [
+                                "8.8.8.8"
+                            ]
+                        },
+                        "public": {
+                            "address": "26.30.225.42"
+                        },
+                        "vlan": {
+                            "id": "0"
+                        }
+                    }
+                ]
+            },
+            {
+                "interface": "wan2",
+                "addresses": []
+            }
+        ]
+    }
+]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #717

## What's Changed
This PR fixes the bug where a small set of APs were not getting an Interface or IP address imported. There was an org uplink endpoint that was found to have the missing information.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Unit, Integration Tests
