### PR TITLE
fix: Correct ForeignKey filter in Device42 load_sites (#1098)

### DIFF
--- a/changes/1098.fixed
+++ b/changes/1098.fixed
@@ -1,0 +1,1 @@
+Fixed Device42 load_sites passing LocationType name string instead of instance to ForeignKey filter.

--- a/nautobot_ssot/integrations/device42/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/device42/diffsync/adapters/nautobot.py
@@ -146,7 +146,7 @@ class NautobotAdapter(Adapter):
 
     def load_sites(self):
         """Add Nautobot Site objects as DiffSync Building models."""
-        for site in Location.objects.filter(location_type=self.job.building_loctype.name):
+        for site in Location.objects.filter(location_type=self.job.building_loctype):
             self.site_map[site.name] = site.id
             try:
                 building = self.building(


### PR DESCRIPTION
Fixes #1098

## Summary
- Fixed `load_sites()` in the Device42 Nautobot adapter passing `self.job.building_loctype.name` (a string) to `Location.objects.filter(location_type=...)`, which expects a `LocationType` instance or PK
- Removed the `.name` accessor so the `LocationType` instance is passed directly to the filter

## Test plan
- [ ] Verify the Device42 data source job completes the `load_target_adapter()` phase without `AttributeError`
- [ ] Confirm `load_sites()` correctly filters locations by the specified building location type

> [!NOTE]
> This PR was authored with the assistance of AI (Claude Opus 4.6). The fix follows the exact solution proposed in the issue by the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)