### PR TITLE
Infoblox integration - Nautobot adapter cache fix

### DIFF
--- a/changes/859.fixed
+++ b/changes/859.fixed
@@ -1,0 +1,1 @@
+Fixed a bug where the cache persisted between sync executions in the Infoblox integration.

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/nautobot.py
@@ -135,7 +135,29 @@ class NautobotAdapter(NautobotMixin, Adapter):  # pylint: disable=too-many-insta
         self.job = job
         self.sync = sync
         self.config = config
+        self._clear_cache()
         self.excluded_cfs = config.cf_fields_ignore.get("custom_fields", [])
+
+    def _clear_cache(self):
+        """Ensure cache stores are empty during each sync run.
+
+        Since the cache is implemented using class attributes, cached values may persist between sync runs.
+        This can lead to subtle bugs caused by cache misses.
+        """
+        for obj_type in [
+            "ipaddr",
+            "location",
+            "namespace",
+            "prefix",
+            "relationship",
+            "role",
+            "status",
+            "tenant",
+            "vlan",
+            "vlangroup",
+            "vrf",
+        ]:
+            getattr(self, f"{obj_type}_map").clear()
 
     def sync_complete(self, source: Adapter, *args, **kwargs):
         """Process object creations/updates using bulk operations.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #859

## What's Changed

Adds logic to clear the cache when initializing the Nautobot adapter in the Infoblox integration. This cache may persist between sync runs and lead to bugs caused by cache misses.