### PR TITLE
Fix contrib sorting TypeError

### DIFF
--- a/changes/802.fixed
+++ b/changes/802.fixed
@@ -1,0 +1,1 @@
+Fix TypeError `contrib.sorting` for issue #802.

--- a/nautobot_ssot/contrib/sorting.py
+++ b/nautobot_ssot/contrib/sorting.py
@@ -3,7 +3,7 @@
 import sys
 
 from diffsync import Adapter, DiffSyncModel
-from typing_extensions import TypedDict, get_type_hints
+from typing_extensions import get_type_hints
 
 from nautobot_ssot.contrib.typeddicts import SortKey
 from nautobot_ssot.contrib.types import SortType
@@ -53,7 +53,7 @@ def get_sortable_fields_from_model(model: DiffSyncModel) -> dict:
 
         sortable_content_type = attribute_type_hints.__args__[0]
 
-        if issubclass(sortable_content_type, dict) or issubclass(sortable_content_type, TypedDict):
+        if issubclass(sortable_content_type, dict):
             sort_key = _get_sort_key_from_typed_dict(sortable_content_type)
             if not sort_key:
                 continue


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

Closes: #802

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Removed `issubclass` check referencing invalid class object on affected line.


