### PR TITLE
Update vSphere integration to handle IPv6 properly

### DIFF
--- a/changes/878.fixed
+++ b/changes/878.fixed
@@ -1,0 +1,1 @@
+Fixed inability of vSphere integration to sync IPv6 addresses

--- a/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
@@ -171,3 +171,47 @@ class TestVsphereAdapter(unittest.TestCase):
         self.assertEqual(prefix.prefix_length, 23)
         self.assertEqual(prefix.namespace__name, "Global")
         self.assertEqual(prefix.type, "network")
+
+    def test_load_ipv6_addresses(self):
+        mock_interfaces = unittest.mock.MagicMock()
+        mock_interfaces.json.return_value = json_fixture(f"{FIXTURES}/get_vm_interfaces_ipv6.json")
+        diffsync_virtualmachine, _ = self.vsphere_adapter.get_or_instantiate(
+            self.vsphere_adapter.virtual_machine,
+            {"name": "Nautobot", "cluster__name": "HeshLawCluster"},
+            {
+                "vcpus": 10,
+                "memory": 49152,
+                "disk": 64,
+                "status__name": "Active",
+            },
+        )
+        diffsync_vminterface, _ = self.vsphere_adapter.get_or_instantiate(
+            self.vsphere_adapter.interface,
+            {"name": "Network adapter 1", "virtual_machine__name": "Nautobot"},
+            {
+                "enabled": False,
+                "mac_address": "00:50:56:b5:e5:5f",
+                "status__name": "Active",
+            },
+        )
+
+        self.vsphere_adapter.load_ip_addresses(
+            mock_interfaces.json()["value"],
+            "00:50:56:b5:e5:5f",
+            diffsync_vminterface,
+            diffsync_virtualmachine,
+        )
+        vm_ip = self.vsphere_adapter.get("ip_address", "2001:0db8:85a3:0000:0000:8a2e:0370:7334__64__Active")
+        self.assertEqual(vm_ip.host, "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+        self.assertEqual(vm_ip.mask_length, 64)
+        self.assertEqual(vm_ip.status__name, "Active")
+        self.assertEqual(
+            vm_ip.vm_interfaces,
+            [{"name": "Network adapter 1", "virtual_machine__name": "Nautobot"}],
+        )
+
+        prefix = self.vsphere_adapter.get("prefix", "2001:db8:85a3::__64__Global__Active")
+        self.assertEqual(prefix.network, "2001:db8:85a3::")
+        self.assertEqual(prefix.prefix_length, 64)
+        self.assertEqual(prefix.namespace__name, "Global")
+        self.assertEqual(prefix.type, "network")

--- a/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models.py
@@ -222,7 +222,6 @@ class TestVSphereDiffSyncModelsCreate(TestCase):
             type="network",
         )
         self.vsphere_adapter.add(prefix_test)
-
         nb_adapter = NBAdapter(config=self.config, cluster_filters=None)
         nb_adapter.job = MagicMock()
         nb_adapter.load()
@@ -232,6 +231,27 @@ class TestVSphereDiffSyncModelsCreate(TestCase):
         self.assertEqual(nb_prefix.network, "192.168.10.0")
         self.assertEqual(nb_prefix.prefix_length, 24)
         self.assertEqual(str(nb_prefix.prefix), "192.168.10.0/24")
+        self.assertEqual(nb_prefix.namespace.name, "Global")
+        self.assertEqual(nb_prefix.type, "network")
+
+    def test_prefix_ipv6_creation(self):
+        prefix_test = self.vsphere_adapter.prefix(
+            network="2001:db8:85a3::",
+            prefix_length=64,
+            namespace__name="Global",
+            status__name="Active",
+            type="network",
+        )
+        self.vsphere_adapter.add(prefix_test)
+        nb_adapter = NBAdapter(config=self.config, cluster_filters=None)
+        nb_adapter.job = MagicMock()
+        nb_adapter.load()
+        self.vsphere_adapter.sync_to(nb_adapter)
+
+        nb_prefix = Prefix.objects.get(network="2001:db8:85a3::", prefix_length=64)
+        self.assertEqual(nb_prefix.network, "2001:db8:85a3::")
+        self.assertEqual(nb_prefix.prefix_length, 64)
+        self.assertEqual(str(nb_prefix.prefix), "2001:db8:85a3::/64")
         self.assertEqual(nb_prefix.namespace.name, "Global")
         self.assertEqual(nb_prefix.type, "network")
 
@@ -285,6 +305,59 @@ class TestVSphereDiffSyncModelsCreate(TestCase):
         self.assertEqual(nb_vm.disk, 50)
         self.assertEqual(nb_vm.cluster.name, "TestCluster")
         self.assertEqual(nb_vm.primary_ip.host, "192.168.1.1")
+
+    def test_vm_creation_and_vm_primary_ipv6(self):
+        nb_clustergroup, _ = ClusterGroup.objects.get_or_create(name="TestClusterGroup")
+        nb_clustertype, _ = ClusterType.objects.get_or_create(name="VMWare vSphere")
+        Cluster.objects.create(
+            name="TestCluster",
+            cluster_group=nb_clustergroup,
+            cluster_type=nb_clustertype,
+        )
+
+        vm_test = self.vsphere_adapter.virtual_machine(
+            **_get_virtual_machine_dict(
+                {"name": "TestVM", "primary_ip6__host": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}
+            )
+        )
+        vm_interface_test = self.vsphere_adapter.interface(
+            **_get_virtual_machine_interface_dict({"name": "Network Adapter 1", "virtual_machine__name": "TestVM"})
+        )
+        vm_interface_ip = self.vsphere_adapter.ip_address(
+            host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            mask_length=64,
+            status__name="Active",
+            vm_interfaces=[{"name": "Network Adapter 1", "virtual_machine__name": "TestVM"}],
+        )
+        prefix_test = self.vsphere_adapter.prefix(
+            network="2001:0db8:85a3::",
+            prefix_length=24,
+            namespace__name="Global",
+            status__name="Active",
+            type="network",
+        )
+
+        self.vsphere_adapter.add(vm_test)
+        self.vsphere_adapter.add(vm_interface_test)
+        self.vsphere_adapter.add(vm_interface_ip)
+        self.vsphere_adapter.add(prefix_test)
+        vm_test.add_child(vm_interface_test)
+        vm_interface_test.add_child(vm_interface_ip)
+
+        nb_adapter = NBAdapter(config=self.config, cluster_filters=None)
+        nb_adapter.job = MagicMock()
+        nb_adapter.load()
+        self.vsphere_adapter.sync_to(nb_adapter)
+
+        nb_adapter.sync_complete(source=None, diff=None)
+        nb_vm = VirtualMachine.objects.get(name="TestVM")
+        self.assertEqual(nb_vm.name, "TestVM")
+        self.assertEqual(nb_vm.status.name, "Active")
+        self.assertEqual(nb_vm.vcpus, 3)
+        self.assertEqual(nb_vm.memory, 4096)
+        self.assertEqual(nb_vm.disk, 50)
+        self.assertEqual(nb_vm.cluster.name, "TestCluster")
+        self.assertEqual(nb_vm.primary_ip.host, "2001:db8:85a3::8a2e:370:7334")
 
 
 class TestVSphereDiffSyncModelsUpdate(TestCase):
@@ -616,6 +689,121 @@ class TestVSphereDiffSyncModelsUpdate(TestCase):
         nb_vm = VirtualMachine.objects.get(name="TestVM")
         self.assertEqual(nb_vm.name, "TestVM")
         self.assertEqual(nb_vm.primary_ip.host, "10.10.10.1")
+
+    def test_vm_primary_ip6_update(self):  # pylint: disable=too-many-locals
+        nb_clustergroup, _ = ClusterGroup.objects.get_or_create(name="TestClusterGroup")
+        nb_clustertype, _ = ClusterType.objects.get_or_create(name="VMWare vSphere")
+        nb_cluster = Cluster.objects.create(
+            name="TestCluster",
+            cluster_group=nb_clustergroup,
+            cluster_type=nb_clustertype,
+        )
+        nb_vm = VirtualMachine.objects.create(
+            name="TestVM",
+            status=self.active_status,
+            vcpus=3,
+            memory=4096,
+            disk=50,
+            cluster=nb_cluster,
+        )
+        nb_vm.tags.set([self.ssot_tag])
+        nb_vm_interface_1 = VMInterface.objects.create(
+            name="Network Adapter 1",
+            enabled=True,
+            virtual_machine=nb_vm,
+            mac_address="AA:BB:CC:DD:EE:FF",
+            status=self.active_status,
+        )
+        nb_vm_interface_2 = VMInterface.objects.create(
+            name="Network Adapter 2",
+            enabled=True,
+            virtual_machine=nb_vm,
+            mac_address="BB:BB:BB:BB:BB:BB",
+            status=self.active_status,
+        )
+        Prefix.objects.create(
+            network="fd12:3456:789a:1::",
+            prefix_length=64,
+            namespace=Namespace.objects.get(name="Global"),
+            status=self.active_status,
+            type="network",
+        )
+        Prefix.objects.create(
+            network="2001:db8:abcd:42::",
+            prefix_length=64,
+            namespace=Namespace.objects.get(name="Global"),
+            status=self.active_status,
+            type="network",
+        )
+        nb_ip_1 = IPAddress.objects.create(host="fd12:3456:789a:1::1234", mask_length=64, status=self.active_status)
+        nb_ip_2 = IPAddress.objects.create(host="2001:db8:abcd:42::abcd", mask_length=64, status=self.active_status)
+        nb_ip_1.vm_interfaces.set([nb_vm_interface_1])
+        nb_ip_2.vm_interfaces.set([nb_vm_interface_2])
+        nb_vm.primary_ip6 = nb_ip_1
+        nb_vm.validated_save()
+
+        vm_test = self.vsphere_adapter.virtual_machine(
+            **_get_virtual_machine_dict({"name": "TestVM", "primary_ip6__host": "2001:db8:abcd:42::abcd"})
+        )
+        vm_interface_test_1 = self.vsphere_adapter.interface(
+            **_get_virtual_machine_interface_dict({"name": "Network Adapter 1", "virtual_machine__name": "TestVM"})
+        )
+        vm_interface_test_2 = self.vsphere_adapter.interface(
+            **_get_virtual_machine_interface_dict(
+                {
+                    "name": "Network Adapter 2",
+                    "virtual_machine__name": "TestVM",
+                    "mac_address": "BB:BB:BB:BB:BB:BB",
+                }
+            )
+        )
+        vm_interface_ip_1 = self.vsphere_adapter.ip_address(
+            host="fd12:3456:789a:1::1234",
+            mask_length=64,
+            status__name="Active",
+            vm_interfaces=[{"name": "Network Adapter 1", "virtual_machine__name": "TestVM"}],
+        )
+        vm_interface_ip_2 = self.vsphere_adapter.ip_address(
+            host="2001:db8:abcd:42::abcd",
+            mask_length=64,
+            status__name="Active",
+            vm_interfaces=[{"name": "Network Adapter 2", "virtual_machine__name": "TestVM"}],
+        )
+        prefix_test_1 = self.vsphere_adapter.prefix(
+            network="fd12:3456:789a:1::",
+            prefix_length=64,
+            namespace__name="Global",
+            status__name="Active",
+            type="network",
+        )
+        prefix_test_2 = self.vsphere_adapter.prefix(
+            network="2001:db8:abcd:42::",
+            prefix_length=64,
+            namespace__name="Global",
+            status__name="Active",
+            type="network",
+        )
+        self.vsphere_adapter.add(vm_test)
+        self.vsphere_adapter.add(vm_interface_test_1)
+        self.vsphere_adapter.add(vm_interface_test_2)
+        self.vsphere_adapter.add(vm_interface_ip_1)
+        self.vsphere_adapter.add(vm_interface_ip_2)
+        self.vsphere_adapter.add(prefix_test_1)
+        self.vsphere_adapter.add(prefix_test_2)
+        vm_test.add_child(vm_interface_test_1)
+        vm_test.add_child(vm_interface_test_2)
+        vm_interface_test_1.add_child(vm_interface_ip_1)
+        vm_interface_test_2.add_child(vm_interface_ip_2)
+
+        nb_adapter = NBAdapter(config=self.config, cluster_filters=None)
+        nb_adapter.job = MagicMock()
+        nb_adapter.load()
+
+        self.vsphere_adapter.sync_to(nb_adapter)
+        nb_adapter.sync_complete(source=None, diff=None)
+        nb_vm = VirtualMachine.objects.get(name="TestVM")
+        self.assertEqual(nb_vm.name, "TestVM")
+        self.assertEqual(nb_vm.primary_ip.host, "2001:db8:abcd:42::abcd")
 
 
 class TestVSphereDiffSyncModelsDelete(TestCase):

--- a/nautobot_ssot/tests/vsphere/vsphere_fixtures/get_vm_interfaces_ipv6.json
+++ b/nautobot_ssot/tests/vsphere/vsphere_fixtures/get_vm_interfaces_ipv6.json
@@ -1,0 +1,17 @@
+{
+   "value": [
+      {
+         "mac_address": "00:50:56:b5:e5:5f",
+         "ip": {
+            "ip_addresses": [
+               {
+                  "ip_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                  "prefix_length": 64,
+                  "state": "PREFERRED"
+               }
+            ]
+         },
+         "nic": "4000"
+      }
+   ]
+}

--- a/tasks.py
+++ b/tasks.py
@@ -899,6 +899,7 @@ def unittest(  # noqa: PLR0913
     verbose=False,
     coverage=False,
     skip_docs_build=False,
+    pdb=False,
 ):
     """Run Nautobot unit tests."""
     if not skip_docs_build:
@@ -918,6 +919,8 @@ def unittest(  # noqa: PLR0913
         command += f" -k='{pattern}'"
     if verbose:
         command += " --verbosity 2"
+    if pdb:
+        command += " --pdb"
 
     run_command(context, command)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #878

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
The vSphere integration was not properly accounting for IPv6 prefix calculation when it deduced a prefix from a given IP address. I've gone and updated the logic so that it can properly create an IPv6 prefix for a given IPv6 address. 

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
