### PR TITLE
Fix Bootstrap Software deletion error.

### DIFF
--- a/changes/980.fixed
+++ b/changes/980.fixed
@@ -1,0 +1,1 @@
+Fix Bootstrap SoftwareVersion deletion error.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2867,7 +2867,11 @@ class NautobotSoftware(_Software_Base_Class):
         """Delete Software in Nautobot from NautobotSoftware object."""
         try:
             _platform = ORMPlatform.objects.get(name=self.platform)
-            _software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
+            if dlm_supports_softwarelcm():
+                _software = ORMSoftware.objects.get(version=self.version, device_platform=_platform)
+            if core_supports_softwareversion():
+                _software = ORMSoftware.objects.get(version=self.version, platform=_platform)
+            self.adapter.job.logger.warning(f"Deleting Nautobot Software Object ({self.platform} - {self.version}.)")
             super().delete()
             _software.delete()
             return self


### PR DESCRIPTION
# Closes: #980

## What's Changed

Adds the check for DLM vs Nautobot support for SoftwareVersions to the delete() method, as is already in use in the create() and update() methods.

