### PR TITLE
Fix Bootstrap location tenant lookup using wrong model class

### DIFF
--- a/changes/977.fixed
+++ b/changes/977.fixed
@@ -1,0 +1,1 @@
+Fixed Bootstrap location sync failing with AttributeError when a tenant is assigned to a location.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -539,7 +539,7 @@ class NautobotLocation(Location):
                     _parent = ORMLocation.objects.get(name=attrs["parent"])
             if "tenant" in attrs:
                 if attrs["tenant"]:
-                    _tenant = Tenant.objects.get(name=attrs["tenant"])
+                    _tenant = ORMTenant.objects.get(name=attrs["tenant"])
             if "time_zone" in attrs:
                 _timezone = None
                 if attrs["time_zone"] and attrs["time_zone"] != "":
@@ -615,7 +615,7 @@ class NautobotLocation(Location):
         if "description" in attrs:
             _update_location.description = attrs["description"]
         if "tenant" in attrs:
-            _tenant = Tenant.objects.get(name=attrs["tenant"])
+            _tenant = ORMTenant.objects.get(name=attrs["tenant"])
             _update_location.tenant = _tenant
         if "physical_address" in attrs:
             _update_location.physical_address = attrs["physical_address"]


### PR DESCRIPTION
## AI Disclosure
⚠️ This pull request was opened by an AI agent. The proposed solution is
automated and should be reviewed carefully by a human maintainer before merging.

## Linked Issue
Closes #977

## Problem Summary
The Bootstrap integration's `NautobotLocation.create()` and `NautobotLocation.update()` methods fail with `AttributeError: objects` when a tenant is assigned to a location in the bootstrap YAML configuration. The code uses `Tenant.objects.get(name=...)` but `Tenant` in this scope refers to the DiffSync model (imported from `nautobot_ssot.integrations.bootstrap.diffsync.models.base`), not the Django ORM model. DiffSync models don't have a `.objects` manager.

## Solution
Changed two lines in `nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py`:
- **Line 542** (`create` method): `Tenant.objects.get(...)` → `ORMTenant.objects.get(...)`
- **Line 618** (`update` method): `Tenant.objects.get(...)` → `ORMTenant.objects.get(...)`

`ORMTenant` is already imported at line 48 as `from nautobot.tenancy.models import Tenant as ORMTenant` and is used correctly in all other model classes in the same file (Circuit, VRF, VLAN, Prefix, etc.).

## How This Solves the Issue
The bug occurred because the `NautobotLocation` class referenced the DiffSync `Tenant` model instead of the ORM `ORMTenant` model when performing Django ORM lookups. DiffSync models are Pydantic-based data models without a Django `.objects` manager, so accessing `.objects` raised `AttributeError`. The fix uses the correct ORM model alias, matching the pattern used throughout the rest of the file.

## Testing Notes
- No new automated tests were added. The fix is a two-character change (`Tenant` → `ORMTenant`) on two lines.
- To manually verify: configure a Bootstrap YAML file with a location that has a `tenant` field set to an existing tenant name, then run the Bootstrap SSoT job. The location should be created/updated with the tenant correctly assigned.

## Limitations & Caveats
- This fix could not be verified against a live Nautobot instance.
- The issue was originally reported against version 3.9.3, but the bug persists unchanged in the current 4.x codebase at the same line numbers.

## Checklist
- [x] Code follows `pylint` and `ruff` standards
- [x] All `Optional` fields on models have explicit default values (Pydantic v2)
- [x] Uses `Adapter` (not `DiffSync`) and `self.adapter` (not `self.diffsync`)
- [x] Changelog fragment created at `./changes/977.fixed`
- [x] Branch is based off `develop`
- [x] This PR is identified as AI-generated
- [x] No unrelated files modified