### PR TITLE
Infoblox Integration - The default value for the Network Views to Nautobot Namespace setting should be a dictionary (#772)

### DIFF
--- a/changes/772.fixed
+++ b/changes/772.fixed
@@ -1,0 +1,1 @@
+The default value for the Network Views to Nautobot Namespace setting in the Infoblox integration should be a dictionary, not a list.

--- a/docs/admin/integrations/infoblox_setup.md
+++ b/docs/admin/integrations/infoblox_setup.md
@@ -140,11 +140,9 @@ The purpose of this setting is to provide flexibility, enabling you to:
 The setting is represented as a dictionary, where the keys are Infoblox network views, and the values are the corresponding Nautobot namespaces.
 
 ```json
-[
-    {
-        "default": "Global"
-    }
-]
+{
+    "default": "Global"
+}
 ```
 
 ### Configuring Infoblox DNS View Mapping

--- a/nautobot_ssot/integrations/infoblox/models.py
+++ b/nautobot_ssot/integrations/infoblox/models.py
@@ -35,7 +35,7 @@ def _get_default_cf_fields_ignore():
 
 def _get_network_view_to_namespace_map():
     """Provides default value for network view to namespace map."""
-    return [{"default": "Global"}]
+    return {"default": "Global"}
 
 
 class SSOTInfobloxConfig(PrimaryModel):  # pylint: disable=too-many-ancestors

--- a/nautobot_ssot/integrations/infoblox/models.py
+++ b/nautobot_ssot/integrations/infoblox/models.py
@@ -222,7 +222,7 @@ class SSOTInfobloxConfig(PrimaryModel):  # pylint: disable=too-many-ancestors
     def _clean_infoblox_network_view_to_namespace_map(self):  # pylint: disable=too-many-branches
         """Performs validation of the infoblox_network_view_to_namespace_map field."""
         if not isinstance(self.infoblox_network_view_to_namespace_map, dict):
-            raise ValidationError({"infoblox_sync_filters": "Namespace/View mappings must be a dictionary."})
+            raise ValidationError({"infoblox_network_view_to_namespace_map": "Namespace/View mappings must be a dictionary."})
 
     def _clean_infoblox_instance(self):
         """Performs validation of the infoblox_instance field."""

--- a/nautobot_ssot/integrations/infoblox/models.py
+++ b/nautobot_ssot/integrations/infoblox/models.py
@@ -222,7 +222,9 @@ class SSOTInfobloxConfig(PrimaryModel):  # pylint: disable=too-many-ancestors
     def _clean_infoblox_network_view_to_namespace_map(self):  # pylint: disable=too-many-branches
         """Performs validation of the infoblox_network_view_to_namespace_map field."""
         if not isinstance(self.infoblox_network_view_to_namespace_map, dict):
-            raise ValidationError({"infoblox_network_view_to_namespace_map": "Namespace/View mappings must be a dictionary."})
+            raise ValidationError(
+                {"infoblox_network_view_to_namespace_map": "Namespace/View mappings must be a dictionary."}
+            )
 
     def _clean_infoblox_instance(self):
         """Performs validation of the infoblox_instance field."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #772 

## What's Changed

The default value for the **Network Views to Nautobot Namespace** setting in the Infoblox integration should be a dictionary, not a list. 

Current (incorrect) default:
```json
[
    {
        "default": "Global"
    }
]
```

Correct default:
```json
{
     "default": "Global"
}
```

