### PR TITLE
fix(device42): Pass LocationType instance instead of name to Location filter (#1098)

### DIFF
--- a/changes/1098.fixed
+++ b/changes/1098.fixed
@@ -1,0 +1,1 @@
+Fixed Device42 integration `load_sites()` passing `LocationType.name` string instead of `LocationType` instance to `Location.objects.filter()`, causing the sync job to fail.

--- a/nautobot_ssot/integrations/device42/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/device42/diffsync/adapters/nautobot.py
@@ -146,7 +146,7 @@ class NautobotAdapter(Adapter):
 
     def load_sites(self):
         """Add Nautobot Site objects as DiffSync Building models."""
-        for site in Location.objects.filter(location_type=self.job.building_loctype.name):
+        for site in Location.objects.filter(location_type=self.job.building_loctype):
             self.site_map[site.name] = site.id
             try:
                 building = self.building(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1098

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Fixed the `load_sites()` method in the Device42 Nautobot DiffSync adapter.

The `Location.objects.filter()` call was passing `self.job.building_loctype.name` (a string) to the `location_type` ForeignKey field. Django expects a model instance or a primary key (UUID) for FK lookups, not a name string. This caused the filter to fail silently or raise errors, resulting in downstream `AttributeError` exceptions during the Device42 sync job.

**Before:**
```python
for site in Location.objects.filter(location_type=self.job.building_loctype.name):
```

**After:**
```python
for site in Location.objects.filter(location_type=self.job.building_loctype):
```

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests — N/A, one-line bugfix correcting argument type; no behavioral logic change
- [x] Documentation Updates — N/A, bugfix only, no feature changes
- [x] Outline Remaining Work, Constraints from Design
