### PR TITLE
Fixes a filtering issue inside the log table within a sync detailed view

### DIFF
--- a/changes/1049.fixed
+++ b/changes/1049.fixed
@@ -1,0 +1,1 @@
+Fixed filtering bug inside log table within sync view.

--- a/nautobot_ssot/views.py
+++ b/nautobot_ssot/views.py
@@ -35,6 +35,7 @@ from nautobot.apps.views import (
     get_obj_from_context,
 )
 from nautobot.core.ui.utils import flatten_context
+from nautobot.core.views.paginator import get_paginate_count
 from nautobot.extras.models import Job as JobModel
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -332,10 +333,9 @@ class SyncUIViewSet(
                     ObjectsTablePanel(
                         weight=100,
                         section=SectionChoices.FULL_WIDTH,
-                        table_class=SyncLogEntryTable,
-                        table_filter="sync",
                         related_field_name="sync",
                         tab_id="logentries",
+                        context_table_key="logs_table",
                         enable_bulk_actions=False,
                         include_paginator=True,
                     ),
@@ -359,7 +359,17 @@ class SyncUIViewSet(
     @action(detail=True, url_path="logs", custom_view_base_action="view")
     def logentries(self, request, *args, **kwargs):
         """Log entries action for Sync UIViewSet."""
-        return Response({})
+        sync = self.get_object()
+        queryset = sync.logs.all()
+        filterset = SyncLogEntryFilterSet(request.GET, queryset=queryset, request=request)
+
+        table = SyncLogEntryTable(filterset.qs, user=request.user)
+        RequestConfig(
+            request,
+            paginate={"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)},
+        ).configure(table)
+
+        return Response({"logs_table": table})
 
     @action(detail=True, url_path="jobresult", custom_view_base_action="view")
     def jobresult(self, request, *args, **kwargs):


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1049 

## What's Changed

Changed the ObjectTablePanel used for log display within a Sync detailed view to use a table that is loaded inside the `logentries @action` instead of using the `table_class` attribute in the panel.  The `table_class` attribute appears to ignore any attempts to filter the queryset.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
