### PR TITLE
Fix AuthFailure During Version Check in CVP Integration

### DIFF
--- a/changes/796.fixed
+++ b/changes/796.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect URL used in CloudVision integration when attempting to connect to portal and get version.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -675,9 +675,12 @@ def get_cvp_version(config: CloudVisionAppConfig):
     """
     client = CvpClient()
     try:
+        parsed_url = urlparse(config.url)
+        if not parsed_url.hostname:
+            raise ValueError(f"Invalid URL provided for CloudVision. {config.url}")
         if config.token and not config.is_on_premise:
             client.connect(
-                nodes=[config.url],
+                nodes=[parsed_url.hostname],
                 username="",
                 password="",
                 is_cvaas=True,
@@ -685,7 +688,7 @@ def get_cvp_version(config: CloudVisionAppConfig):
             )
         else:
             client.connect(
-                nodes=[config.url],
+                nodes=[parsed_url.hostname],
                 username=config.cvp_user,
                 password=config.cvp_password,
                 is_cvaas=False,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #796 

## What's Changed
This PR is intended to fix the issue where the wrong URL is being passed to the CVP client during the version check.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do
Need to validate this fixes the issue with a CVP instance.
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example