### PR TITLE
Add Migration for SoR CustomField

### DIFF
--- a/changes/740.fixed
+++ b/changes/740.fixed
@@ -1,0 +1,1 @@
+Added migration for SolarWinds integration to update CustomFields from Solarwinds to SolarWinds to match update in #696.

--- a/nautobot_ssot/migrations/0013_update_solarwinds_customfields.py
+++ b/nautobot_ssot/migrations/0013_update_solarwinds_customfields.py
@@ -1,10 +1,9 @@
 # Migration to update CustomFields that are Solarwinds to SolarWinds.
 from django.db import migrations
 
+
 def update_solarwinds_customfields(apps, schema_editor):
     """Update CustomFields that are Solarwinds to SolarWinds."""
-    CustomField = apps.get_model("extras", "customfield")
-
     for app, model in [
         ("dcim", "Device"),
         ("dcim", "Interface"),

--- a/nautobot_ssot/migrations/0013_update_solarwinds_customfields.py
+++ b/nautobot_ssot/migrations/0013_update_solarwinds_customfields.py
@@ -1,0 +1,33 @@
+# Migration to update CustomFields that are Solarwinds to SolarWinds.
+from django.db import migrations
+
+def update_solarwinds_customfields(apps, schema_editor):
+    """Update CustomFields that are Solarwinds to SolarWinds."""
+    CustomField = apps.get_model("extras", "customfield")
+
+    for app, model in [
+        ("dcim", "Device"),
+        ("dcim", "Interface"),
+        ("ipam", "Prefix"),
+        ("ipam", "IPAddress"),
+    ]:
+        model = apps.get_model(app, model)
+        cf_list = []
+        for instance in model.objects.filter(_custom_field_data__system_of_record="Solarwinds").iterator():
+            print(f"System of Record CustomField on {instance} is being updated from Solarwinds to SolarWinds.")
+            instance._custom_field_data["system_of_record"] = "SolarWinds"
+            cf_list.append(instance)
+        model.objects.bulk_update(cf_list, ["_custom_field_data"], 1000)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nautobot_ssot", "0012_ssotinfobloxconfig_infoblox_network_view_to_namespace_map"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=update_solarwinds_customfields,
+            reverse_code=migrations.operations.special.RunPython.noop,
+        )
+    ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #740 

## What's Changed
This PR adds a new migration to update any System of Record CustomFields that were using Solarwinds to now be SolarWinds. This is to address the update that was done in #696 where the Nautobot adapter load is now expecting SolarWinds to be in the CustomField.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))