### PR TITLE
Overwrite _handle_typed_dict

### DIFF
--- a/changes/784.fixed
+++ b/changes/784.fixed
@@ -1,0 +1,1 @@
+Change _handle_to_many_relationship from static method to instance method 

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -270,8 +270,7 @@ class NautobotAdapter(Adapter):
             relationship_association_parameters["destination_id"] = database_object.id
         return relationship_association_parameters
 
-    @staticmethod
-    def _handle_to_many_relationship(database_object, diffsync_model, parameter_name):
+    def _handle_to_many_relationship(self,database_object, diffsync_model, parameter_name):
         """Handle a single one- or many-to-many relationship field.
 
         one- or many-to-many relationships are type annotated as a list of typed dictionaries. The typed
@@ -326,7 +325,7 @@ class NautobotAdapter(Adapter):
         related_objects_list = []
         # TODO: Allow for filtering, i.e. not taking into account all the objects behind the relationship.
         for related_object in getattr(database_object, parameter_name).all():
-            dictionary_representation = NautobotAdapter._handle_typed_dict(inner_type, related_object)
+            dictionary_representation = self._handle_typed_dict(inner_type, related_object)
             # Only use those where there is a single field defined, all 'None's will not help us.
             if any(dictionary_representation.values()):
                 related_objects_list.append(dictionary_representation)

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -270,7 +270,7 @@ class NautobotAdapter(Adapter):
             relationship_association_parameters["destination_id"] = database_object.id
         return relationship_association_parameters
 
-    def _handle_to_many_relationship(self,database_object, diffsync_model, parameter_name):
+    def _handle_to_many_relationship(self, database_object, diffsync_model, parameter_name):
         """Handle a single one- or many-to-many relationship field.
 
         one- or many-to-many relationships are type annotated as a list of typed dictionaries. The typed


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #784 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
We have _handle_to_many_relationship method that is defined as a staticmethod. However, it uses _handle_typed_dict directly from its own class NautobotAdapter.

Therefore, an adapter would inherit NautobotAdapter cannot overwrite this method because it would still be the one from its parent that is called.
