### PR TITLE
Fix vSphere import failure with disconnected VM network adapter

### DIFF
--- a/changes/1106.fixed
+++ b/changes/1106.fixed
@@ -1,0 +1,1 @@
+Fixed vSphere import failure when a VM has a disconnected network adapter with an unexpected state such as UNRECOVERABLE_ERROR.

--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
@@ -283,6 +283,11 @@ class VsphereDiffSync(Adapter):
 
         for nic in nics:
             nic_mac = nic["value"]["mac_address"].lower()
+            nic_state = nic["value"]["state"]
+            if nic_state not in self.config.default_vm_interface_map:
+                self.job.log_warning(
+                    message=f"Unknown NIC state '{nic_state}' for {nic['value']['label']} on {vm_id}, defaulting to disabled."
+                )
             diffsync_vminterface, _ = self.get_or_instantiate(
                 self.interface,
                 {
@@ -290,7 +295,7 @@ class VsphereDiffSync(Adapter):
                     "virtual_machine__name": diffsync_virtualmachine.name,
                 },
                 {
-                    "enabled": self.config.default_vm_interface_map[nic["value"]["state"]],
+                    "enabled": self.config.default_vm_interface_map.get(nic_state, False),
                     "status__name": "Active",
                     "mac_address": nic_mac.upper(),
                 },


### PR DESCRIPTION
## AI Disclosure
⚠️ This pull request was opened by an AI agent. The proposed solution is
automated and should be reviewed carefully by a human maintainer before merging.

## Linked Issue
Closes #1106

## Problem Summary
The vSphere integration crashes with a `KeyError` when importing VMs that have a disconnected network adapter. When a VM NIC is in a state such as `UNRECOVERABLE_ERROR` (which occurs when a network adapter is disconnected in vSphere), the adapter code attempts a direct dictionary lookup against `self.config.default_vm_interface_map`, which only contains mappings for `CONNECTED` and `NOT_CONNECTED` states.

## Solution
Changed the direct dictionary access on line 293 of `nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py` from bracket notation (`dict[key]`) to `.get(key, False)`. This safely defaults unknown NIC states to `enabled=False` (disabled), which is the most sensible default for a NIC in an error or disconnected state.

Additionally added a warning log message when an unknown NIC state is encountered, so users have visibility into which interfaces were defaulted.

**Files modified:**
- `nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py` — `load_vm_interfaces()` method
- `changes/1106.fixed` — changelog fragment

## How This Solves the Issue
The bug occurred because the `default_vm_interface_map` dictionary only contains `{"CONNECTED": True, "NOT_CONNECTED": False}`, but vSphere can report other NIC states like `UNRECOVERABLE_ERROR` for disconnected adapters. The fix changes the dictionary lookup from `dict[key]` (which raises `KeyError` for missing keys) to `dict.get(key, False)` (which returns `False` for any unmapped state). This means the reported `KeyError: "UNRECOVERABLE_ERROR"` no longer occurs, and the NIC is imported as disabled.

## Testing Notes
- No automated tests were added because testing requires a vSphere environment with a VM that has a disconnected network adapter.
- To manually verify: create a VM in vSphere, disconnect a network adapter, and run the SSoT import. The import should complete successfully with the disconnected NIC imported as disabled, and a warning should appear in the job logs.

## Limitations & Caveats
- This fix could not be verified against a live vSphere instance. The fix is based on the error traceback and code analysis.
- The fix treats ALL unknown NIC states as disabled. If vSphere introduces new valid states in the future, they would also default to disabled rather than raising an error. The warning log provides visibility for this case.
- The `default_vm_interface_map` config validation in `models.py` still only allows `CONNECTED` and `NOT_CONNECTED` as keys. Users cannot add custom mappings for other states via config. This is a deliberate choice to keep the change minimal.

## Checklist
- [x] Code follows `pylint` and `ruff` standards
- [x] All `Optional` fields on models have explicit default values (Pydantic v2)
- [x] Uses `Adapter` (not `DiffSync`) and `self.adapter` (not `self.diffsync`)
- [x] Changelog fragment created at `./changes/1106.fixed`
- [x] Branch is based off `develop`
- [x] This PR is identified as AI-generated
- [x] No unrelated files modified