### PR TITLE
Fix Prefix MultipleObjectsReturned Error in Citrix ADM Integration

### DIFF
--- a/changes/793.fixed
+++ b/changes/793.fixed
@@ -1,0 +1,1 @@
+Fixed search for parent Prefix of IPAddress to include Namespace to avoid getting multiple results in Citrix ADM integration.

--- a/changes/793.fixed
+++ b/changes/793.fixed
@@ -1,1 +1,2 @@
 Fixed search for parent Prefix of IPAddress to include Namespace to avoid getting multiple results in Citrix ADM integration.
+Fixed DNA Center loading of Controller locations with missing parent.

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
@@ -259,18 +259,18 @@ class NautobotAddress(Address):
     @classmethod
     def create(cls, adapter, ids, attrs):
         """Create IP Address in Nautobot from NautobotAddress object."""
+        if attrs.get("tenant"):
+            pf_namespace = Namespace.objects.get_or_create(name=attrs["tenant"])[0]
+        else:
+            pf_namespace = Namespace.objects.get(name="Global")
         new_ip = IPAddress(
             address=ids["address"],
-            parent=Prefix.objects.get(prefix=ids["prefix"]),
+            parent=Prefix.objects.get(prefix=ids["prefix"], namespace=pf_namespace),
             status=Status.objects.get(name="Active"),
-            namespace=(
-                Namespace.objects.get_or_create(name=attrs["tenant"])[0]
-                if attrs.get("tenant")
-                else Namespace.objects.get(name="Global")
-            ),
+            namespace=pf_namespace,
         )
         if attrs.get("tenant"):
-            new_ip.tenant = Tenant.objects.update_or_create(name=attrs["tenant"])[0]
+            new_ip.tenant = Tenant.objects.get_or_create(name=attrs["tenant"])[0]
         if attrs.get("tags"):
             new_ip.tags.set(attrs["tags"])
             for tag in attrs["tags"]:

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -251,7 +251,8 @@ class DnaCenterAdapter(Adapter):
                     ),
                     "parent_of_parent": (
                         self.job.dnac.location.parent.parent.parent.parent.name
-                        if self.job.dnac.location.parent.parent.parent.parent
+                        if self.job.dnac.location.parent.parent.parent
+                        and self.job.dnac.location.parent.parent.parent.parent
                         else None
                     ),
                 },


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #793

## What's Changed
This PR resolves the issue described in #793 where multiple Prefixes were returned when finding the parent for an IPAddress in the Citrix ADM integration. I've also found another bug in the DNA Center integration where I missed checking for a parent Location on the DNAC Controller Location hierarchy.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
