### PR TITLE
Fix Check for DLM Installed Before Loading ValidatedSoftware

### DIFF
--- a/changes/819.fixed
+++ b/changes/819.fixed
@@ -1,0 +1,1 @@
+Fix check before loading ValidatedSoftware Model.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -142,7 +142,7 @@ class NautobotAdapter(Adapter):
     if dlm_supports_softwarelcm():
         software = NautobotSoftware
         software_image = NautobotSoftwareImage
-    if core_supports_softwareversion():
+    if validate_dlm_installed():
         validated_software = NautobotValidatedSoftware
 
     top_level = [


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #819

## What's Changed
Bugfix for attempting to load ValidatedSoftware models if DLM app isn't installed. 
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ X ] Explanation of Change(s)
- [ X ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ X ] Attached Screenshots, Payload Example
- [ X ] Unit, Integration Tests
- [ X ] Documentation Updates (when adding/changing features)
- [ X ] Outline Remaining Work, Constraints from Design
