### PR TITLE
Enhance contrib to support object metadata.

### DIFF
--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -12,7 +12,7 @@ from diffsync.exceptions import ObjectCrudException
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
 from nautobot.extras.choices import RelationshipTypeChoices
-from nautobot.extras.models import Relationship, RelationshipAssociation
+from nautobot.extras.models import MetadataType, Relationship, RelationshipAssociation
 from typing_extensions import get_type_hints
 
 from nautobot_ssot.contrib.types import (
@@ -50,6 +50,7 @@ class NautobotAdapter(Adapter):
         super().__init__(*args, **kwargs)
         self.job = job
         self.sync = sync
+        self.metadata_type = None
         self.invalidate_cache()
 
     def invalidate_cache(self, zero_out_hits=True):
@@ -388,3 +389,26 @@ class NautobotAdapter(Adapter):
             if lookups[-1] in ["app_label", "model"]:
                 return getattr(ContentType.objects.get_for_model(related_object), lookups[-1])
         return None
+
+    def get_or_create_metadatatype(self):
+        """Retrieve or create a MetadataType object to track the last sync time of this SSoT job."""
+        # MetadataType name will be extracted from the Data Source name.
+        print(dir(self.job.__class__))
+        metadata_type__name = self.job.__class__.Meta.data_source
+
+        # Create a MetadataType of type datetime
+        metadata_type, created = MetadataType.objects.get_or_create(
+            name=f"Last sync from {metadata_type__name}",
+            defaults={
+                "data_type": "datetime",
+                "description": f"Timestamp of the last sync from the Data source {metadata_type__name}",
+            },
+        )
+
+        # Use select_related for content_types since they'll be used during model CRUD operations.
+        if not created:
+            # Refetch with select_related if needed
+            metadata_type = MetadataType.objects.prefetch_related("content_types").get(pk=metadata_type.pk)
+
+        # Define the metadata type on the adapter so that can be used on the models crud operations
+        self.metadata_type = metadata_type

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -10,6 +10,7 @@ import structlog
 # pylint-django doesn't understand classproperty, and complains unnecessarily. We disable this specific warning:
 # pylint: disable=no-self-argument
 from diffsync.enum import DiffSyncFlags
+from django.conf import settings
 from django.db.utils import OperationalError
 from django.templatetags.static import static
 from django.utils import timezone
@@ -17,6 +18,7 @@ from django.utils.functional import classproperty
 from nautobot.extras.jobs import BooleanVar, DryRunVar, Job
 
 from nautobot_ssot.choices import SyncLogEntryActionChoices
+from nautobot_ssot.contrib.adapter import NautobotAdapter
 from nautobot_ssot.models import BaseModel, Sync, SyncLogEntry
 
 DataMapping = namedtuple("DataMapping", ["source_name", "source_url", "target_name", "target_url"])
@@ -179,7 +181,12 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
         )
         if memory_profiling:
             record_memory_trace("target_load")
-
+        # Check if the adapter is an instance of NautobotAdapter to determine if it's a contrib implementation,
+        # in which case we should create the required MetadataType object.
+        if self.__class__.__name__ in settings.PLUGINS_CONFIG.get("nautobot_ssot", {}).get(
+            "enable_metadata_for", []
+        ) and isinstance(self.target_adapter, NautobotAdapter):
+            self.target_adapter.get_or_create_metadatatype()
         self.logger.info("Calculating diffs...")
         self.calculate_diff()
         calculate_diff_time = datetime.now()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #632

## What's Changed

- Create a MetadataType of type datetime per integration called "Last sync from job.Meta.data_source" - we can do this in the job in the sync_data method by checking if the Nautobot adapter is a subclass of or exactly the nautobot_ssot.contrib.NautobotAdapter class
  - Also check the setting explained further down

- On model.create and model.update, create or update the timestamp value in the metadata
  - Also check the settings explained further down

- In nautobot_config.py under PLUGINS_CONFIG.nautobot_ssot.enable_metadata_for there is a list of Job class names for which metadata should be used

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)