### PR TITLE
fix(ssot/dnac): Process devices with unrecognized platforms instead o…

### DIFF
--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -522,9 +522,16 @@ class DnaCenterAdapter(Adapter):
             platform = DNA_CENTER_LIB_MAPPER[dev["softwareType"]]
         else:
             if not dev.get("softwareType") and dev.get("type"):
-                for series in ["2700", "2800", "3800", "9120", "9124", "9130", "9136", "9166"]:
+                for series in ["2700", "2800", "3800", "9120", "9124", "9130", "9136", "9166", "9115"]:
                     if series in dev["type"]:
                         platform = "cisco_ios"
+                        break
+
+                for series in ["8540", "1850", "1562"]:
+                    if series in dev["type"]:
+                        platform = "cisco_aireos"
+                        break
+
             if (
                 (dev.get("family") and "Meraki" in dev["family"])
                 or (dev.get("platformId") and dev["platformId"].startswith(("MX", "MS", "MR", "Z")))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #908

## What's Changed

When syncing some devices from Cisco DNA Center, the SSoT job would silently skip creating or updating any device whose platform was not recognized or explicitly mapped, such as certain models of Cisco Wireless APs.

This resulted in an incomplete synchronization where these devices would be missing in Nautobot, but the job would still report as successful, making the data discrepancy difficult to notice.

This commit modifies the device processing logic to ensure that devices are no longer skipped due to an unrecognized platform. Now, these devices are correctly identified and synced into Nautobot, leading to a more complete and accurate inventory representation.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
