### PR TITLE
bootstrap integration: validatedSW, auto-add missing SW

### DIFF
--- a/changes/880.changed
+++ b/changes/880.changed
@@ -1,0 +1,1 @@
+Changed boostrap integration validated_software creation to automatically add missing software_version's.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
@@ -985,7 +985,6 @@ class BootstrapAdapter(Adapter, LabelMixin):
                     system_of_record=os.getenv("SYSTEM_OF_RECORD", "Bootstrap"),
                 )
             self.add(_new_software)
-            print(f"Added software: {_new_software}")
             if self.job.debug:
                 self.job.logger.debug(f"Loaded Bootstrap Software: {_new_software}")
 

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2691,9 +2691,19 @@ if validate_dlm_installed():
             _object_tags = []  # noqa: F841
             _platform = ORMPlatform.objects.get(name=attrs["platform"])
             if dlm_supports_softwarelcm():
-                _software = ORMSoftware.objects.get(version=attrs["software_version"], device_platform=_platform)
+                _software, created = ORMSoftware.objects.get_or_create(
+                    version=attrs["software_version"], device_platform=_platform
+                )
             if core_supports_softwareversion():
-                _software = ORMSoftware.objects.get(version=attrs["software_version"], platform=_platform)
+                defaults = {"status": ORMStatus.objects.get(name="Active")}
+                _software, created = ORMSoftware.objects.get_or_create(
+                    version=attrs["software_version"], platform=_platform, defaults=defaults
+                )
+            if created:
+                adapter.job.logger.warning(
+                    f"Software Version ({_software}) did not exist, so was automatically created."
+                )
+
             _new_validated_software = ORMValidatedSoftware(
                 software=_software,
                 start=ids["valid_since"] if not None else datetime.today().date(),
@@ -2751,9 +2761,19 @@ if validate_dlm_installed():
             _object_tags = []  # noqa: F841
             _platform = ORMPlatform.objects.get(name=self.platform)
             if dlm_supports_softwarelcm():
-                _software = ORMSoftware.objects.get(version=self.software_version, device_platform=_platform)
+                _software, created = ORMSoftware.objects.get_or_create(
+                    version=self.software_version, device_platform=_platform
+                )
             if core_supports_softwareversion():
-                _software = ORMSoftware.objects.get(version=self.software_version, platform=_platform)
+                defaults = {"status": ORMStatus.objects.get(name="Active")}
+                _software, created = ORMSoftware.objects.get_or_create(
+                    version=self.software_version, platform=_platform, defaults=defaults
+                )
+            if created:
+                self.adapter.job.logger.warning(
+                    f"Software Version ({_software}) did not exist, so was automatically created."
+                )
+
             self.adapter.job.logger.info(f"Updating Validated Software - {self} with attrs {attrs}.")
             _update_validated_software = ORMValidatedSoftware.objects.get(
                 software=_software, start=self.valid_since, end=self.valid_until


### PR DESCRIPTION
When adding ValidatedSoftware, if the software version specified is missing, it will automatically add the software as well.

