### PR TITLE
Fixes #787: Add SKIP_UNMATCHED_DST to slurpit sync

### DIFF
--- a/changes/787.fixed
+++ b/changes/787.fixed
@@ -1,0 +1,1 @@
+Add `SKIP_UNMATCHED_DST` to Slurpit sync.

--- a/nautobot_ssot/integrations/slurpit/jobs.py
+++ b/nautobot_ssot/integrations/slurpit/jobs.py
@@ -2,6 +2,7 @@
 """Slurpit DataSource job class."""
 
 import slurpit
+from diffsync.enum import DiffSyncFlags
 from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
@@ -136,6 +137,8 @@ class SlurpitDataSource(DataSource, Job):  # pylint: disable=too-many-instance-a
         if not self.namespace:
             self.namespace = Namespace.objects.get(name="Global")
         self.ignore_prefixes = ignore_prefixes
+
+        self.diffsync_flags |= DiffSyncFlags.SKIP_UNMATCHED_DST
 
         self.kwargs = {
             "sync_slurpit_tagged_only": sync_slurpit_tagged_only,


### PR DESCRIPTION

# Closes: #787 

## What's Changed
add `SKIP_UNMATCHED_DST` to slurpit sync job so that it does not delete existing objects. 

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
