### PR TITLE
Patch 596 handleinfoblox404

### DIFF
--- a/changes/596.fixed
+++ b/changes/596.fixed
@@ -1,0 +1,1 @@
+Use required default arg ("msg") instead of kwarg ("message") when using self.job.logger.

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -339,7 +339,7 @@ class InfobloxAdapter(Adapter):
             a_record = self.conn.get_a_record_by_ref(ref)
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == 404:
-                self.job.logger.warning(message=f"A record {ref} not found, likely dynamic and expired.")
+                self.job.logger.warning(f"A record {ref} not found, likely dynamic and expired.")
                 return
             raise
         record_ext_attrs = get_ext_attr_dict(extattrs=a_record.get("extattrs", {}), excluded_attrs=self.excluded_attrs)
@@ -371,7 +371,7 @@ class InfobloxAdapter(Adapter):
             ptr_record = self.conn.get_ptr_record_by_ref(ref)
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == 404:
-                self.job.logger.warning(message=f"PTR record {ref} not found, likely dynamic and expired.")
+                self.job.logger.warning(f"PTR record {ref} not found, likely dynamic and expired.")
                 return
             raise
         record_ext_attrs = get_ext_attr_dict(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #596 

## What's Changed

This bug was marked "Closed" but is still an ongoing issue.  The calls to logger were using kwarg `message=` when the class was expecting the default kwarg `msg=`.  

I've changed the two places where this is configured in the Infoblox diffsync adapter. 