### PR TITLE
Hide `Sync` and `SyncLogEntry` in version control diff view.

### DIFF
--- a/changes/836.added
+++ b/changes/836.added
@@ -1,0 +1,1 @@
+Added `hide_in_diff_view` flag for `Sync` and `SyncLogEntry` to hide those models in version control diff view.

--- a/nautobot_ssot/models.py
+++ b/nautobot_ssot/models.py
@@ -83,6 +83,7 @@ class Sync(BaseModel):  # pylint: disable=nb-string-field-blank-null
     summary = models.JSONField(blank=True, null=True)
 
     job_result = models.ForeignKey(to=JobResult, on_delete=models.CASCADE, blank=True, null=True)
+    hide_in_diff_view = True
 
     class Meta:
         """Metaclass attributes of Sync model."""
@@ -182,6 +183,8 @@ class SyncLogEntry(BaseModel):  # pylint: disable=nb-string-field-blank-null
     object_repr = models.TextField(blank=True, default="", editable=False)
 
     message = models.TextField(blank=True)
+
+    hide_in_diff_view = True
 
     class Meta:
         """Metaclass attributes of SyncLogEntry."""


### PR DESCRIPTION
# Closes: #836

## What's Changed

Added `hide_in_diff_view` flag to the `Sync` and `SyncLogEntry` to hide those models by default in version control diff view.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
