### PR TITLE
Fix sorting __annotation__ `AttributeError` in sorting

### DIFF
--- a/changes/816.fixed
+++ b/changes/816.fixed
@@ -1,0 +1,1 @@
+Fixed sorting bug for types without `__annotation__`.

--- a/nautobot_ssot/contrib/sorting.py
+++ b/nautobot_ssot/contrib/sorting.py
@@ -27,14 +27,18 @@ def _is_sortable_field(attribute_type_hints) -> bool:
     ]
 
 
-def _get_sort_key_from_typed_dict(sortable_content_type) -> str:
+def get_sort_key_from_typed_dict(sortable_content_type) -> str:
     """Get the dictionary key from a TypedDict if found."""
-    for key, value in sortable_content_type.__annotations__.items():
-        try:
-            metadata = value.__metadata__
-        except AttributeError:
+    try:
+        annotations: dict = sortable_content_type.__annotations__
+    except AttributeError:
+        # If no annotations, no sort key set
+        return None
+
+    for key, value in annotations.items():
+        if not hasattr(value, "__metadata__"):
             continue
-        for entry in metadata:
+        for entry in value.__metadata__:
             if entry == SortKey:
                 return key
     return None
@@ -54,7 +58,7 @@ def get_sortable_fields_from_model(model: DiffSyncModel) -> dict:
         sortable_content_type = attribute_type_hints.__args__[0]
 
         if issubclass(sortable_content_type, dict):
-            sort_key = _get_sort_key_from_typed_dict(sortable_content_type)
+            sort_key = get_sort_key_from_typed_dict(sortable_content_type)
             if not sort_key:
                 continue
             sortable_fields[model_attribute_name] = {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

Closes: 816
## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
