### PR TITLE
[LTM 2.4] Release v3.11.1

### DIFF
--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/1019.fixed
+++ b/changes/1019.fixed
@@ -1,1 +1,0 @@
-Fixed `unpermitted_values` bug and additional KeyError bug.

--- a/changes/1055.fixed
+++ b/changes/1055.fixed
@@ -1,1 +1,0 @@
-Fixed a performance issue with the SSoT log entries table view.

--- a/docs/admin/release_notes/version_3.11.md
+++ b/docs/admin/release_notes/version_3.11.md
@@ -31,3 +31,14 @@ Version 3.11 marks the designation of the 3.x branch as a Long Term Maintenance 
 - [#1007](https://github.com/nautobot/nautobot-app-ssot/issues/1007) - Cleaned up outdated code related to older versions of Nautobot and the Device Lifecycle Management App.
 - Rebaked from the cookie `nautobot-app-v2.7.0`.
 - Rebaked from the cookie `nautobot-app-v2.7.1`.
+
+## [v3.11.1 (2026-01-12)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.11.1)
+
+### Fixed
+
+- [#1019](https://github.com/nautobot/nautobot-app-ssot/issues/1019) - Fixed `unpermitted_values` bug and additional KeyError bug.
+- [#1055](https://github.com/nautobot/nautobot-app-ssot/issues/1055) - Fixed a performance issue with the SSoT log entries table view.
+
+### Housekeeping
+
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot"
-version = "3.11.1a0"
+version = "3.11.1"
 description = "Nautobot Single Source of Truth"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v3.11.1 (2026-01-12)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.11.1)

### Fixed

- [#1019](https://github.com/nautobot/nautobot-app-ssot/issues/1019) - Fixed `unpermitted_values` bug and additional KeyError bug.
- [#1055](https://github.com/nautobot/nautobot-app-ssot/issues/1055) - Fixed a performance issue with the SSoT log entries table view.

### Housekeeping

- Rebaked from the cookie `nautobot-app-v2.7.2`.