### PR TITLE
Updated ServiceNow instance config loading

### DIFF
--- a/changes/750.fixed
+++ b/changes/750.fixed
@@ -1,0 +1,1 @@
+Fixed ServiceNow instance configuration loading.

--- a/nautobot_ssot/integrations/servicenow/utils.py
+++ b/nautobot_ssot/integrations/servicenow/utils.py
@@ -15,7 +15,7 @@ def get_servicenow_parameters():
     db_config = SSOTServiceNowConfig.load()
     settings_config = settings.PLUGINS_CONFIG.get("nautobot_ssot", {})
     result = {
-        "instance": settings_config.get("servicenow_instance", db_config.servicenow_instance),
+        "instance": settings_config.get("servicenow_instance", "") or db_config.servicenow_instance,
         "username": settings_config.get("servicenow_username", ""),
         "password": settings_config.get("servicenow_password", ""),
     }

--- a/nautobot_ssot/tests/servicenow/test_jobs.py
+++ b/nautobot_ssot/tests/servicenow/test_jobs.py
@@ -74,7 +74,15 @@ class ServiceNowDataTargetJobTestCase(TestCase):
             },
         )
 
-    @override_settings(PLUGINS_CONFIG={})
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot": {
+                "servicenow_instance": "",
+                "servicenow_username": "",
+                "servicenow_password": "",
+            }
+        }
+    )
     @mock.patch.dict(os.environ, {"SNOW_USERNAME": "someuser", "SNOW_PASSWORD": "notsosecret"})
     def test_config_information_db(self):
         """Verify the config_information() API for configs provided in the database."""


### PR DESCRIPTION


# Closes: #750

## What's Changed

Updated the ServiceNow integration config loading to allow instance from the DB config. Previously it was being overridden by the default app settings in __init__.py

Tests were also updated to make sure this is captured the same way in the future.