### PR TITLE
Remove expired Host records left when HTTP 404 is seen

### DIFF
--- a/changes/945.fixed
+++ b/changes/945.fixed
@@ -1,0 +1,1 @@
+Apply MeganerdDev's fix from #923 (Fixes #922) to Host Record lookups.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #945

## What's Changed

Apply MeganerdDev's solution from #923 (Fixes #922) to `_load_dns_host_record_for_ip()`.  922 only addresses A and PTR records, but this issue also occurs with Host records.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
