### PR TITLE
Fix _handle_single_parameter metadata `key` vs `name` inconsistency

### DIFF
--- a/changes/723.fixed
+++ b/changes/723.fixed
@@ -1,0 +1,1 @@
+Fixed `_handle_single_parameter` metadata key vs name inconsistency.

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -78,8 +78,9 @@ class NautobotAdapter(DiffSync):
         metadata_for_this_field = getattr(type_hints[parameter_name], "__metadata__", [])
         for metadata in metadata_for_this_field:
             if isinstance(metadata, CustomFieldAnnotation):
-                if metadata.name in database_object.cf:
-                    parameters[parameter_name] = database_object.cf[metadata.key]
+                field_key = metadata.key or metadata.name
+                if field_key in database_object.cf:
+                    parameters[parameter_name] = database_object.cf[field_key]
                 is_custom_field = True
                 break
             if isinstance(metadata, CustomRelationshipAnnotation):

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -78,6 +78,8 @@ class NautobotAdapter(DiffSync):
         metadata_for_this_field = getattr(type_hints[parameter_name], "__metadata__", [])
         for metadata in metadata_for_this_field:
             if isinstance(metadata, CustomFieldAnnotation):
+                # if metadata.name in database_object.cf:
+                #     parameters[parameter_name] = database_object.cf[metadata.key]
                 field_key = metadata.key or metadata.name
                 if field_key in database_object.cf:
                     parameters[parameter_name] = database_object.cf[field_key]

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -78,8 +78,6 @@ class NautobotAdapter(DiffSync):
         metadata_for_this_field = getattr(type_hints[parameter_name], "__metadata__", [])
         for metadata in metadata_for_this_field:
             if isinstance(metadata, CustomFieldAnnotation):
-                # if metadata.name in database_object.cf:
-                #     parameters[parameter_name] = database_object.cf[metadata.key]
                 field_key = metadata.key or metadata.name
                 if field_key in database_object.cf:
                     parameters[parameter_name] = database_object.cf[field_key]

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -395,7 +395,7 @@ class NautobotModel(DiffSyncModel):
                 ) from error
             except MultipleObjectsReturned as error:
                 raise ObjectCrudException(
-                    f"Found multiple instances for {field_name} wit: {related_model_dict}"
+                    f"Found multiple instances for {field_name} with: {related_model_dict}"
                 ) from error
             setattr(obj, field_name, related_object)
 

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -215,7 +215,7 @@ class NautobotAdapterTests(TestCase):
         """
 
         custom_field, _ = extras_models.CustomField.objects.update_or_create(
-            key="fallback_test", 
+            key="fallback_test",
             defaults={"label": "Custom Field for fallback test"},
         )
         custom_field.content_types.set([ContentType.objects.get_for_model(tenancy_models.Tenant)])
@@ -226,6 +226,7 @@ class NautobotAdapterTests(TestCase):
 
         class TestModel(NautobotModel):
             """Test model"""
+
             _model = tenancy_models.Tenant
             _modelname = "tenant"
             _identifiers = ("name",)
@@ -236,6 +237,7 @@ class NautobotAdapterTests(TestCase):
 
         class Adapter(NautobotAdapter):
             """Test adapter"""
+
             top_level = ["tenant"]
             tenant = TestModel
 


### PR DESCRIPTION
# Closes: #723 

## What's Changed
Adjusted _handle_single_parameter to correctly implement the intent from the `CustomFieldAnnotation` docstring:
```
    Note that for backwards compatibility purposes it is also possible to use `CustomFieldAnnotation.name` instead of
    `CustomFieldAnnotation.key`.
```

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Unit, Integration Tests

# BEFORE FIX
![Screenshot 2025-08-13 111337](https://github.com/user-attachments/assets/e5248740-adf1-4563-8d66-0e0e58ba8cc0)

# AFTER FIX
![Screenshot 2025-08-13 114040](https://github.com/user-attachments/assets/d4241aac-e9a2-4264-8db3-02216f6b9fb7)
