### PR TITLE
Fix Citrix ADM Throwing IP Error

### DIFF
--- a/changes/940.fixed
+++ b/changes/940.fixed
@@ -1,0 +1,1 @@
+Fixed error in Citrix ADM integration when attempting to assign an IP Address to an Interface.

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -299,11 +299,10 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 ):
                     continue
                 if not is_ip_within(ipaddr.prefix, prefix.prefix):
-                    host_addr = ipaddr.address.split("/")[0]
-                    if is_ip_within(host_addr, prefix.prefix):
+                    if is_ip_within(ipaddr.host_address, prefix.prefix):
                         if self.job.debug:
                             self.job.logger.debug(
-                                "More specific Prefix %s found for IPAddress %s", prefix.prefix, ipaddr.address
+                                "More specific Prefix %s found for IPAddress %s", prefix.prefix, ipaddr.host_address
                             )
                         ipaddr.prefix = prefix.prefix
                         self.update(ipaddr)

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -204,7 +204,7 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                         tags=_tags,
                     )
                     self.load_address_to_interface(
-                        address=addr,
+                        host_addr=port["ipaddress"],
                         device=adc["hostname"],
                         port=port["port"],
                         primary=_primary,
@@ -274,20 +274,18 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             },
         )
 
-    def load_address_to_interface(self, address: str, device: str, port: str, primary: bool = False):
+    def load_address_to_interface(self, host_addr: str, device: str, port: str, primary: bool = False):
         """Load CitrixAdmIPAddressOnInterface DiffSync model with specified data.
 
         Args:
-            address (str): IP Address in mapping. Expected in CIDR notation (e.g. "10.0.0.1/24").
+            host_addr (str): IP Address in mapping, e.g. "10.0.0.1".
             device (str): Device that IP resides on.
             port (str): Interface that IP is configured on.
             primary (str): Whether the IP is primary IP for assigned device. Defaults to False.
         """
-        try:
-            self.get(self.ip_on_intf, {"address": address, "device": device, "port": port})
-        except ObjectNotFound:
-            new_map = self.ip_on_intf(address=address, device=device, port=port, primary=primary, uuid=None)
-            self.add(new_map)
+        self.get_or_instantiate(
+            self.ip_on_intf, ids={"host_address": host_addr, "device": device, "port": port}, attrs={"primary": primary}
+        )
 
     def find_closer_parent_prefix(self) -> None:
         """Find more accurate parent Prefix for loaded IPAddresses."""

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/citrix_adm.py
@@ -198,7 +198,8 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                         _tags.sort()
                     _primary = bool("MGMT" in _tags or "MIP" in _tags)
                     self.load_address(
-                        address=addr,
+                        host_addr=port["ipaddress"],
+                        mask_length=port["netmask"],
                         prefix=prefix,
                         tags=_tags,
                     )
@@ -254,34 +255,30 @@ class CitrixAdmAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             )
             self.add(new_pf)
 
-    def load_address(self, address: str, prefix: str, tags: Optional[list] = None):
+    def load_address(self, host_addr: str, mask_length: int, prefix: str, tags: Optional[list] = None):
         """Load CitrixAdmAddress DiffSync model with specified data.
 
         Args:
-            address (str): IP Address to be loaded.
+            host_addr (str): IP Address to be loaded.
+            mask_length (int): Mask length for IP Address.
             prefix (str): Prefix that IP Address resides in.
-            device (str): Device that IP resides on.
-            port (str): Interface that IP is configured on.
-            primary (str): Whether the IP is primary IP for assigned device. Defaults to False.
             tags (list): List of tags assigned to IP. Defaults to None.
         """
-        try:
-            self.get(self.address, {"address": address, "prefix": prefix})
-        except ObjectNotFound:
-            new_addr = self.address(
-                address=address,
-                prefix=prefix,
-                tenant=self.tenant.name if self.tenant else None,
-                uuid=None,
-                tags=tags if tags else [],
-            )
-            self.add(new_addr)
+        self.get_or_instantiate(
+            self.address,
+            ids={"host_address": host_addr, "tenant": self.tenant.name if self.tenant else None},
+            attrs={
+                "mask_length": mask_length,
+                "prefix": prefix,
+                "tags": tags if tags else [],
+            },
+        )
 
     def load_address_to_interface(self, address: str, device: str, port: str, primary: bool = False):
         """Load CitrixAdmIPAddressOnInterface DiffSync model with specified data.
 
         Args:
-            address (str): IP Address in mapping.
+            address (str): IP Address in mapping. Expected in CIDR notation (e.g. "10.0.0.1/24").
             device (str): Device that IP resides on.
             port (str): Interface that IP is configured on.
             primary (str): Whether the IP is primary IP for assigned device. Defaults to False.

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/nautobot.py
@@ -156,7 +156,8 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             addresses = IPAddress.objects.filter(_custom_field_data__system_of_record="Citrix ADM")
         for addr in addresses:
             new_ip = self.address(
-                address=str(addr.address),
+                host_address=str(addr.host),
+                mask_length=addr.mask_length,
                 prefix=str(addr.parent.prefix),
                 tenant=addr.tenant.name if addr.tenant else None,
                 uuid=addr.id,

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/adapters/nautobot.py
@@ -168,7 +168,7 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             self.add(new_ip)
             for mapping in IPAddressToInterface.objects.filter(ip_address=addr):
                 new_mapping = self.ip_on_intf(
-                    address=str(addr.address),
+                    host_address=str(addr.host),
                     device=mapping.interface.device.name,
                     port=mapping.interface.name,
                     primary=len(addr.primary_ip4_for.all()) > 0 or len(addr.primary_ip6_for.all()) > 0,

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/base.py
@@ -105,11 +105,12 @@ class Address(DiffSyncModel):
     """DiffSync model for Citrix ADM IP Addresses."""
 
     _modelname = "address"
-    _identifiers = ("address", "prefix")
-    _attributes = ("tenant", "tags")
+    _identifiers = ("host_address", "tenant")
+    _attributes = ("mask_length", "prefix", "tags")
     _children = {}
 
-    address: str
+    host_address: str
+    mask_length: int
     prefix: str
     tenant: Optional[str] = None
     tags: Optional[list] = None

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/base.py
@@ -122,11 +122,11 @@ class IPAddressOnInterface(DiffSyncModel):
     """DiffSync model for Citrix ADM tracking IPAddress on particular Device interfaces."""
 
     _modelname = "ip_on_intf"
-    _identifiers = ("address", "device", "port")
+    _identifiers = ("host_address", "device", "port")
     _attributes = ("primary",)
     _children = {}
 
-    address: str
+    host_address: str
     device: str
     port: str
     primary: bool

--- a/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/citrix_adm/diffsync/models/nautobot.py
@@ -316,8 +316,9 @@ class NautobotIPAddressOnInterface(IPAddressOnInterface):
     @classmethod
     def create(cls, adapter, ids, attrs):
         """Create IPAddressToInterface in Nautobot from IPAddressOnInterface object."""
+        tenant_name = adapter.job.tenant.name if adapter.job.tenant else "Global"
         new_map = IPAddressToInterface(
-            ip_address=IPAddress.objects.get(address=ids["address"]),
+            ip_address=IPAddress.objects.get(host=ids["host_address"], parent__namespace__name=tenant_name),
             interface=Interface.objects.get(name=ids["port"], device__name=ids["device"]),
         )
         new_map.validated_save()

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
@@ -129,7 +129,8 @@ class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
         self.citrix_adm.load_addresses()
         self.citrix_adm.load_prefix.assert_called_with(prefix="192.168.1.0/24")
         self.citrix_adm.load_address.assert_called_with(
-            address="192.168.1.5/24",
+            host_addr="192.168.1.5",
+            mask_length=24,
             prefix="192.168.1.0/24",
             tags=["MGMT"],
         )
@@ -144,9 +145,9 @@ class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
 
     def test_load_address(self):
         """Test the Nautobot SSoT Citrix ADM load_address() function."""
-        self.citrix_adm.load_address(address="10.0.0.1/24", prefix="10.0.0.0/24", tags=["TEST"])
+        self.citrix_adm.load_address(host_addr="10.0.0.1", mask_length=24, prefix="10.0.0.0/24", tags=["TEST"])
         self.assertEqual(
-            {"10.0.0.1/24__10.0.0.0/24"},
+            {"10.0.0.1__None"},
             {addr.get_unique_id() for addr in self.citrix_adm.get_all("address")},
         )
 

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
@@ -135,7 +135,7 @@ class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
             tags=["MGMT"],
         )
         self.citrix_adm.load_address_to_interface.assert_called_with(
-            address="192.168.1.5/24", device="TEST", port="0/1", primary=True
+            host_addr="192.168.1.5", device="TEST", port="0/1", primary=True
         )
 
     def test_load_prefix(self):
@@ -153,7 +153,7 @@ class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
 
     def test_load_address_to_interface(self):
         """Test the Nautobot SSoT Citrix ADM load_address_to_interface() function."""
-        self.citrix_adm.load_address_to_interface(address="10.0.0.1/24", device="TEST", port="mgmt", primary=True)
+        self.citrix_adm.load_address_to_interface(host_addr="10.0.0.1", device="TEST", port="mgmt", primary=True)
         self.assertEqual(
-            {"10.0.0.1/24__TEST__mgmt"}, {map.get_unique_id() for map in self.citrix_adm.get_all("ip_on_intf")}
+            {"10.0.0.1__TEST__mgmt"}, {map.get_unique_id() for map in self.citrix_adm.get_all("ip_on_intf")}
         )

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
@@ -169,8 +169,8 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         self.nb_adapter.load_addresses()
         self.assertEqual(
             {
-                "10.1.1.1/24__10.1.1.0/24",
-                "2001:db8:3333:4444:5555:6666:7777:8888/128__2001:db8:3333:4444:5555:6666:7777:8888/128",
+                "10.1.1.1__Test",
+                "2001:db8:3333:4444:5555:6666:7777:8888__Test",
             },
             {addr.get_unique_id() for addr in self.nb_adapter.get_all("address")},
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #940 

## What's Changed
This PR fixes the issue in the Citrix ADM integration where an error is thrown when creating an IPAddressToInterface object.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do
N/A
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Unit, Integration Tests
