### PR TITLE
Update Aruba/Cisco Platform logic

### DIFF
--- a/changes/731.changed
+++ b/changes/731.changed
@@ -1,0 +1,1 @@
+Changed Aruba/Cisco Platform values to enable better differentation between Operating Systems.

--- a/nautobot_ssot/integrations/solarwinds/diffsync/adapters/solarwinds.py
+++ b/nautobot_ssot/integrations/solarwinds/diffsync/adapters/solarwinds.py
@@ -360,14 +360,38 @@ class SolarWindsAdapter(Adapter):  # pylint: disable=too-many-instance-attribute
             manufacturer (str): Manufacturer name for associated Platform.
         """
         if "Aruba" in manufacturer:
-            self.get_or_instantiate(
-                self.platform,
-                ids={"name": "arubanetworks.aoscx", "manufacturer__name": manufacturer},
-                attrs={"network_driver": "aruba_aoscx", "napalm_driver": ""},
-            )
-            return "arubanetworks.aoscx"
+            if device_type.startswith(("1", "60", "61", "62", "63", "64", "8", "93", "94")):
+                self.get_or_instantiate(
+                    self.platform,
+                    ids={"name": "arubanetworks.aos.aoscx", "manufacturer__name": manufacturer},
+                    attrs={"network_driver": "aruba_aoscx", "napalm_driver": ""},
+                )
+                return "arubanetworks.aos.aoscx"
+            elif device_type.startswith(("AP", "MC", "MM", "7", "90", "91", "92")):
+                self.get_or_instantiate(
+                    self.platform,
+                    ids={"name": "arubanetworks.aos.os", "manufacturer__name": manufacturer},
+                    attrs={"network_driver": "aruba_os", "napalm_driver": ""},
+                )
+                return "arubanetworks.aos.os"
+            elif device_type.startswith(("25", "29", "38", "54")):
+                self.get_or_instantiate(
+                    self.platform,
+                    ids={"name": "arubanetworks.aos.osswitch", "manufacturer__name": manufacturer},
+                    attrs={"network_driver": "aruba_osswitch", "napalm_driver": ""},
+                )
+                return "arubanetworks.aos.osswitch"
+
         if "Cisco" in manufacturer:
-            if not device_type.startswith("N"):
+            if device_type.startswith("85"):
+                if "wireless" in device_type.lower() or "wlc" in device_type.lower():
+                    self.get_or_instantiate(
+                        self.platform,
+                        ids={"name": "cisco.ios.aireos", "manufacturer__name": manufacturer},
+                        attrs={"network_driver": "cisco_aireos", "napalm_driver": ""},
+                    )
+                return "cisco.ios.aireos"
+            elif not device_type.startswith("N"):
                 self.get_or_instantiate(
                     self.platform,
                     ids={"name": "cisco.ios.ios", "manufacturer__name": manufacturer},

--- a/nautobot_ssot/integrations/solarwinds/diffsync/adapters/solarwinds.py
+++ b/nautobot_ssot/integrations/solarwinds/diffsync/adapters/solarwinds.py
@@ -352,13 +352,14 @@ class SolarWindsAdapter(Adapter):  # pylint: disable=too-many-instance-attribute
             self.role, ids={"name": role}, attrs={"content_types": [{"app_label": "dcim", "model": "device"}]}
         )
 
-    def load_platform(self, device_type: str, manufacturer: str):  # pylint: disable=inconsistent-return-statements
+    def load_platform(self, device_type: str, manufacturer: str):
         """Load Platform into DiffSync model based upon DeviceType.
 
         Args:
             device_type (str): DeviceType name for associated Platform.
             manufacturer (str): Manufacturer name for associated Platform.
         """
+        platform = "UNKNOWN"
         if "Aruba" in manufacturer:
             if device_type.startswith(("1", "60", "61", "62", "63", "64", "8", "93", "94")):
                 self.get_or_instantiate(
@@ -366,21 +367,21 @@ class SolarWindsAdapter(Adapter):  # pylint: disable=too-many-instance-attribute
                     ids={"name": "arubanetworks.aos.aoscx", "manufacturer__name": manufacturer},
                     attrs={"network_driver": "aruba_aoscx", "napalm_driver": ""},
                 )
-                return "arubanetworks.aos.aoscx"
+                platform = "arubanetworks.aos.aoscx"
             elif device_type.startswith(("AP", "MC", "MM", "7", "90", "91", "92")):
                 self.get_or_instantiate(
                     self.platform,
                     ids={"name": "arubanetworks.aos.os", "manufacturer__name": manufacturer},
                     attrs={"network_driver": "aruba_os", "napalm_driver": ""},
                 )
-                return "arubanetworks.aos.os"
+                platform = "arubanetworks.aos.os"
             elif device_type.startswith(("25", "29", "38", "54")):
                 self.get_or_instantiate(
                     self.platform,
                     ids={"name": "arubanetworks.aos.osswitch", "manufacturer__name": manufacturer},
                     attrs={"network_driver": "aruba_osswitch", "napalm_driver": ""},
                 )
-                return "arubanetworks.aos.osswitch"
+                platform = "arubanetworks.aos.osswitch"
 
         if "Cisco" in manufacturer:
             if device_type.startswith("85"):
@@ -390,29 +391,30 @@ class SolarWindsAdapter(Adapter):  # pylint: disable=too-many-instance-attribute
                         ids={"name": "cisco.ios.aireos", "manufacturer__name": manufacturer},
                         attrs={"network_driver": "cisco_aireos", "napalm_driver": ""},
                     )
-                return "cisco.ios.aireos"
+                platform = "cisco.ios.aireos"
             elif not device_type.startswith("N"):
                 self.get_or_instantiate(
                     self.platform,
                     ids={"name": "cisco.ios.ios", "manufacturer__name": manufacturer},
                     attrs={"network_driver": "cisco_ios", "napalm_driver": "ios"},
                 )
-                return "cisco.ios.ios"
-            if device_type.startswith("N"):
+                platform = "cisco.ios.ios"
+            elif device_type.startswith("N"):
                 self.get_or_instantiate(
                     self.platform,
                     ids={"name": "cisco.nxos.nxos", "manufacturer__name": manufacturer},
                     attrs={"network_driver": "cisco_nxos", "napalm_driver": "nxos"},
                 )
-                return "cisco.nxos.nxos"
+                platform = "cisco.nxos.nxos"
         elif "Palo" in manufacturer:
             self.get_or_instantiate(
                 self.platform,
                 ids={"name": "paloaltonetworks.panos.panos", "manufacturer__name": manufacturer},
                 attrs={"network_driver": "paloalto_panos", "napalm_driver": ""},
             )
-            return "paloaltonetworks.panos.panos"
-        return "UNKNOWN"
+            platform = "paloaltonetworks.panos.panos"
+
+        return platform
 
     def load_interfaces(self, device: DiffSyncModel, intfs: dict) -> None:
         """Load interfaces for passed device.

--- a/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
+++ b/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
@@ -306,6 +306,43 @@ class TestSolarWindsAdapterTestCase(TransactionTestCase):  # pylint: disable=too
         self.solarwinds.load_role(role="Test")
         self.assertEqual({"Test"}, {role.get_unique_id() for role in self.solarwinds.get_all("role")})
 
+    def test_load_platform_aireos(self):
+        """Test the load_platform() function with AireOS device."""
+        result = self.solarwinds.load_platform(device_type="8540 Series Wireless Controllers", manufacturer="Cisco")
+        result2 = self.solarwinds.load_platform(device_type="8500WLC", manufacturer="Cisco")
+        self.assertEqual(result, "cisco.ios.aireos")
+        self.assertEqual(result2, "cisco.ios.aireos")
+        self.assertEqual(
+            {"cisco.ios.aireos__Cisco"}, {plat.get_unique_id() for plat in self.solarwinds.get_all("platform")}
+        )
+
+    def test_load_platform_aruba_aoscx(self):
+        """Test the load_platform() function with Aruba AOSCX device."""
+        result = self.solarwinds.load_platform(device_type="6100-US", manufacturer="Aruba")
+        self.assertEqual(result, "arubanetworks.aos.aoscx")
+        self.assertEqual(
+            {"arubanetworks.aos.aoscx__Aruba"}, {plat.get_unique_id() for plat in self.solarwinds.get_all("platform")}
+        )
+
+    def test_load_platform_aruba_os(self):
+        """Test the load_platform() function with Aruba OS device."""
+        result = self.solarwinds.load_platform(device_type="MM-HW-5K", manufacturer="Aruba")
+        result2 = self.solarwinds.load_platform(device_type="7240XM-US", manufacturer="Aruba")
+        self.assertEqual(result, "arubanetworks.aos.os")
+        self.assertEqual(result2, "arubanetworks.aos.os")
+        self.assertEqual(
+            {"arubanetworks.aos.os__Aruba"}, {plat.get_unique_id() for plat in self.solarwinds.get_all("platform")}
+        )
+
+    def test_load_platform_aruba_osswitch(self):
+        """Test the load_platform() function with Aruba OSSwitch device."""
+        result = self.solarwinds.load_platform(device_type="2530-US", manufacturer="Aruba")
+        self.assertEqual(result, "arubanetworks.aos.osswitch")
+        self.assertEqual(
+            {"arubanetworks.aos.osswitch__Aruba"},
+            {plat.get_unique_id() for plat in self.solarwinds.get_all("platform")},
+        )
+
     def test_load_platform_ios(self):
         """Test the load_platform() function with IOS device."""
         result = self.solarwinds.load_platform(device_type="ASR1001", manufacturer="Cisco")


### PR DESCRIPTION
Allows better differentiation between Aruba OS types, as well as add support for (EOL) 8500-WLC AireOS platform type.

Used fantastic chart created here to help with model types: https://github.com/networktocode/netutils/pull/588#issuecomment-2672972706

