### PR TITLE
Use query for notes key on Meraki get-organization-devices API response since key might be omitted

### DIFF
--- a/changes/962.fixed
+++ b/changes/962.fixed
@@ -1,0 +1,1 @@
+Meraki get-organization-devices API may omit notes key in response, changed slice to get() on the dictionary payload.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -113,7 +113,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                             "controller_group": self.job.instance.controller_managed_device_groups.first().name
                             if self.job.instance.controller_managed_device_groups.count() != 0
                             else "",
-                            "notes": dev["notes"].rstrip(),
+                            "notes": dev.get("notes", "").rstrip(),
                             "serial": dev["serial"],
                             "status": status,
                             "role": role,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #962 

## What's Changed
Since the `notes` key might not always be included in the API response, use a `.get()` instead of a slice

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
