### PR TITLE
Fix issue with metadata_type when contrib models are used without the contrib adapter.

### DIFF
--- a/changes/926.fixed
+++ b/changes/926.fixed
@@ -1,0 +1,1 @@
+Fix issue with metadata_type when contrib models are used without the contrib adapter.

--- a/changes/926.fixed
+++ b/changes/926.fixed
@@ -1,1 +1,1 @@
-Fix issue with metadata_type when contrib models are used without the contrib adapter.
+Fixed issue with metadata_type when contrib models are used without the contrib adapter.

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -76,7 +76,7 @@ class NautobotModel(DiffSyncModel):
         try:
             obj = self.get_from_db()
             self._update_obj_with_parameters(obj, attrs, self.adapter)
-            if hasattr(self.adapter, "metadata_type") and self.adapter.metadata_type:
+            if getattr(self.adapter, "metadata_type", None):
                 self._update_obj_metadata(obj, self.adapter)
         except ObjectCrudException as error:
             raise ObjectNotUpdated(error) from error
@@ -110,7 +110,7 @@ class NautobotModel(DiffSyncModel):
         except ObjectCrudException as error:
             raise ObjectNotCreated(error) from error
 
-        if hasattr(adapter, "metadata_type") and adapter.metadata_type:
+        if getattr(adapter, "metadata_type", None):
             try:
                 cls._update_obj_metadata(obj, adapter)
             except ObjectCrudException as error:

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -76,7 +76,7 @@ class NautobotModel(DiffSyncModel):
         try:
             obj = self.get_from_db()
             self._update_obj_with_parameters(obj, attrs, self.adapter)
-            if self.adapter.metadata_type:
+            if hasattr(self.adapter, "metadata_type") and self.adapter.metadata_type:
                 self._update_obj_metadata(obj, self.adapter)
         except ObjectCrudException as error:
             raise ObjectNotUpdated(error) from error
@@ -110,7 +110,7 @@ class NautobotModel(DiffSyncModel):
         except ObjectCrudException as error:
             raise ObjectNotCreated(error) from error
 
-        if adapter.metadata_type:
+        if hasattr(adapter, "metadata_type") and adapter.metadata_type:
             try:
                 cls._update_obj_metadata(obj, adapter)
             except ObjectCrudException as error:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #926

## What's Changed

When using contrib models without the contrib adapter, the `metadata_type` attribute is missing from the adapter instance during model [creation](https://github.com/nautobot/nautobot-app-ssot/blob/a20baa131ab1c30d51d24f8cc8ea43fc92cf3e2b/nautobot_ssot/contrib/model.py#L113) or [update](https://github.com/nautobot/nautobot-app-ssot/blob/a20baa131ab1c30d51d24f8cc8ea43fc92cf3e2b/nautobot_ssot/contrib/model.py#L79). To fix this, I first check whether the `metadata_type` attribute exists on the adapter instance, and then evaluate its value if present.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
