### PR TITLE
Fix the synchronization of the prefix location from Infoblox extensibility attributes. (#729)

### DIFF
--- a/changes/729.fixed
+++ b/changes/729.fixed
@@ -1,0 +1,1 @@
+Fixed the synchronization of the prefix location from Infoblox extensibility attributes.

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -47,7 +47,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
         if attr_value:
             if attr.lower() in ["site", "facility", "location"]:
                 try:
-                    obj.location_id = adapter.location_map[attr_value]
+                    obj.location = adapter.location_map[attr_value]
                 except KeyError as err:
                     adapter.job.logger.warning(
                         f"Unable to find Location {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
@@ -79,7 +79,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
                     obj.role = attr_value.lower()
                 else:
                     try:
-                        obj.role_id = adapter.role_map[attr_value]
+                        obj.role = adapter.role_map[attr_value]
                     except KeyError as err:
                         adapter.job.logger.warning(
                             f"Unable to find Role {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
@@ -92,7 +92,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
                         )
             if attr.lower() in ["tenant", "dept", "department"]:
                 try:
-                    obj.tenant_id = adapter.tenant_map[attr_value]
+                    obj.tenant = adapter.tenant_map[attr_value]
                 except KeyError as err:
                     adapter.job.logger.warning(
                         f"Unable to find Tenant {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -79,7 +79,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
                     obj.role = attr_value.lower()
                 else:
                     try:
-                        obj.role = adapter.role_map[attr_value]
+                        obj.role_id = adapter.role_map[attr_value]
                     except KeyError as err:
                         adapter.job.logger.warning(
                             f"Unable to find Role {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
@@ -92,7 +92,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
                         )
             if attr.lower() in ["tenant", "dept", "department"]:
                 try:
-                    obj.tenant = adapter.tenant_map[attr_value]
+                    obj.tenant_id = adapter.tenant_map[attr_value]
                 except KeyError as err:
                     adapter.job.logger.warning(
                         f"Unable to find Tenant {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -13,6 +13,7 @@ from nautobot.ipam.models import IPAddress as OrmIPAddress
 from nautobot.ipam.models import Namespace as OrmNamespace
 from nautobot.ipam.models import Prefix as OrmPrefix
 from nautobot.ipam.models import VLANGroup as OrmVlanGroup
+from packaging import version
 
 from nautobot_ssot.integrations.infoblox.choices import (
     DNSRecordTypeChoices,
@@ -47,7 +48,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
     for attr, attr_value in extattrs.items():  # pylint: disable=too-many-nested-blocks
         if attr_value:
             if attr.lower() in ["site", "facility", "location"]:
-                if settings.VERSION_MAJOR==2 and settings.VERSION_MINOR<2:
+                if version.parse(settings.VERSION) < version.parse("2.2.0"):
                     try:
                         obj.location = adapter.location_map[attr_value]
                     except KeyError as err:
@@ -66,7 +67,7 @@ def process_ext_attrs(adapter, obj: object, extattrs: dict):  # pylint: disable=
                     except KeyError as err:
                         adapter.job.logger.warning(
                             f"Unable to find Location {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
-                        ) 
+                        )
             if attr.lower() == "vrf":
                 if isinstance(attr_value, list):
                     for vrf in attr_value:


### PR DESCRIPTION
# Closes: #729

## What's Changed

The location of a prefix should be synced from the “site” or “location” extensibility attribute of an Infoblox network.

After reviewing the code, I identified that we were setting [location_id ](https://github.com/michalis1/nautobot-app-ssot/blob/6bf86de74e7d6248cdaf9571aa62c960ef679d19/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py#L50) instead of the location of a prefix.