### PR TITLE
fix: 🐛 skip duplicate devices in LibreNMS to resolve job failure

### DIFF
--- a/changes/844.fixed
+++ b/changes/844.fixed
@@ -1,0 +1,1 @@
+Fixed job failure if there are duplicate devices in LibreNMS. Will skip device instead.

--- a/nautobot_ssot/integrations/librenms/diffsync/adapters/librenms.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/adapters/librenms.py
@@ -3,7 +3,7 @@
 import os
 
 from diffsync import DiffSync
-from diffsync.exceptions import ObjectNotFound
+from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
 from django.contrib.contenttypes.models import ContentType
 from nautobot.dcim.models import Location, LocationType
 from nautobot.extras.models import Status
@@ -99,7 +99,10 @@ class LibrenmsAdapter(DiffSync):
                     ip_address=device["ip"],
                     system_of_record=os.getenv("NAUTOBOT_SSOT_LIBRENMS_SYSTEM_OF_RECORD", "LibreNMS"),
                 )
-                self.add(new_device)
+                try:
+                    self.add(new_device)
+                except ObjectAlreadyExists:
+                    self.job.logger.warning(f"Device {device[self.hostname_field]} already exists. Skipping.")
         else:
             self.job.logger.info(f'Device {device[self.hostname_field]} is "ping-only". Skipping.')
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #844

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Added exception handling to skip and log duplicate devices being imported from LibreNMS.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ X ] Explanation of Change(s)
- [ X ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ X ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
