### PR TITLE
Meraki Integration - Load all device switchports multiple times

### DIFF
--- a/changes/1143.fixed
+++ b/changes/1143.fixed
@@ -1,0 +1,1 @@
+Load meraki switchports only once, instead of loading them per device.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -112,8 +112,9 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             dev["name"]: dev
             for dev in self.conn.get_org_devices(total_pages=self.api_total_pages, page_size=self.api_page_size)
         }
-        statuses = self.conn.get_org_device_statuses()
+        statuses = self.conn.get_org_device_statuses(total_pages=self.api_total_pages, page_size=self.api_page_size)
         status = "Offline"
+        org_switchports = self.conn.get_org_switchports(total_pages=self.api_total_pages)
         for dev in self.device_map.values():
             if dev.get("name"):
                 if dev["name"] in statuses:
@@ -169,7 +170,12 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                         elif dev["model"].startswith(("MR", "CW")):
                             self.load_ap_ports(device=new_dev, serial=dev["serial"])
                         elif dev["model"].startswith(("MS", "C9300")):
-                            self.load_switch_ports(device=new_dev, serial=dev["serial"], lan_ip=dev.get("lanIp"))
+                            self.load_switch_ports(
+                                device=new_dev,
+                                org_switchports=org_switchports,
+                                serial=dev["serial"],
+                                lan_ip=dev.get("lanIp"),
+                            )
             else:
                 self.job.logger.warning(f"Device serial {dev['serial']} is missing hostname so will be skipped.")
 
@@ -307,10 +313,9 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 self.add(new_port)
                 device.add_child(new_port)
 
-    def load_switch_ports(self, device: DiffSyncModel, serial: str, lan_ip: str):
+    def load_switch_ports(self, org_switchports: dict, device: DiffSyncModel, serial: str, lan_ip: str):
         """Load ports of a switch device from Meraki dashboard into DiffSync models."""
         mgmt_ports = self.conn.get_management_ports(serial=serial)
-        org_switchports = self.conn.get_org_switchports()
 
         net_prefix = None
         for port in mgmt_ports.keys():

--- a/nautobot_ssot/integrations/meraki/utils/meraki.py
+++ b/nautobot_ssot/integrations/meraki/utils/meraki.py
@@ -84,7 +84,7 @@ class DashboardClient:
             )
         return devices
 
-    def get_org_uplink_statuses(self) -> dict:
+    def get_org_uplink_statuses(self, total_pages="all", page_size=1000) -> dict:
         """Retrieve appliance uplink statuses for MX, MG, and Z devices for specified Organization ID.
 
         Returns:
@@ -92,7 +92,9 @@ class DashboardClient:
         """
         settings_map = {}
         try:
-            result = self.conn.organizations.getOrganizationUplinksStatuses(organizationId=self.org_id)
+            result = self.conn.organizations.getOrganizationUplinksStatuses(
+                organizationId=self.org_id, total_pages=total_pages, perPage=page_size
+            )
             settings_map = {net["serial"]: net for net in result}
         except meraki.APIError as err:
             self.logger.logger.warning(
@@ -120,7 +122,7 @@ class DashboardClient:
             )
         return addresses
 
-    def get_org_switchports(self) -> dict:
+    def get_org_switchports(self, total_pages="all") -> dict:
         """Retrieve all ports for switches in specified organization ID.
 
         Returns:
@@ -128,7 +130,9 @@ class DashboardClient:
         """
         port_map = {}
         try:
-            result = self.conn.switch.getOrganizationSwitchPortsBySwitch(organizationId=self.org_id)
+            result = self.conn.switch.getOrganizationSwitchPortsBySwitch(
+                organizationId=self.org_id, total_pages=total_pages
+            )
             port_map = {switch["serial"]: switch for switch in result}
         except meraki.APIError as err:
             self.logger.logger.warning(
@@ -136,7 +140,7 @@ class DashboardClient:
             )
         return port_map
 
-    def get_org_device_statuses(self) -> dict:
+    def get_org_device_statuses(self, total_pages="all", page_size=1000) -> dict:
         """Retrieve device statuses from Meraki dashboard.
 
         Returns:
@@ -144,7 +148,9 @@ class DashboardClient:
         """
         statuses = {}
         try:
-            response = self.conn.organizations.getOrganizationDevicesStatuses(organizationId=self.org_id)
+            response = self.conn.organizations.getOrganizationDevicesStatuses(
+                organizationId=self.org_id, total_pages=total_pages, perPage=page_size
+            )
             statuses = {dev["name"]: dev["status"] for dev in response}
         except meraki.APIError as err:
             self.logger.logger.warning(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1143

## What's Changed

Currently, switchports are loaded from the Meraki Dashboard separately for each device, which adds significant latency to the sync process. I’ve updated load_devices so that device switchports are loaded only once.