### PR TITLE
Fix Meraki Loading Invalid IP Version

### DIFF
--- a/changes/842.fixed
+++ b/changes/842.fixed
@@ -1,0 +1,1 @@
+Fixed IP version bug in Meraki integration on AP uplink ports.

--- a/nautobot_ssot/tests/meraki/fixtures/get_org_uplink_addresses_by_device.json
+++ b/nautobot_ssot/tests/meraki/fixtures/get_org_uplink_addresses_by_device.json
@@ -28,6 +28,24 @@
                         "vlan": {
                             "id": "0"
                         }
+                    },
+                    {
+                        "protocol": "ipv6",
+                        "address": "2001:116:4811:7d51:b7e:a1fa:edbe:4f2c",
+                        "gateway": "fe80::",
+                        "assignmentMode": "dynamic",
+                        "nameservers": {
+                            "addresses": [
+                                "2001:507:1642:6a02:526d:70eb:dc18:4fc3",
+                                "::"
+                            ]
+                        },
+                        "public": {
+                            "address": null
+                        },
+                        "vlan": {
+                            "id": "0"
+                        }
                     }
                 ]
             }

--- a/nautobot_ssot/tests/meraki/test_adapters_meraki.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_meraki.py
@@ -83,7 +83,7 @@ class TestMerakiAdapterTestCase(TransactionTestCase):
         expected_ports = set(wan1_ports + wan2_ports + lan_ports + man1_ports)
         self.assertEqual(expected_ports, {port.get_unique_id() for port in self.meraki.get_all("port")})
         self.assertEqual(
-            {"10.1.15.0/24__Global", "10.5.52.3/32__Global"},
+            {"10.1.15.0/24__Global", "10.5.52.3/32__Global", "2001:116:4811:7d51:b7e:a1fa:edbe:4f2c/128__Global"},
             {pf.get_unique_id() for pf in self.meraki.get_all("prefix")},
         )
         self.assertEqual(
@@ -91,6 +91,7 @@ class TestMerakiAdapterTestCase(TransactionTestCase):
                 "10.1.15.10__10.1.15.0/24__None",
                 "10.1.15.34__10.1.15.0/24__None",
                 "10.5.52.3__10.5.52.3/32__None",
+                "2001:116:4811:7d51:b7e:a1fa:edbe:4f2c__2001:116:4811:7d51:b7e:a1fa:edbe:4f2c/128__None",
             },
             {ip.get_unique_id() for ip in self.meraki.get_all("ipaddress")},
         )
@@ -237,6 +238,7 @@ class TestMerakiAdapterTestCase(TransactionTestCase):
             "interface": "man1",
             "addresses": [
                 {
+                    "protocol": "ipv4",
                     "address": "10.5.52.3",
                 }
             ],
@@ -261,16 +263,11 @@ class TestMerakiAdapterTestCase(TransactionTestCase):
         self.meraki.device_map = {"HQ AP": fix.GET_ORG_DEVICES_FIXTURE[3]}
         self.meraki.conn.network_map = {"L_165471703274884707": {"name": "HQ"}}
 
-        ap_port = {
-            "interface": "man1",
-            "addresses": [
-                {
-                    "address": "10.5.52.3",
-                }
-            ],
-        }
-
-        self.meraki.load_ap_uplink_ports(device=mock_device, port=ap_port, prefix="10.5.52.0/24")
+        self.meraki.load_ap_uplink_ports(
+            device=mock_device,
+            port=fix.GET_ORG_UPLINK_ADDRESSES_BY_DEVICE_FIXTURE[0]["uplinks"][0],
+            prefix="10.5.52.0/24",
+        )
         self.assertEqual(
             {
                 "man1__HQ AP",
@@ -278,5 +275,9 @@ class TestMerakiAdapterTestCase(TransactionTestCase):
             {uplink.get_unique_id() for uplink in self.meraki.get_all("port")},
         )
         self.assertEqual(
-            {"10.5.52.3__10.5.52.0/24__None"}, {ip.get_unique_id() for ip in self.meraki.get_all("ipaddress")}
+            {
+                "10.5.52.3__10.5.52.0/24__None",
+                "2001:116:4811:7d51:b7e:a1fa:edbe:4f2c__2001:116:4811:7d51:b7e:a1fa:edbe:4f2c/128__None",
+            },
+            {ip.get_unique_id() for ip in self.meraki.get_all("ipaddress")},
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #842

## What's Changed
This PR fixes the bug described in #842 where an IPv6 address is passed to a function with an IPv4 prefix throwing a TypeError. This should now allow for IPv6 addresses seen on the uplinks.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Unit, Integration Tests