### PR TITLE
SolarWinds integration: Add 'wireless' to device_type checks

### DIFF
--- a/changes/744.added
+++ b/changes/744.added
@@ -1,0 +1,1 @@
+Added extra check when determiming device_type for 'wireless' in Cisco model names.

--- a/nautobot_ssot/integrations/solarwinds/utils/solarwinds.py
+++ b/nautobot_ssot/integrations/solarwinds/utils/solarwinds.py
@@ -421,14 +421,11 @@ class SolarWindsClient:  # pylint: disable=too-many-public-methods, too-many-ins
             elif "Cisco" in node["Vendor"]:
                 device_type = device_type.replace("Cisco", "").strip()
                 device_type = device_type.replace("Catalyst ", "C").strip()
-                if (
-                    device_type
-                    and "WS-" not in device_type
-                    and "WLC" not in device_type
-                    and "ASR" not in device_type
-                    and not device_type.startswith("N")
-                ):
-                    device_type = f"WS-{device_type}"
+                if device_type:
+                    if not any(
+                        s in device_type.upper() for s in ["WS-", "WLC", "ASR", "WIRELESS"]
+                    ) and not device_type.startswith("N"):
+                        device_type = f"WS-{device_type}"
             elif "Palo" in node["Vendor"]:
                 pass  # Nothing needed yet.
         return device_type

--- a/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
+++ b/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
@@ -422,9 +422,24 @@ class TestSolarWindsClientTestCase(TransactionTestCase):  # pylint: disable=too-
         ),
         ("both_blank", {"Vendor": "Cisco", "DeviceType": "", "Model": ""}, ""),
         (
-            "8540_wlc",
+            "ignore_wireless",
             {"Vendor": "Cisco", "DeviceType": "Cisco 8540 Wireless Series Controllers", "Model": ""},
             "8540 Wireless Series Controllers",
+        ),
+        (
+            "ignore_wlc",
+            {"Vendor": "Cisco", "DeviceType": "Cisco 8500 WLC", "Model": ""},
+            "8500 WLC",
+        ),
+        (
+            "ignore_asr",
+            {"Vendor": "Cisco", "DeviceType": "Cisco ASR 9901", "Model": ""},
+            "ASR 9901",
+        ),
+        (
+            "ignore_ws-",
+            {"Vendor": "Cisco", "DeviceType": "Cisco WS-C3850-48U-S", "Model": ""},
+            "WS-C3850-48U-S",
         ),
     ]
 

--- a/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
+++ b/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
@@ -421,6 +421,11 @@ class TestSolarWindsClientTestCase(TransactionTestCase):  # pylint: disable=too-
             "WS-C4500X-32 SFP+ Switch",
         ),
         ("both_blank", {"Vendor": "Cisco", "DeviceType": "", "Model": ""}, ""),
+        (
+            "8540_wlc",
+            {"Vendor": "Cisco", "DeviceType": "Cisco 8540 Wireless Series Controllers", "Model": ""},
+            "8540 Wireless Series Controllers",
+        ),
     ]
 
     @parameterized.expand(node_types, skip_on_empty=True)


### PR DESCRIPTION
Cisco 8540 WLC's were getting `WS-` prepended to their device_type, causing them to be incorrectly categorized as ios, not aireos. This resolves that issue.

Adding the one extra 'if' check caused Pylint to complain with `R0916: Too many boolean expressions in if statement`, so I refactored that logic a tad as well.

Added one extra test case for the `standardize_device_type` function for this case.