### PR TITLE
SNOW - Gracefully handle duplicates, repair table_query feature

### DIFF
--- a/changes/867.fixed
+++ b/changes/867.fixed
@@ -1,0 +1,3 @@
+- Gracefully swallow ServiceNow exceptions
+- Adds ServiceNow duplicate file reports
+- Fixes ServiceNow comparison filters to only compare against company names with Manufacturer set to True

--- a/docs/admin/integrations/servicenow_setup.md
+++ b/docs/admin/integrations/servicenow_setup.md
@@ -40,6 +40,23 @@ PLUGINS_CONFIG = {
 !!! note
     All integration settings are defined in the block above as an example. Only some will be needed as described below.
 
+## Duplicates
+
+When duplicates records are encountered in ServiceNow this is problematic for Nautobot to identify the correct record to update. The ServiceNow SSOT sync logic will warn you about these duplicate instances but it is up to the end-user to reconcile them for accurate data syncronization.
+
+At the end of an SSOT run, for every ServiceNow table where duplicates were found - a corresponding `duplicate_${table}.txt` file will be present in the results. This is in the format of a CSV file with the top row containing the attribute name and each subsequent row being the element that was found in duplicate.
+
+For example, if multiple product models were discovered you'll see a log warning and a file called `duplicate_product_model.txt` in the SSOT run output with contents such as:
+
+```
+manufacturer_name,model_name,model_number
+Cisco,Catalyst 9300,C9300-48P
+Dell,PowerEdge R740,R740-8SFF
+HP,ProLiant DL360,DL360-G10
+Juniper,EX4300,EX4300-48P
+Arista,7050X3,DCS-7050X3-32S
+```
+
 ## Upgrading from `nautobot-plugin-ssot-servicenow` App
 
 !!! warning

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
@@ -17,7 +17,7 @@ from nautobot_ssot.contrib.model import DiffSyncModel
 from . import models
 
 
-class ServiceNowDiffSync(Adapter):
+class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attributes
     """DiffSync adapter using pysnow to communicate with a ServiceNow server."""
 
     # create defaultdict object to store objects that should be deleted from ServiceNow if they do not
@@ -162,12 +162,12 @@ class ServiceNowDiffSync(Adapter):
         )
 
     def log_duplicate_records(self, model_cls: DiffSyncModel) -> None:
-        """Log any duplicate records that were found during the load process."""
-        if not self.duplicate_records.get(model_cls._modelname, False):
-            self.duplicate_records[model_cls._modelname] = [",".join(model_cls._identifiers)]
-        self.duplicate_records[model_cls._modelname].append(
-            ",".join([getattr(model_cls, attr) for attr in model_cls._identifiers])
-        )
+        """Capture duplicate records in CSV format that were found during the ServiceNow record load."""
+        model_name = model_cls._modelname  # pylint: disable=protected-access
+        model_identifiers = model_cls._identifiers  # pylint: disable=protected-access
+        if not self.duplicate_records.get(model_name, False):
+            self.duplicate_records[model_name] = [",".join(model_identifiers)]
+        self.duplicate_records[model_name].append(",".join([getattr(model_cls, attr) for attr in model_identifiers]))
 
     def load_record(self, table, record, model_cls, mappings, **kwargs):
         """Helper method to load_table()."""

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
@@ -12,6 +12,8 @@ from diffsync.enum import DiffSyncFlags
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
 from jinja2 import Environment, FileSystemLoader
 
+from nautobot_ssot.contrib.model import DiffSyncModel
+
 from . import models
 
 
@@ -49,6 +51,8 @@ class ServiceNowDiffSync(Adapter):
         # to improve performance when a device is created, we use ServiceNow's bulk/batch API to
         # create all of these interfaces in a single API call.
         self.interfaces_to_create_per_device = {}
+
+        self.duplicate_records = defaultdict(list)  # Store duplicate records for user notification
 
     def load(self):
         """Load data via pysnow."""
@@ -102,6 +106,9 @@ class ServiceNowDiffSync(Adapter):
             else:
                 self.load_table(modelname, **entry)
 
+        for modelname, duplicate_uids in self.duplicate_records.items():
+            self.job.create_file(f"duplicate_{modelname}.txt", "\n".join(duplicate_uids))
+
     @classmethod
     def load_yaml_datafile(cls, filename, config=None):
         """Get the contents of the given YAML data file.
@@ -145,9 +152,19 @@ class ServiceNowDiffSync(Adapter):
             for parent in self.get_all(kwargs["parent"]["modelname"]):
                 for record in self.client.all_table_entries(table, {kwargs["parent"]["column"]: parent.sys_id}):
                     self.load_record(table, record, model_cls, mappings, **kwargs)
+        if self.duplicate_records.get(modelname, False):
+            self.job.logger.warning(f"Found {len(self.duplicate_records[modelname])} duplicate {modelname} record(s).")
 
         self.job.logger.info(
             f"Loaded {len(self.get_all(modelname))} {modelname} records from ServiceNow table `{table}`."
+        )
+
+    def log_duplicate_records(self, model_cls: DiffSyncModel) -> None:
+        """Log any duplicate records that were found during the load process."""
+        if not self.duplicate_records.get(model_cls._modelname, False):
+            self.duplicate_records[model_cls._modelname] = [",".join(model_cls._identifiers)]
+        self.duplicate_records[model_cls._modelname].append(
+            ",".join([getattr(model_cls, attr) for attr in model_cls._identifiers])
         )
 
     def load_record(self, table, record, model_cls, mappings, **kwargs):
@@ -163,7 +180,7 @@ class ServiceNowDiffSync(Adapter):
         except ObjectAlreadyExists:
             # The baseline data in a standard ServiceNow developer instance has a number of duplicate Location entries.
             # For now, ignore the duplicate entry and continue
-            self.job.logger.warning(f'Ignoring apparent duplicate record for {modelname} "{model.get_unique_id()}".')
+            self.log_duplicate_records(model)
 
         if "parent" in kwargs:
             parent_uid = getattr(model, kwargs["parent"]["field"])
@@ -174,7 +191,10 @@ class ServiceNowDiffSync(Adapter):
                 )
             else:
                 parent_model = self.get(kwargs["parent"]["modelname"], parent_uid)
+                try:
                 parent_model.add_child(model)
+                except ObjectAlreadyExists:
+                    pass
 
         return model
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #867 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

* Passes through the `table_query` attribute from the servicenow `mappings.yaml`. This is called out in the comments - `Only load companies that are flagged as manufacturer: true, as those correspond to Nautobot Manufacturer records` but in implementation this value was not being referenced anywhere so it was a noOp. I repaired the connection and tested locally to see that it properly only brings in company names that are listed as manufacturers.
* Added file output to give user an indication of all duplicates encountered in each servicenow table.
* Behavior is now to swallow, log overview of how many duplicates encountered, and provide file output outlining what duplicates were encountered.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)