### PR TITLE
Add diff pagination to Sync detail view - LTM

### DIFF
--- a/changes/1146.fixed
+++ b/changes/1146.fixed
@@ -1,0 +1,1 @@
+Fixed display of large diffs by implementing pagination in render_diff() method.

--- a/nautobot_ssot/template_content.py
+++ b/nautobot_ssot/template_content.py
@@ -22,14 +22,6 @@ class JobResultSyncLink(TemplateExtension):
         if sync_objects.count() == 0:
             return ""
         sync = sync_objects.first()
-        if sync_objects.count() > 1:
-            return f"""
-                <div class="btn-group">
-                    <a href="{reverse('plugins:nautobot_ssot:sync', kwargs={'pk': sync.pk})}" class="btn btn-primary">
-                        <span class="mdi mdi-database-sync-outline"></span> SSoT Sync Details (first of multiple)
-                    </a>
-                </div>
-            """
         return f"""
             <div class="btn-group">
                 <a href="{reverse('plugins:nautobot_ssot:sync', kwargs={'pk': sync.pk})}" class="btn btn-primary">

--- a/nautobot_ssot/template_content.py
+++ b/nautobot_ssot/template_content.py
@@ -15,11 +15,8 @@ class JobResultSyncLink(TemplateExtension):
 
     def buttons(self):
         """Inject a custom button into the JobResult detail view, if applicable."""
-        try:
-            sync_objects = Sync.objects.filter(job_result=self.context["object"])
-        except Sync.DoesNotExist:
-            return ""
-        if sync_objects.count() == 0:
+        sync_objects = Sync.objects.filter(job_result=self.context["object"])
+        if not sync_objects.exists():
             return ""
         sync = sync_objects.first()
         return f"""

--- a/nautobot_ssot/template_content.py
+++ b/nautobot_ssot/template_content.py
@@ -16,16 +16,27 @@ class JobResultSyncLink(TemplateExtension):
     def buttons(self):
         """Inject a custom button into the JobResult detail view, if applicable."""
         try:
-            sync = Sync.objects.get(job_result=self.context["object"])
+            sync_objects = Sync.objects.filter(job_result=self.context["object"])
+        except Sync.DoesNotExist:
+            return ""
+        if sync_objects.count() == 0:
+            return ""
+        sync = sync_objects.first()
+        if sync_objects.count() > 1:
             return f"""
                 <div class="btn-group">
                     <a href="{reverse('plugins:nautobot_ssot:sync', kwargs={'pk': sync.pk})}" class="btn btn-primary">
-                        <span class="mdi mdi-database-sync-outline"></span> SSoT Sync Details
+                        <span class="mdi mdi-database-sync-outline"></span> SSoT Sync Details (first of multiple)
                     </a>
                 </div>
             """
-        except Sync.DoesNotExist:
-            return ""
+        return f"""
+            <div class="btn-group">
+                <a href="{reverse('plugins:nautobot_ssot:sync', kwargs={'pk': sync.pk})}" class="btn btn-primary">
+                    <span class="mdi mdi-database-sync-outline"></span> SSoT Sync Details
+                </a>
+            </div>
+        """
 
 
 template_extensions = [JobResultSyncLink]

--- a/nautobot_ssot/templatetags/render_diff.py
+++ b/nautobot_ssot/templatetags/render_diff.py
@@ -2,6 +2,7 @@
 
 from django import template
 from django.core.paginator import EmptyPage, InvalidPage
+from django.template.loader import get_template
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from nautobot.apps.views import EnhancedPaginator
@@ -90,56 +91,14 @@ def _group_flat_items(flat_items):
     return grouped
 
 
-def _build_page_url(request, page_num):
-    """Build a URL for a specific diff page, preserving existing query parameters."""
-    params = request.GET.copy()
-    params[_PAGE_PARAM] = page_num
-    return f"?{params.urlencode()}"
-
-
 def _render_pagination_controls(page_obj, request):
-    """Return Bootstrap-compatible pagination HTML using EnhancedPage.smart_pages()."""
+    """Render pagination controls using Nautobot's standard inc/paginator.html template."""
     if not page_obj.has_other_pages():
         return mark_safe("")  # noqa: S308
 
-    items_html = ""
-
-    if page_obj.has_previous():
-        prev_url = _build_page_url(request, page_obj.previous_page_number())
-        items_html += format_html('<li class="page-item"><a class="page-link" href="{}">Previous</a></li>', prev_url)
-    else:
-        items_html += '<li class="page-item disabled"><span class="page-link">Previous</span></li>'
-
-    for page_num in page_obj.smart_pages():
-        if not page_num:
-            # False is used as the ellipsis/skip marker by EnhancedPage.smart_pages()
-            items_html += '<li class="page-item disabled"><span class="page-link">\u2026</span></li>'
-        elif page_num == page_obj.number:
-            items_html += format_html('<li class="page-item active"><span class="page-link">{}</span></li>', page_num)
-        else:
-            page_url = _build_page_url(request, page_num)
-            items_html += format_html(
-                '<li class="page-item"><a class="page-link" href="{}">{}</a></li>', page_url, page_num
-            )
-
-    if page_obj.has_next():
-        next_url = _build_page_url(request, page_obj.next_page_number())
-        items_html += format_html('<li class="page-item"><a class="page-link" href="{}">Next</a></li>', next_url)
-    else:
-        items_html += '<li class="page-item disabled"><span class="page-link">Next</span></li>'
-
-    summary = format_html(
-        '<p class="text-muted small">Showing {}\u2013{} of {} objects</p>',
-        page_obj.start_index(),
-        page_obj.end_index(),
-        page_obj.paginator.count,
-    )
-
-    return format_html(
-        '<nav aria-label="Diff pagination"><ul class="pagination">{}</ul></nav>{}',
-        mark_safe(items_html),  # noqa: S308
-        summary,
-    )
+    tpl = get_template("inc/paginator.html")
+    context = {"page": page_obj, "paginator": page_obj.paginator}
+    return mark_safe(tpl.render(context, request))  # noqa: S308
 
 
 def render_diff_paginated(diff, request):

--- a/nautobot_ssot/templatetags/render_diff.py
+++ b/nautobot_ssot/templatetags/render_diff.py
@@ -94,11 +94,11 @@ def _group_flat_items(flat_items):
 def _render_pagination_controls(page_obj, request):
     """Render pagination controls using Nautobot's standard inc/paginator.html template."""
     if not page_obj.has_other_pages():
-        return mark_safe("")  # noqa: S308
+        return ""
 
     tpl = get_template("inc/paginator.html")
     context = {"page": page_obj, "paginator": page_obj.paginator}
-    return mark_safe(tpl.render(context, request))  # noqa: S308
+    return tpl.render(context, request)
 
 
 def render_diff_paginated(diff, request):

--- a/nautobot_ssot/templatetags/render_diff.py
+++ b/nautobot_ssot/templatetags/render_diff.py
@@ -1,14 +1,15 @@
 """Template tag for rendering a DiffSync diff dictionary in a more human-readable form."""
 
 from django import template
-from django.core.paginator import EmptyPage, InvalidPage, Paginator
+from django.core.paginator import EmptyPage, InvalidPage
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from nautobot.apps.views import EnhancedPaginator
+from nautobot.core.views.paginator import get_paginate_count
 
 register = template.Library()
 
-_DIFF_PAGE_PARAM = "diff_page"
-DEFAULT_DIFF_PAGE_SIZE = 50
+_PAGE_PARAM = "page"
 
 
 def render_diff_recursive(diff):
@@ -92,21 +93,14 @@ def _group_flat_items(flat_items):
 def _build_page_url(request, page_num):
     """Build a URL for a specific diff page, preserving existing query parameters."""
     params = request.GET.copy()
-    params[_DIFF_PAGE_PARAM] = page_num
+    params[_PAGE_PARAM] = page_num
     return f"?{params.urlencode()}"
 
 
 def _render_pagination_controls(page_obj, request):
-    """Return Bootstrap-compatible pagination HTML for the given page object."""
+    """Return Bootstrap-compatible pagination HTML using EnhancedPage.smart_pages()."""
     if not page_obj.has_other_pages():
         return mark_safe("")  # noqa: S308
-
-    paginator = page_obj.paginator
-    current = page_obj.number
-    num_pages = paginator.num_pages
-
-    # Always show first, last, and a window around the current page
-    pages_to_show = {1, num_pages} | set(range(max(1, current - 2), min(num_pages + 1, current + 3)))
 
     items_html = ""
 
@@ -116,18 +110,17 @@ def _render_pagination_controls(page_obj, request):
     else:
         items_html += '<li class="page-item disabled"><span class="page-link">Previous</span></li>'
 
-    prev_page = None
-    for page_num in sorted(pages_to_show):
-        if prev_page is not None and page_num - prev_page > 1:
+    for page_num in page_obj.smart_pages():
+        if not page_num:
+            # False is used as the ellipsis/skip marker by EnhancedPage.smart_pages()
             items_html += '<li class="page-item disabled"><span class="page-link">\u2026</span></li>'
-        if page_num == current:
+        elif page_num == page_obj.number:
             items_html += format_html('<li class="page-item active"><span class="page-link">{}</span></li>', page_num)
         else:
             page_url = _build_page_url(request, page_num)
             items_html += format_html(
                 '<li class="page-item"><a class="page-link" href="{}">{}</a></li>', page_url, page_num
             )
-        prev_page = page_num
 
     if page_obj.has_next():
         next_url = _build_page_url(request, page_obj.next_page_number())
@@ -139,7 +132,7 @@ def _render_pagination_controls(page_obj, request):
         '<p class="text-muted small">Showing {}\u2013{} of {} objects</p>',
         page_obj.start_index(),
         page_obj.end_index(),
-        paginator.count,
+        page_obj.paginator.count,
     )
 
     return format_html(
@@ -149,17 +142,17 @@ def _render_pagination_controls(page_obj, request):
     )
 
 
-def render_diff_paginated(diff, request, per_page=DEFAULT_DIFF_PAGE_SIZE):
+def render_diff_paginated(diff, request):
     """Render a paginated DiffSync diff dict to HTML with pagination controls.
 
-    Flattens the diff into a list of top-level objects, paginates them, and renders
-    only the current page. Falls back to a full render when the diff is small enough
-    to fit on a single page.
+    Uses Nautobot's EnhancedPaginator and PAGINATE_COUNT setting to determine page
+    size. Flattens the diff into a list of top-level objects, paginates them, and
+    renders only the current page. Falls back to a full render when the diff fits
+    on a single page.
 
     Args:
         diff: The diff dictionary to render.
-        request: The current HTTP request (used for page number and URL building).
-        per_page: Number of top-level diff objects per page (default 50).
+        request: The current HTTP request (used for page count, page number, and URL building).
 
     Returns:
         Safe HTML string with diff content and optional pagination controls.
@@ -167,17 +160,18 @@ def render_diff_paginated(diff, request, per_page=DEFAULT_DIFF_PAGE_SIZE):
     if not diff:
         return format_html("<p>No diff data available.</p>")
 
+    per_page = get_paginate_count(request)
     flat_items = _flatten_diff(diff)
 
     if len(flat_items) <= per_page:
         return render_diff(diff)
 
     try:
-        page_num = int(request.GET.get(_DIFF_PAGE_PARAM, 1))
+        page_num = int(request.GET.get(_PAGE_PARAM, 1))
     except (TypeError, ValueError):
         page_num = 1
 
-    paginator = Paginator(flat_items, per_page)
+    paginator = EnhancedPaginator(flat_items, per_page)
     try:
         page_obj = paginator.page(page_num)
     except (EmptyPage, InvalidPage):

--- a/nautobot_ssot/templatetags/render_diff.py
+++ b/nautobot_ssot/templatetags/render_diff.py
@@ -112,9 +112,7 @@ def _render_pagination_controls(page_obj, request):
 
     if page_obj.has_previous():
         prev_url = _build_page_url(request, page_obj.previous_page_number())
-        items_html += format_html(
-            '<li class="page-item"><a class="page-link" href="{}">Previous</a></li>', prev_url
-        )
+        items_html += format_html('<li class="page-item"><a class="page-link" href="{}">Previous</a></li>', prev_url)
     else:
         items_html += '<li class="page-item disabled"><span class="page-link">Previous</span></li>'
 
@@ -123,9 +121,7 @@ def _render_pagination_controls(page_obj, request):
         if prev_page is not None and page_num - prev_page > 1:
             items_html += '<li class="page-item disabled"><span class="page-link">\u2026</span></li>'
         if page_num == current:
-            items_html += format_html(
-                '<li class="page-item active"><span class="page-link">{}</span></li>', page_num
-            )
+            items_html += format_html('<li class="page-item active"><span class="page-link">{}</span></li>', page_num)
         else:
             page_url = _build_page_url(request, page_num)
             items_html += format_html(
@@ -135,9 +131,7 @@ def _render_pagination_controls(page_obj, request):
 
     if page_obj.has_next():
         next_url = _build_page_url(request, page_obj.next_page_number())
-        items_html += format_html(
-            '<li class="page-item"><a class="page-link" href="{}">Next</a></li>', next_url
-        )
+        items_html += format_html('<li class="page-item"><a class="page-link" href="{}">Next</a></li>', next_url)
     else:
         items_html += '<li class="page-item disabled"><span class="page-link">Next</span></li>'
 

--- a/nautobot_ssot/templatetags/render_diff.py
+++ b/nautobot_ssot/templatetags/render_diff.py
@@ -1,10 +1,14 @@
 """Template tag for rendering a DiffSync diff dictionary in a more human-readable form."""
 
 from django import template
+from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 register = template.Library()
+
+_DIFF_PAGE_PARAM = "diff_page"
+DEFAULT_DIFF_PAGE_SIZE = 50
 
 
 def render_diff_recursive(diff):
@@ -44,14 +48,15 @@ def render_diff_recursive(diff):
                 child_class = "diff-changed"
             child_result += format_html('<li class="{}">{}<ul>', child_class, child)
 
-            for attr, value in child_diffs.pop("+", {}).items():
+            for attr, value in child_diffs.get("+", {}).items():
                 child_result += format_html('<li class="diff-added">{}: {}</li>', attr, value)
 
-            for attr, value in child_diffs.pop("-", {}).items():
+            for attr, value in child_diffs.get("-", {}).items():
                 child_result += format_html('<li class="diff-subtracted">{}: {}</li>', attr, value)
 
-            if child_diffs:
-                child_result += render_diff_recursive(child_diffs)
+            nested = {k: v for k, v in child_diffs.items() if k not in ("+", "-")}
+            if nested:
+                child_result += render_diff_recursive(nested)
 
             child_result += "</ul></li>"
         result += format_html("<li>{}<ul>{}</ul></li>", record_type, mark_safe(child_result))  # noqa: S308
@@ -61,5 +66,131 @@ def render_diff_recursive(diff):
 @register.simple_tag
 def render_diff(diff):
     """Render a DiffSync diff dict to HTML."""
+    if not diff:
+        return ""
     html_text = render_diff_recursive(diff)
     return format_html("<ul>{}</ul>", mark_safe(html_text))  # noqa: S308
+
+
+def _flatten_diff(diff):
+    """Flatten a diff dict into a list of (model_type, obj_id, obj_diff) tuples."""
+    items = []
+    for model_type, children in diff.items():
+        for obj_id, obj_diff in children.items():
+            items.append((model_type, obj_id, obj_diff))
+    return items
+
+
+def _group_flat_items(flat_items):
+    """Group flattened diff items back into a nested diff dict, preserving model_type order."""
+    grouped = {}
+    for model_type, obj_id, obj_diff in flat_items:
+        grouped.setdefault(model_type, {})[obj_id] = obj_diff
+    return grouped
+
+
+def _build_page_url(request, page_num):
+    """Build a URL for a specific diff page, preserving existing query parameters."""
+    params = request.GET.copy()
+    params[_DIFF_PAGE_PARAM] = page_num
+    return f"?{params.urlencode()}"
+
+
+def _render_pagination_controls(page_obj, request):
+    """Return Bootstrap-compatible pagination HTML for the given page object."""
+    if not page_obj.has_other_pages():
+        return mark_safe("")  # noqa: S308
+
+    paginator = page_obj.paginator
+    current = page_obj.number
+    num_pages = paginator.num_pages
+
+    # Always show first, last, and a window around the current page
+    pages_to_show = {1, num_pages} | set(range(max(1, current - 2), min(num_pages + 1, current + 3)))
+
+    items_html = ""
+
+    if page_obj.has_previous():
+        prev_url = _build_page_url(request, page_obj.previous_page_number())
+        items_html += format_html(
+            '<li class="page-item"><a class="page-link" href="{}">Previous</a></li>', prev_url
+        )
+    else:
+        items_html += '<li class="page-item disabled"><span class="page-link">Previous</span></li>'
+
+    prev_page = None
+    for page_num in sorted(pages_to_show):
+        if prev_page is not None and page_num - prev_page > 1:
+            items_html += '<li class="page-item disabled"><span class="page-link">\u2026</span></li>'
+        if page_num == current:
+            items_html += format_html(
+                '<li class="page-item active"><span class="page-link">{}</span></li>', page_num
+            )
+        else:
+            page_url = _build_page_url(request, page_num)
+            items_html += format_html(
+                '<li class="page-item"><a class="page-link" href="{}">{}</a></li>', page_url, page_num
+            )
+        prev_page = page_num
+
+    if page_obj.has_next():
+        next_url = _build_page_url(request, page_obj.next_page_number())
+        items_html += format_html(
+            '<li class="page-item"><a class="page-link" href="{}">Next</a></li>', next_url
+        )
+    else:
+        items_html += '<li class="page-item disabled"><span class="page-link">Next</span></li>'
+
+    summary = format_html(
+        '<p class="text-muted small">Showing {}\u2013{} of {} objects</p>',
+        page_obj.start_index(),
+        page_obj.end_index(),
+        paginator.count,
+    )
+
+    return format_html(
+        '<nav aria-label="Diff pagination"><ul class="pagination">{}</ul></nav>{}',
+        mark_safe(items_html),  # noqa: S308
+        summary,
+    )
+
+
+def render_diff_paginated(diff, request, per_page=DEFAULT_DIFF_PAGE_SIZE):
+    """Render a paginated DiffSync diff dict to HTML with pagination controls.
+
+    Flattens the diff into a list of top-level objects, paginates them, and renders
+    only the current page. Falls back to a full render when the diff is small enough
+    to fit on a single page.
+
+    Args:
+        diff: The diff dictionary to render.
+        request: The current HTTP request (used for page number and URL building).
+        per_page: Number of top-level diff objects per page (default 50).
+
+    Returns:
+        Safe HTML string with diff content and optional pagination controls.
+    """
+    if not diff:
+        return format_html("<p>No diff data available.</p>")
+
+    flat_items = _flatten_diff(diff)
+
+    if len(flat_items) <= per_page:
+        return render_diff(diff)
+
+    try:
+        page_num = int(request.GET.get(_DIFF_PAGE_PARAM, 1))
+    except (TypeError, ValueError):
+        page_num = 1
+
+    paginator = Paginator(flat_items, per_page)
+    try:
+        page_obj = paginator.page(page_num)
+    except (EmptyPage, InvalidPage):
+        page_obj = paginator.page(paginator.num_pages)
+
+    page_diff = _group_flat_items(list(page_obj.object_list))
+    diff_html = render_diff(page_diff)
+    pagination_html = _render_pagination_controls(page_obj, request)
+
+    return format_html("{}{}", diff_html, pagination_html)

--- a/nautobot_ssot/tests/test_render_diff.py
+++ b/nautobot_ssot/tests/test_render_diff.py
@@ -1,8 +1,14 @@
 """Test Render_diff templatetags."""
 
-import unittest
+from django.test import RequestFactory
+from nautobot.core.testing import TestCase
 
-from nautobot_ssot.templatetags.render_diff import render_diff
+from nautobot_ssot.templatetags.render_diff import (
+    _flatten_diff,
+    _group_flat_items,
+    render_diff,
+    render_diff_paginated,
+)
 
 test_params = [
     (
@@ -55,8 +61,7 @@ test_params = [
 ]
 
 
-@unittest.skip("TODO")
-class TestRenderDiff(unittest.TestCase):
+class TestRenderDiff(TestCase):
     """Tests for render_diff function."""
 
     def test_render_diff_as_expected(self):
@@ -64,3 +69,92 @@ class TestRenderDiff(unittest.TestCase):
         for input_dict, rendered_diff in test_params:
             with self.subTest():
                 self.assertEqual(render_diff(input_dict), rendered_diff)
+
+    def test_render_diff_empty(self):
+        """Empty diff returns empty string."""
+        self.assertEqual(render_diff({}), "")
+        self.assertEqual(render_diff(None), "")
+
+
+class TestFlattenGroupDiff(TestCase):
+    """Tests for _flatten_diff and _group_flat_items helpers."""
+
+    def test_flatten_diff(self):
+        """Flatten produces (model_type, obj_id, obj_diff) tuples."""
+        diff = {"region": {"ams": {"+": {}}, "nyc": {"-": {}}}}
+        flat = _flatten_diff(diff)
+        self.assertEqual(len(flat), 2)
+        self.assertIn(("region", "ams", {"+": {}}), flat)
+        self.assertIn(("region", "nyc", {"-": {}}), flat)
+
+    def test_group_flat_items(self):
+        """Grouped items reconstruct nested diff structure."""
+        flat = [("region", "ams", {"+": {}}), ("region", "nyc", {"-": {}})]
+        grouped = _group_flat_items(flat)
+        self.assertEqual(grouped, {"region": {"ams": {"+": {}}, "nyc": {"-": {}}}})
+
+
+class TestRenderDiffPaginated(TestCase):
+    """Tests for render_diff_paginated function."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a user for request context."""
+        from django.contrib.auth import get_user_model
+
+        cls.user = get_user_model().objects.create(username="test_render_diff_user")
+
+    def setUp(self):
+        """Create request factory for each test."""
+        self.factory = RequestFactory()
+
+    def _make_request(self, path="/", per_page=3, **query):
+        """Create a GET request with user attached (required by get_paginate_count)."""
+        params = {"per_page": str(per_page), **query}
+        request = self.factory.get(path, params)
+        request.user = self.user
+        return request
+
+    def test_empty_diff(self):
+        """Empty diff returns no-data message."""
+        request = self._make_request()
+        result = render_diff_paginated({}, request)
+        self.assertIn("No diff data available", str(result))
+
+    def test_small_diff_no_pagination(self):
+        """Diff with few items renders fully without pagination controls."""
+        # 2 items, per_page=3 -> fits on one page
+        diff = {"region": {"a": {}, "b": {}}}
+        request = self._make_request()
+        result = render_diff_paginated(diff, request)
+        self.assertIn("region", str(result))
+        self.assertIn("a", str(result))
+        self.assertIn("b", str(result))
+        # No pagination nav when single page
+        self.assertNotIn("page=", str(result))
+
+    def test_large_diff_paginated(self):
+        """Diff with many items renders paginated."""
+        # 5 items, per_page=3 -> 2 pages
+        diff = {
+            "region": {
+                "a": {},
+                "b": {},
+                "c": {},
+                "d": {},
+                "e": {},
+            }
+        }
+        request = self._make_request()
+        result = render_diff_paginated(diff, request)
+        self.assertIn("region", str(result))
+        self.assertIn(" Showing ", str(result))
+        self.assertIn("page=", str(result))
+
+    def test_page_param_respected(self):
+        """Requested page number is used."""
+        diff = {"region": {f"x{i}": {} for i in range(5)}}
+        request = self._make_request(page="2")
+        result = render_diff_paginated(diff, request)
+        self.assertIn("x3", str(result))
+        self.assertIn("x4", str(result))

--- a/nautobot_ssot/tests/test_render_diff.py
+++ b/nautobot_ssot/tests/test_render_diff.py
@@ -1,5 +1,6 @@
 """Test Render_diff templatetags."""
 
+from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 from nautobot.core.testing import TestCase
 
@@ -100,8 +101,6 @@ class TestRenderDiffPaginated(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Create a user for request context."""
-        from django.contrib.auth import get_user_model  # pylint: disable=import-outside-toplevel
-
         cls.user = get_user_model().objects.create(username="test_render_diff_user")
 
     def setUp(self):

--- a/nautobot_ssot/tests/test_render_diff.py
+++ b/nautobot_ssot/tests/test_render_diff.py
@@ -100,7 +100,7 @@ class TestRenderDiffPaginated(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Create a user for request context."""
-        from django.contrib.auth import get_user_model
+        from django.contrib.auth import get_user_model  # pylint: disable=import-outside-toplevel
 
         cls.user = get_user_model().objects.create(username="test_render_diff_user")
 

--- a/nautobot_ssot/views.py
+++ b/nautobot_ssot/views.py
@@ -41,7 +41,7 @@ from rest_framework.response import Response
 
 from nautobot_ssot.api import serializers
 from nautobot_ssot.integrations import utils
-from nautobot_ssot.templatetags.render_diff import render_diff
+from nautobot_ssot.templatetags.render_diff import render_diff, render_diff_paginated
 
 from .filters import SyncFilterSet, SyncLogEntryFilterSet
 from .forms import SyncBulkEditForm, SyncFilterForm, SyncForm, SyncLogEntryFilterForm
@@ -136,6 +136,9 @@ class DiffPanel(ObjectTextPanel):
     def get_value(self, context):
         """Render the value for the diff."""
         obj = get_obj_from_context(context, "object")
+        request = context.get("request")
+        if request is not None:
+            return render_diff_paginated(obj.diff, request)
         return render_diff(obj.diff)
 
 


### PR DESCRIPTION
## Summary
Adds pagination to the diff display on the Sync detail view for improved performance when viewing large sync results. This PR is basically a duplicate of #1146 but for LTM.

## Changes
- fix: Fix bug in Template when rendering Sync object (handle multiple Sync records per JobResult)
- refactor: Redo render_diff to add pagination