### PR TITLE
Fixed performance issue with SSoT Logs table view

### DIFF
--- a/changes/1055.fixed
+++ b/changes/1055.fixed
@@ -1,0 +1,1 @@
+Fixed a performance issue with the SSoT log entries table view.

--- a/nautobot_ssot/tests/test_views.py
+++ b/nautobot_ssot/tests/test_views.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from unittest import skip
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from nautobot.apps.testing import ViewTestCases
 from nautobot.core.testing.utils import disable_warnings
@@ -13,6 +15,7 @@ from nautobot.users.models import ObjectPermission
 
 from nautobot_ssot.choices import SyncLogEntryActionChoices, SyncLogEntryStatusChoices
 from nautobot_ssot.models import Sync, SyncLogEntry
+from nautobot_ssot.views import SyncLogEntryUIViewSet
 
 
 class SyncViewsTestCase(  # pylint: disable=too-many-ancestors
@@ -150,7 +153,7 @@ class SyncLogEntryViewsTestCase(ViewTestCases.ListObjectsViewTestCase):  # pylin
             target="Nautobot",
             start_time=datetime.now(),
             dry_run=False,
-            diff={},
+            diff={"foo": "bar"},
             job_result=job_result,
         )
 
@@ -169,3 +172,45 @@ class SyncLogEntryViewsTestCase(ViewTestCases.ListObjectsViewTestCase):  # pylin
     @skip("Not implemented")
     def test_list_objects_with_constrained_permission(self):
         pass
+
+    def test_queryset_optimization(self):
+        """Test that the SyncLogEntry queryset uses select_related and only() correctly."""
+        # Get the queryset from the viewset
+        queryset = SyncLogEntryUIViewSet.queryset
+
+        # Evaluate the queryset to get all log entries
+        # This should trigger a single query with select_related
+        with CaptureQueriesContext(connection) as ctx:
+            log_entries = list(queryset.all())
+
+        # Should have exactly 1 query (the main query with select_related)
+        self.assertEqual(len(ctx.captured_queries), 1, "Queryset should use select_related to fetch in one query")
+
+        # Verify we have log entries
+        self.assertGreater(len(log_entries), 0)
+
+        # Test that accessing sync-related fields doesn't trigger additional queries
+        with CaptureQueriesContext(connection) as ctx:
+            for entry in log_entries:
+                # Access all the sync fields that are specified in the only() clause
+                _ = entry.sync.id
+                _ = entry.sync.source
+                _ = entry.sync.target
+                _ = entry.sync.start_time
+                # Also test accessing the sync object itself (for __str__)
+                _ = str(entry.sync)
+
+        # Should have 0 additional queries since select_related was used
+        self.assertEqual(len(ctx.captured_queries), 0, "Accessing sync fields should not trigger additional queries")
+
+        # Verify that sync.diff was NOT loaded (it's not in the only() clause)
+        # Accessing it should trigger an additional query
+        with CaptureQueriesContext(connection) as ctx:
+            _ = log_entries[0].sync.diff
+
+        # Should have 1 additional query to fetch the deferred diff field
+        self.assertEqual(
+            len(ctx.captured_queries),
+            1,
+            "Accessing sync.diff should trigger an additional query since it wasn't loaded in the original queryset",
+        )

--- a/nautobot_ssot/views.py
+++ b/nautobot_ssot/views.py
@@ -373,7 +373,23 @@ class SyncLogEntryUIViewSet(ObjectListViewMixin):
     filterset_class = SyncLogEntryFilterSet
     filterset_form_class = SyncLogEntryFilterForm
     lookup_field = "pk"
-    queryset = SyncLogEntry.objects.all()
+    queryset = SyncLogEntry.objects.select_related("sync").only(
+        "id",
+        "timestamp",
+        "sync_id",
+        "action",
+        "status",
+        "diff",
+        "message",
+        "synced_object_type",
+        "synced_object_id",
+        "object_repr",
+        # Sync fields needed for __str__ and link rendering
+        "sync__id",
+        "sync__source",
+        "sync__target",
+        "sync__start_time",
+    )
     serializer_class = serializers.SyncLogEntrySerializer
     table_class = SyncLogEntryTable
     action_buttons = ("export",)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1055

NTC-4938

## What's Changed

This PR changes the queryset for the SyncLogEntryUIViewSet to only load the related fields that it requires.

### Details

The `SyncLogEntry` model has a ForeignKey relationship to the `Sync` model. Currently, when you load the SSoT Logs table (`/plugins/ssot/logs/`) it runs a SQL query that includes all fields of the related Sync object by default.

```sql
SELECT "nautobot_ssot_synclogentry"."id",
       "nautobot_ssot_synclogentry"."sync_id",
       "nautobot_ssot_synclogentry"."timestamp",
       "nautobot_ssot_synclogentry"."action",
       "nautobot_ssot_synclogentry"."status",
       "nautobot_ssot_synclogentry"."diff",
       "nautobot_ssot_synclogentry"."synced_object_type_id",
       "nautobot_ssot_synclogentry"."synced_object_id",
       "nautobot_ssot_synclogentry"."object_repr",
       "nautobot_ssot_synclogentry"."message",
       "nautobot_ssot_sync"."id",
       "nautobot_ssot_sync"."source",
       "nautobot_ssot_sync"."target",
       "nautobot_ssot_sync"."start_time",
       "nautobot_ssot_sync"."source_load_time",
       "nautobot_ssot_sync"."target_load_time",
       "nautobot_ssot_sync"."diff_time",
       "nautobot_ssot_sync"."sync_time",
       "nautobot_ssot_sync"."source_load_memory_final",
       "nautobot_ssot_sync"."source_load_memory_peak",
       "nautobot_ssot_sync"."target_load_memory_final",
       "nautobot_ssot_sync"."target_load_memory_peak",
       "nautobot_ssot_sync"."diff_memory_final",
       "nautobot_ssot_sync"."diff_memory_peak",
       "nautobot_ssot_sync"."sync_memory_final",
       "nautobot_ssot_sync"."sync_memory_peak",
       "nautobot_ssot_sync"."dry_run",
       "nautobot_ssot_sync"."diff",
       "nautobot_ssot_sync"."summary",
       "nautobot_ssot_sync"."job_result_id"
FROM "nautobot_ssot_synclogentry"
INNER JOIN "nautobot_ssot_sync" ON ("nautobot_ssot_synclogentry"."sync_id" = "nautobot_ssot_sync"."id")
ORDER BY "nautobot_ssot_synclogentry"."timestamp" DESC
LIMIT 50
```

This causes the (sometime rather large) diff for the related sync to be loaded, despite it not being used in the table.

This PR changes which fields get fetched by using the combination of `.select_related()` and `.only()` methods. This assists in paring down the query which helps load the table much faster.

```sql
SELECT "nautobot_ssot_synclogentry"."id",
       "nautobot_ssot_synclogentry"."sync_id",
       "nautobot_ssot_synclogentry"."timestamp",
       "nautobot_ssot_synclogentry"."action",
       "nautobot_ssot_synclogentry"."status",
       "nautobot_ssot_synclogentry"."diff",
       "nautobot_ssot_synclogentry"."synced_object_type_id",
       "nautobot_ssot_synclogentry"."synced_object_id",
       "nautobot_ssot_synclogentry"."object_repr",
       "nautobot_ssot_synclogentry"."message",
       "nautobot_ssot_sync"."id",
       "nautobot_ssot_sync"."source",
       "nautobot_ssot_sync"."target",
       "nautobot_ssot_sync"."start_time",
       "django_content_type"."id",
       "django_content_type"."app_label",
       "django_content_type"."model"
FROM "nautobot_ssot_synclogentry"
INNER JOIN "nautobot_ssot_sync" ON ("nautobot_ssot_synclogentry"."sync_id" = "nautobot_ssot_sync"."id")
LEFT OUTER JOIN "django_content_type" ON ("nautobot_ssot_synclogentry"."synced_object_type_id" = "django_content_type"."id")
ORDER BY "nautobot_ssot_synclogentry"."timestamp" DESC
LIMIT 50
```

### Screenshots

Here are the Silk profiling results for a decently large diff:

| Before | After |
| - | - |
| <img width="188" height="141" alt="Screenshot 2026-01-12 at 10 18 48 AM" src="https://github.com/user-attachments/assets/fe44a622-cfcb-40ed-b989-b2d4dcce4c6e" /> | <img width="195" height="140" alt="Screenshot 2026-01-12 at 10 18 37 AM" src="https://github.com/user-attachments/assets/14a0c70b-eb11-4353-acfe-872e848dbfc7" /> |
| <img width="931" height="646" alt="Screenshot 2026-01-12 at 10 19 02 AM" src="https://github.com/user-attachments/assets/25a22347-60da-4fc7-85b9-b44a8248fcbc" /> | <img width="925" height="412" alt="Screenshot 2026-01-12 at 10 18 30 AM" src="https://github.com/user-attachments/assets/0545fe81-05b5-46a1-a0cf-60c2b9408b24" /> |

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
