### PR TITLE
Fixed pagination when retrieving locations from DNA Center

### DIFF
--- a/changes/1160.fixed
+++ b/changes/1160.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in the DNA Center integration where the get_locations method was not correctly paginating the results.

--- a/nautobot_ssot/integrations/dna_center/utils/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/utils/dna_center.py
@@ -45,9 +45,11 @@ class DnaCenterClient:
         try:
             total_num_sites = self.conn.sites.get_site_count()["response"]
             offset = 1
+            # Default page size is 50, max is 500, so we'll use a comfortable middle ground.
+            limit = 200
             while len(loc_data) < total_num_sites:
-                loc_data.extend(self.conn.sites.get_site(offset=offset)["response"])
-                offset = len(loc_data)
+                loc_data.extend(self.conn.sites.get_site(offset=offset, limit=limit)["response"])
+                offset += limit
             for _, item in enumerate(loc_data):
                 if item["siteNameHierarchy"] not in loc_names:
                     loc_names.append(item["siteNameHierarchy"])

--- a/nautobot_ssot/tests/dna_center/test_utils_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_utils_dna_center.py
@@ -33,7 +33,7 @@ class TestDnaCenterClient(TestCase):  # pylint: disable=too-many-public-methods
         self.verify = False
         self.dnac = DnaCenterClient(self.url, self.username, self.password, verify=self.verify)
         self.dnac.conn = MagicMock()
-        self.dnac.conn.sites.get_site_count.return_value = {"response": 4}
+        self.dnac.conn.sites.get_site_count.return_value = {"response": 31}
         self.dnac.conn.devices.get_device_count.return_value = {"response": 3}
 
         self.mock_response = create_autospec(Response)
@@ -69,6 +69,26 @@ class TestDnaCenterClient(TestCase):  # pylint: disable=too-many-public-methods
         self.dnac.conn.sites.get_site.return_value = RECV_LOCATION_FIXTURE
         actual = self.dnac.get_locations()
         self.assertEqual(actual, LOCATION_FIXTURE)
+
+    def test_get_locations_pagination(self):
+        """Test the get_locations method correctly paginates without skipping items.
+
+        Simulates a 1-based offset API returning a fixed page size. With N total items
+        and page_size P, an off-by-one in offset causes one duplicate per page. When the
+        accumulated duplicates inflate loc_data to >= total before all unique items are
+        fetched, the loop exits early and items are silently skipped.
+        """
+        all_locations = RECV_LOCATION_FIXTURE["response"][:30]
+
+        def fake_get_site(offset=1, limit=10, **kwargs):
+            """Simulate 1-based offset API returning up to limit items."""
+            start = offset - 1
+            return {"response": all_locations[start : start + limit]}
+
+        self.dnac.conn.sites.get_site.side_effect = fake_get_site
+        self.dnac.conn.sites.get_site_count.return_value = {"response": len(all_locations)}
+        actual = self.dnac.get_locations()
+        self.assertEqual(len(actual), len(all_locations))
 
     def test_get_locations_catches_api_error(self):
         """Test the get_locations method in DnaCenterClient catches dnacentersdkException."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1160

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This PR changes the `DnaCenterClient.get_locations` method to set an explicit page size (limit) instead of relying on the number of returned items.

## Detailed Analysis

In the existing implementation, we use the default page size for the API call, which is 50. We explicitly set the starting offset to 1 and then increment the offset by how many records we have fully retrieved. This works fine if there are 100 or fewer locations, but it starts to break down once you hit exactly 100 locations:

| Call | Offset | Items Returned | loc_data Length | Unique Items | Duplicate |
|------|--------|----------------|-----------------|--------------|-----------|
| 1    | 1      | 1–50           | 50              | 50           | —         |
| 2    | 50     | 50–99          | 100             | 99           | item 50   |

As you can see in the table above, we retrieved location 50 twice, and then we remove the duplicates as part of the for loop after we retrieve them all:

https://github.com/nautobot/nautobot-app-ssot/blob/0d9ded09ad82769ca980e2a08ba96c95d5e1cc7b/nautobot_ssot/integrations/dna_center/utils/dna_center.py#L51-L54

Once you have over 100 locations, the loop "self corrects" and retrieves all locations and deals with the duplicates afterward...until you hit another iteration of the default page size (150):

| Call | Offset | Items Returned | loc_data Length | Unique Items | Duplicate |
|------|--------|----------------|-----------------|--------------|-----------|
| 1    | 1      | 1–50           | 50              | 50           | —         |
| 2    | 50     | 50–99          | 100             | 99           | item 50   |
| 3    | 100    | 100–149        | 150             | 149          | —  |

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-5064