### PR TITLE
Bootstrap integration: add enabled option for scheduled_jobs

### DIFF
--- a/changes/745.added
+++ b/changes/745.added
@@ -1,0 +1,1 @@
+Added enabled option for ScheduledJob in Bootstrap SSOT.

--- a/docs/user/integrations/bootstrap.md
+++ b/docs/user/integrations/bootstrap.md
@@ -720,6 +720,9 @@ The `query:` key takes a graphql formatted string to retrieve the information re
 ### ScheduledJob
 Create a ScheduledJob. The Job to be scheduled must already exist. As Job's vary greatly, any Job specific variables should be under the `job_vars` key, and you should check the Job specific documentation for details on what these values should be. The `start_time` must be in the future if the ScheduledJob is being updated or created. Once created, it does not need to be updated unless you wish to modify the schedule. The Bootstrap `system_of_record` cannot be applied to ScheduledJobs, make sure all desired ScheduledJobs exist in your YAML definition.
 
+!!! warning
+    Use of the `enabled` parameter to disable a ScheduledJob will cause it to no longer appear in the Scheduled Jobs list view in the UI. You will need to use Bootstrap again or the [nbshell](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/tools/nautobot-shell/) to re-enable it.
+
 ```yaml
 scheduled_job:
   - name: # str
@@ -728,6 +731,7 @@ scheduled_job:
     crontab: # str -- Basic Crontab syntax. Use with interval 'custom'
     job_model: # str -- The name of the Job you wish to schedule
     user: # str -- Username to run this scheduled job as
+    enabled: # bool -- Optional, defaults to True
     profile: # bool -- Optional, defaults to False
     task_queue: # str -- Optional, celery queue name, defaults to None (default queue)
     job_vars: # dict -- Optional

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
@@ -886,6 +886,7 @@ class BootstrapAdapter(Adapter, LabelMixin):
                 profile=scheduled_job.get("profile", False),
                 approval_required=scheduled_job.get("approval_required", False),
                 task_queue=scheduled_job.get("task_queue"),
+                enabled=scheduled_job.get("enabled", True),
             )
             self.add(_scheduled_job)
 

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -1194,6 +1194,7 @@ class NautobotAdapter(Adapter):
                     approval_required=job.approval_required,
                     profile=job.celery_kwargs.get("nautobot_job_profile", False),
                     task_queue=job.celery_kwargs.get("queue"),
+                    enabled=job.enabled,
                 )
                 _scheduled_job.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
                 self.add(_scheduled_job)

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/base.py
@@ -775,6 +775,7 @@ class ScheduledJob(DiffSyncModel):
         "profile",
         "approval_required",
         "task_queue",
+        "enabled",
     )
     _children = {}
 
@@ -788,6 +789,7 @@ class ScheduledJob(DiffSyncModel):
     profile: bool = False
     approval_required: bool = False
     task_queue: Optional[str] = None
+    enabled: Optional[bool] = True
 
     uuid: Optional[UUID] = None
 

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2365,6 +2365,7 @@ class NautobotScheduledJob(ScheduledJob):
             approval_required=attrs.get("approval_required"),
             kwargs=job_kwargs,
             celery_kwargs=celery_kwargs,
+            enabled=attrs.get("enabled"),
         )
         scheduled_job.validated_save()
 
@@ -2409,6 +2410,8 @@ class NautobotScheduledJob(ScheduledJob):
             job.approval_required = attrs["approval_required"]
         if "task_queue" in attrs:
             job.celery_kwargs["queue"] = attrs["task_queue"]
+        if "enabled" in attrs:
+            job.enabled = attrs["enabled"]
 
         job.validated_save()
         return super().update(attrs)


### PR DESCRIPTION
Added `enabled` parameter for scheduled_jobs, in Boostrap integration.

I noticed that disabled Scheduled Jobs do not appear in the list view in the UI, due to [this](https://github.com/nautobot/nautobot/blob/cb9bacbed04e7b8849cd24bd28094b632e093ca2/nautobot/extras/views.py#L1956) in Nautobot core. I'd love to see if that can be changed, but in the meantime I also added a warning to the docs for anyone using this parameter.