### PR TITLE
Fix DNA Center Loading Meraki

### DIFF
--- a/changes/845.fixed
+++ b/changes/845.fixed
@@ -1,1 +1,2 @@
 Fix DNA Center integration to ensure Meraki devices aren't included in the failed device list if the `import_meraki` setting is False.
+Fixed duplicate IPAddressToInterface diffs being created due to mask_length being included as identifier in DNA Center integration.

--- a/changes/845.fixed
+++ b/changes/845.fixed
@@ -1,0 +1,1 @@
+Fix DNA Center integration to ensure Meraki devices aren't included in the failed device list if the `import_meraki` setting is False.

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -336,14 +336,6 @@ class DnaCenterAdapter(Adapter):
         for dev in devices:
             dev_role = "Unknown"
             vendor = "Cisco"
-            if not dev.get("hostname"):
-                if self.job.debug:
-                    self.job.logger.warning(f"Device {dev['id']} is missing hostname so will be skipped.")
-                dev["field_validation"] = {
-                    "reason": "Failed due to missing hostname.",
-                }
-                self.failed_import_devices.append(dev)
-                continue
             dev_role = self.get_device_role(dev)
             platform = self.get_device_platform(dev)
             if not PLUGIN_CFG.get("dna_center_import_merakis") and platform == "cisco_meraki":
@@ -352,6 +344,14 @@ class DnaCenterAdapter(Adapter):
                 self.job.logger.warning(f"Device {dev['hostname']} is missing Platform so will be skipped.")
                 dev["field_validation"] = {
                     "reason": "Failed due to missing platform.",
+                }
+                self.failed_import_devices.append(dev)
+                continue
+            if not dev.get("hostname"):
+                if self.job.debug:
+                    self.job.logger.warning(f"Device {dev['id']} is missing hostname so will be skipped.")
+                dev["field_validation"] = {
+                    "reason": "Failed due to missing hostname.",
                 }
                 self.failed_import_devices.append(dev)
                 continue
@@ -525,9 +525,9 @@ class DnaCenterAdapter(Adapter):
                 for series in ["2700", "2800", "3800", "9120", "9124", "9130", "9136", "9166"]:
                     if series in dev["type"]:
                         platform = "cisco_ios"
-            if not dev.get("softwareType") and (
+            if (
                 (dev.get("family") and "Meraki" in dev["family"])
-                or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "MX", "Z")))
+                or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "Z")))
                 or (dev.get("errorDescription") and "Meraki" in dev["errorDescription"])
             ):
                 platform = "cisco_meraki"

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -530,7 +530,7 @@ class DnaCenterAdapter(Adapter):
                         platform = "cisco_ios"
             if not dev.get("softwareType") and (
                 (dev.get("family") and "Meraki" in dev["family"])
-                or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "Z")))
+                or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "MX", "Z")))
             ):
                 platform = "cisco_meraki"
         return platform

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -334,11 +334,6 @@ class DnaCenterAdapter(Adapter):
         """Load Device data from DNA Center info DiffSync models."""
         devices = self.conn.get_devices()
         for dev in devices:
-            if not PLUGIN_CFG.get("dna_center_import_merakis") and (
-                (dev.get("family") and "Meraki" in dev["family"])
-                or (dev.get("errorDescription") and "Meraki" in dev["errorDescription"])
-            ):
-                continue
             dev_role = "Unknown"
             vendor = "Cisco"
             if not dev.get("hostname"):
@@ -351,6 +346,8 @@ class DnaCenterAdapter(Adapter):
                 continue
             dev_role = self.get_device_role(dev)
             platform = self.get_device_platform(dev)
+            if not PLUGIN_CFG.get("dna_center_import_merakis") and platform == "cisco_meraki":
+                continue
             if platform == "unknown":
                 self.job.logger.warning(f"Device {dev['hostname']} is missing Platform so will be skipped.")
                 dev["field_validation"] = {
@@ -531,6 +528,7 @@ class DnaCenterAdapter(Adapter):
             if not dev.get("softwareType") and (
                 (dev.get("family") and "Meraki" in dev["family"])
                 or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "MX", "Z")))
+                or (dev.get("errorDescription") and "Meraki" in dev["errorDescription"])
             ):
                 platform = "cisco_meraki"
         return platform

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -336,7 +336,6 @@ class DnaCenterAdapter(Adapter):
         for dev in devices:
             dev_role = "Unknown"
             vendor = "Cisco"
-            dev_role = self.get_device_role(dev)
             platform = self.get_device_platform(dev)
             if not PLUGIN_CFG.get("dna_center_import_merakis") and platform == "cisco_meraki":
                 continue
@@ -357,6 +356,7 @@ class DnaCenterAdapter(Adapter):
                 continue
             if dev.get("type") and "Juniper" in dev["type"]:
                 vendor = "Juniper"
+            dev_role = self.get_device_role(dev)
             dev_details = self.conn.get_device_detail(dev_id=dev["id"])
             loc_data = {}
             if dev_details and dev_details.get("siteHierarchyGraphId"):

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -579,7 +579,6 @@ class DnaCenterAdapter(Adapter):
                         )
                         self.load_ipaddress_to_interface(
                             host=host,
-                            mask_length=mask_length,
                             device=dev.name if dev.name else "",
                             port=port["portName"],
                             primary=primary,
@@ -625,19 +624,18 @@ class DnaCenterAdapter(Adapter):
             )
             self.add(new_ip)
 
-    def load_ipaddress_to_interface(self, host: str, mask_length: int, device: str, port: str, primary: bool):  # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def load_ipaddress_to_interface(self, host: str, device: str, port: str, primary: bool):
         """Load DNAC IPAddressOnInterface DiffSync model with specified data.
 
         Args:
             host (str): Host IP Address in mapping.
-            mask_length (int): Subnet mask length for host IP Address.
             device (str): Device that IP resides on.
             port (str): Interface that IP is configured on.
             primary (str): Whether the IP is primary IP for assigned device. Defaults to False.
         """
         self.get_or_instantiate(
             self.ip_on_intf,
-            ids={"host": host, "mask_length": mask_length, "device": device, "port": port},
+            ids={"host": host, "device": device, "port": port},
             attrs={"primary": primary},
         )
 

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -528,7 +528,10 @@ class DnaCenterAdapter(Adapter):
                 for series in ["2700", "2800", "3800", "9120", "9124", "9130", "9136", "9166"]:
                     if series in dev["type"]:
                         platform = "cisco_ios"
-            if not dev.get("softwareType") and dev.get("family") and "Meraki" in dev["family"]:
+            if not dev.get("softwareType") and (
+                (dev.get("family") and "Meraki" in dev["family"])
+                or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "Z")))
+            ):
                 platform = "cisco_meraki"
         return platform
 

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
@@ -327,7 +327,6 @@ class NautobotAdapter(Adapter):
         for mapping in mappings:
             new_ipaddr_to_interface = self.ip_on_intf(
                 host=str(mapping.ip_address.host),
-                mask_length=mapping.ip_address.mask_length,
                 device=mapping.interface.device.name,
                 port=mapping.interface.name,
                 primary=bool(

--- a/nautobot_ssot/integrations/dna_center/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/models/base.py
@@ -160,12 +160,11 @@ class IPAddressOnInterface(DiffSyncModel):
     """DiffSync model for DNA Center tracking IPAddress on particular Device interfaces."""
 
     _modelname = "ip_on_intf"
-    _identifiers = ("host", "mask_length", "device", "port")
+    _identifiers = ("host", "device", "port")
     _attributes = ("primary",)
     _children = {}
 
     host: str
-    mask_length: int
     device: str
     port: str
     primary: bool

--- a/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
@@ -322,6 +322,22 @@ class TestDnaCenterAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
             "Device spine1.abc.in has unknown location in hierarchy so will not be imported."
         )
 
+    def test_load_devices_missing_hostname(self):
+        """Validate handling of a Device when hostname is missing."""
+        device_fixture_no_hostname = [
+            {
+                "id": "12345",
+                "managementIpAddress": "10.0.0.1",
+                "serialNumber": "ABC123",
+                "softwareType": "IOS",
+                "hostname": None,
+            }
+        ]
+        self.dna_center_client.get_devices.return_value = device_fixture_no_hostname
+        self.dna_center.load_devices()
+        self.dna_center.job.logger.warning.assert_called_with("Device 12345 is missing hostname so will be skipped.")
+        self.assertEqual(len(self.dna_center.get_all("device")), 0)
+
     def test_load_ports(self):
         """Test Nautobot SSoT for Cisco DNA Center load_ports() function."""
         self.dna_center.load_devices()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #845 

## What's Changed
This PR fixes a bug where Meraki devices were added to the failed device list even when the `import_meraki` setting is False.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do
N/A
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Unit, Integration Tests
