### PR TITLE
Handle HTTP 404 exception case for expired an A record and PTR reference

### DIFF
--- a/changes/596.fixed
+++ b/changes/596.fixed
@@ -1,0 +1,1 @@
++ Handles HTTP 404 exception case for expired A record and PTR reference, and logs as a warning instead of failing the job run.

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -335,7 +335,13 @@ class InfobloxAdapter(Adapter):
             ip_record (object): Parent IP Address record
             namespace (str): Namespace of this record
         """
-        a_record = self.conn.get_a_record_by_ref(ref)
+        try:
+            a_record = self.conn.get_a_record_by_ref(ref)
+        except requests.exceptions.HTTPError as exc:
+            if exc.response.status_code == 404:
+                self.job.logger.warning(message=f"A record {ref} not found, likely dynamic and expired.")
+                return
+            raise
         record_ext_attrs = get_ext_attr_dict(extattrs=a_record.get("extattrs", {}), excluded_attrs=self.excluded_attrs)
 
         new_a_record = self.dnsarecord(
@@ -361,7 +367,13 @@ class InfobloxAdapter(Adapter):
             ip_record (object): Parent IP Address record
             namespace (str): Namespace of this record
         """
-        ptr_record = self.conn.get_ptr_record_by_ref(ref)
+        try:
+            ptr_record = self.conn.get_ptr_record_by_ref(ref)
+        except requests.exceptions.HTTPError as exc:
+            if exc.response.status_code == 404:
+                self.job.logger.warning(message=f"PTR record {ref} not found, likely dynamic and expired.")
+                return
+            raise
         record_ext_attrs = get_ext_attr_dict(
             extattrs=ptr_record.get("extattrs", {}), excluded_attrs=self.excluded_attrs
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #596

## What's Changed

Handle HTTP 404 exception case for expired A record and PTR reference, instead of the failing our job we log the event as a warning.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
