### PR TITLE
Update "get_disk_total" to handle disks with no capacity

### DIFF
--- a/changes/1029.fixed
+++ b/changes/1029.fixed
@@ -1,0 +1,1 @@
+Fixed vSphere sync failing when Virtual Machine has a disk with no capacity.

--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
@@ -39,7 +39,16 @@ def deduce_network_from_ip(ip: str, subnet_mask: str) -> str:
 
 
 def create_ipaddr(address: str):
-    """Create an IPV4 or IPV6 object."""
+    """Create an IPv4 or IPv6 address object from a string.
+
+    Attempts to parse the address as IPv4 first, falling back to IPv6 if that fails.
+
+    Args:
+        address: IP address string to parse (e.g. ``"192.168.1.1"`` or ``"::1"``).
+
+    Returns:
+        An ``ipaddress.IPv4Address`` or ``ipaddress.IPv6Address`` instance.
+    """
     try:
         ip_address = ipaddress.IPv4Address(address)
     except ipaddress.AddressValueError:
@@ -48,11 +57,27 @@ def create_ipaddr(address: str):
 
 
 def get_disk_total(disks: List):
-    """Calculcate total disk capacity."""
-    total = 0
+    """Calculate total disk capacity in GiB from a list of vSphere disk objects.
+
+    Skips disks without a capacity (e.g. CD/DVD drives) and sums the remaining
+    disk capacities, converting from bytes to GiB (truncated to int).
+
+    Args:
+        disks: List of vSphere disk objects, each containing a nested ``value``
+            dict with an optional ``capacity`` field in bytes.
+
+    Returns:
+        Total disk capacity in GiB as an integer.
+    """
+    total_bytes = 0
     for disk in disks:
-        total += disk["value"]["capacity"]
-    return int(total / 1024.0**3)
+        value = disk.get("value") or {}
+        capacity = value.get("capacity")
+        if capacity is None:
+            continue
+        total_bytes += capacity
+
+    return int(total_bytes / 1024.0**3)
 
 
 class VsphereDiffSync(Adapter):

--- a/nautobot_ssot/tests/vsphere/vsphere_fixtures/vm_details_nautobot.json
+++ b/nautobot_ssot/tests/vsphere/vsphere_fixtures/vm_details_nautobot.json
@@ -9,6 +9,12 @@
         "disks": [
             {
                 "value": {
+                    "label": "CD/DVD drive 1"
+                },
+                "key": "1000"
+            },
+            {
+                "value": {
                     "scsi": {
                         "bus": 0,
                         "unit": 0


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1029

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Updates the `get_disk_total` to properly handle when a virtual machine has a disk without a capacity key in its data returned from vCenter. 

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Unit, Integration Tests
