### PR TITLE
Fix unittest wrapper run with uv.

### DIFF
--- a/changes/1154.fixed
+++ b/changes/1154.fixed
@@ -1,0 +1,1 @@
+Support uv controlled development environment to run unittest.

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -39,10 +39,6 @@ def _check_for_conflicting_apps():
         )
 
 
-if not is_truthy(os.getenv("NAUTOBOT_SSOT_ALLOW_CONFLICTING_APPS", "False")):
-    _check_for_conflicting_apps()
-
-
 class NautobotSSOTAppConfig(NautobotAppConfig):
     """App configuration for the nautobot_ssot app."""
 
@@ -131,22 +127,21 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
     docs_view_name = "plugins:nautobot_ssot:docs"
     searchable_models = ["sync"]
 
-    def __init__(self, *args, **kwargs):
-        """Initialize a NautobotSSOTAppConfig instance and set default attributes."""
-        super().__init__(*args, **kwargs)
-        # Only set searchable_models if enabled in config
-        if settings.PLUGINS_CONFIG["nautobot_ssot"].get("enable_global_search", True):
-            self.searchable_models = [
-                "Sync",
-                "SyncLogEntry",
-            ]
-
     def ready(self):
         """Trigger callback when database is ready."""
         super().ready()
         for module in each_enabled_integration_module("signals"):
             logger.debug("Registering signals for %s", module.__file__)
             module.register_signals(self)
+        if not is_truthy(os.getenv("NAUTOBOT_SSOT_ALLOW_CONFLICTING_APPS", "False")):
+            _check_for_conflicting_apps()
+
+        # Only set searchable_models if enabled in config
+        if settings.PLUGINS_CONFIG.get("nautobot_ssot", {}).get("enable_global_search", True):
+            self.searchable_models = [
+                "Sync",
+                "SyncLogEntry",
+            ]
 
 
 config = NautobotSSOTAppConfig  # pylint:disable=invalid-name

--- a/nautobot_ssot/integrations/utils.py
+++ b/nautobot_ssot/integrations/utils.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("nautobot.ssot")
 
 def each_enabled_integration() -> Generator[str, None, None]:
     """Return all enabled integrations."""
-    config = settings.PLUGINS_CONFIG["nautobot_ssot"]
+    config = settings.PLUGINS_CONFIG.get("nautobot_ssot", {})
 
     for path in Path(__file__).parent.iterdir():
         if config.get(f"enable_{path.name}", False):

--- a/nautobot_ssot/jobs/__init__.py
+++ b/nautobot_ssot/jobs/__init__.py
@@ -14,7 +14,7 @@ from nautobot_ssot.jobs.examples import ExampleDataSource, ExampleDataTarget
 
 logger = logging.getLogger("nautobot.ssot")
 
-hide_jobs_setting = settings.PLUGINS_CONFIG["nautobot_ssot"].get("hide_example_jobs", False)
+hide_jobs_setting = settings.PLUGINS_CONFIG.get("nautobot_ssot", {}).get("hide_example_jobs", False)
 if is_truthy(hide_jobs_setting):
     jobs = []
 else:


### PR DESCRIPTION
This fixes django test runner when env is controlled with `uv run nautobot-server test nautobot_ssot`.

Tested the app in uv environment for running nbshell and tests.

```
uv run nautobot-server shell
settings.PLUGINS_CONFIG.keys()
dict_keys(['nautobot_ssot', 'nautobot_ssot_custom'])

uv run nautobot-server test nautobot_ssot_custom
settings.PLUGINS_CONFIG.keys()
dict_keys([])
```
Looks like when uv runs the test wrapper on first module initialization to discover tests, config is not yet fully loaded due to Django LazyLoad. The solution is to get the PLUGIN_CONFIG key gracefully with `.get()` to avoid KeyError.