### PR TITLE
Fixes #760, bootstrap scheduled_job User update

### DIFF
--- a/changes/760.fixed
+++ b/changes/760.fixed
@@ -1,0 +1,1 @@
+Fixed issue causing bootstrap scheduled_job to fail when updating the User field.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2366,7 +2366,7 @@ class NautobotScheduledJob(ScheduledJob):
 
         if attrs.get("user"):
             try:
-                job.user = ORMUser.objects.get(name=attrs["user"])
+                job.user = ORMUser.objects.get(username=attrs["user"])
             except ORMUser.DoesNotExist:
                 self.adapter.job.logger.error(f"User ({attrs['user']}) does not exist, unable to update ({self.name})")
 


### PR DESCRIPTION
# Closes: #760 

## What's Changed
Incorrect keyword `name` was being used for User object, the correct keyword is `username`.

