### PR TITLE
Remove expired A and PTR records left when HTTP 404 is seen

### DIFF
--- a/changes/922.fixed
+++ b/changes/922.fixed
@@ -1,0 +1,1 @@
+Remove stale A and PTR records when HTTP 404 is seen.

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -340,6 +340,23 @@ class InfobloxAdapter(Adapter):
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == 404:
                 self.job.logger.warning(message=f"A record {ref} not found, likely dynamic and expired.")
+                # remove any existing stale A record from Nautobot
+                try:
+                    stale = self.dnsarecord(
+                        address=ip_record.address,
+                        prefix=ip_record.prefix,
+                        prefix_length=ip_record.prefix_length,
+                        namespace=namespace,
+                        dns_name="",
+                        ip_addr_type=ip_record.ip_addr_type,
+                        description="",
+                        status=ip_record.status,
+                        ext_attrs={},
+                        ref=ref
+                    )
+                    self.remove(stale)
+                except Exception:
+                    pass
                 return
             raise
         record_ext_attrs = get_ext_attr_dict(extattrs=a_record.get("extattrs", {}), excluded_attrs=self.excluded_attrs)
@@ -372,6 +389,23 @@ class InfobloxAdapter(Adapter):
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == 404:
                 self.job.logger.warning(message=f"PTR record {ref} not found, likely dynamic and expired.")
+                # remove any existing stale PTR record from Nautobot
+                try:
+                    stale = self.dnsptrrecord(
+                        address=ip_record.address,
+                        prefix=ip_record.prefix,
+                        prefix_length=ip_record.prefix_length,
+                        namespace=namespace,
+                        dns_name="",
+                        ip_addr_type=ip_record.ip_addr_type,
+                        description="",
+                        status=ip_record.status,
+                        ext_attrs={},
+                        ref=ref
+                    )
+                    self.remove(stale)
+                except Exception:
+                    pass
                 return
             raise
         record_ext_attrs = get_ext_attr_dict(

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -355,7 +355,7 @@ class InfobloxAdapter(Adapter):
                         ref=ref
                     )
                     self.remove(stale)
-                except Exception:
+                except Exception:  # noqa: S110
                     pass
                 return
             raise
@@ -371,7 +371,7 @@ class InfobloxAdapter(Adapter):
             description=a_record.get("comment") or "",
             status=ip_record.status,
             ext_attrs=record_ext_attrs,
-            ref=ref,
+            ref=ref
         )
 
         self.add(new_a_record)
@@ -404,7 +404,7 @@ class InfobloxAdapter(Adapter):
                         ref=ref
                     )
                     self.remove(stale)
-                except Exception:
+                except Exception:  # noqa: S110
                     pass
                 return
             raise

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -352,7 +352,7 @@ class InfobloxAdapter(Adapter):
                         description="",
                         status=ip_record.status,
                         ext_attrs={},
-                        ref=ref
+                        ref=ref,
                     )
                     self.remove(stale)
                 except Exception:  # noqa: S110
@@ -371,7 +371,7 @@ class InfobloxAdapter(Adapter):
             description=a_record.get("comment") or "",
             status=ip_record.status,
             ext_attrs=record_ext_attrs,
-            ref=ref
+            ref=ref,
         )
 
         self.add(new_a_record)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #922 

## What's Changed

We will attempt to remove "stale" records when we see the HTTP 404 for A and PTR records

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
