### PR TITLE
Fix Bootstrap Software Deletion Exception if Software has reference to a Device

### DIFF
--- a/changes/982.fixed
+++ b/changes/982.fixed
@@ -1,0 +1,1 @@
+Fixed Exception when attempting to delete Software referenced by a Device.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2879,6 +2879,10 @@ class NautobotSoftware(_Software_Base_Class):
             self.adapter.job.logger.warning(
                 f"Unable to find Software {self.platform} - {self.version} for deletion. {err}"
             )
+        except ProtectedError as err:
+            self.adapter.job.logger.warning(
+                f"Unable to delete Software {self.platform} - {self.version}, as it is referenced by another object. {err}"
+            )
 
 
 class NautobotSoftwareImage(_SoftwareImage_Base_Class):


### PR DESCRIPTION
## What's Changed

Logs a Warning instead of raising an Exception, if SoftwareVersion object has a reference and cannot be deleted.
