### PR TITLE
Release 3.12

### DIFF
--- a/changes/1027.added
+++ b/changes/1027.added
@@ -1,1 +1,0 @@
-Added Job input to Assign All Meraki Devices Under a Single Location

--- a/changes/1028.added
+++ b/changes/1028.added
@@ -1,1 +1,0 @@
-Added setting to Allow Syncing of DHCP-Based Management IPs

--- a/docs/admin/release_notes/version_3.12.md
+++ b/docs/admin/release_notes/version_3.12.md
@@ -1,0 +1,18 @@
+# v3.12 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Major features or milestones
+- Changes to compatibility with Nautobot and/or other apps, libraries etc.
+
+<!-- towncrier release notes start -->
+
+
+## [v3.12.0 (2026-01-22)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.12.0)
+
+### Added
+
+- [#1027](https://github.com/nautobot/nautobot-app-ssot/issues/1027) - Added Job input to Assign All Meraki Devices Under a Single Location
+- [#1028](https://github.com/nautobot/nautobot-app-ssot/issues/1028) - Added setting to Allow Syncing of DHCP-Based Management IPs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.12: "admin/release_notes/version_3.12.md"
           - v3.11: "admin/release_notes/version_3.11.md"
           - v3.10: "admin/release_notes/version_3.10.md"
           - v3.9: "admin/release_notes/version_3.9.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_ssot"
 directory = "changes"
-filename = "docs/admin/release_notes/version_3.11.md"
+filename = "docs/admin/release_notes/version_3.12.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-ssot/issues/{issue})"


### PR DESCRIPTION
## Release Overview

This release includes some features backported from 4.0 for the Meraki integration.

## [v3.12.0 (2026-01-22)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.12.0)

### Added

- [#1027](https://github.com/nautobot/nautobot-app-ssot/issues/1027) - Added Job input to Assign All Meraki Devices Under a Single Location
- [#1028](https://github.com/nautobot/nautobot-app-ssot/issues/1028) - Added setting to Allow Syncing of DHCP-Based Management IPs
