### PR TITLE
U/swanandtambe fix dnac latitude and longitude in nautobot adapter to the model default and get diff to work.

### DIFF
--- a/changes/NTC-5084.fixed
+++ b/changes/NTC-5084.fixed
@@ -1,0 +1,1 @@
+Fixed dnac latitude and longitude in nautobot adapter to match the model default and get diff to work.

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
@@ -129,8 +129,8 @@ class NautobotAdapter(Adapter):
                     address=building.physical_address,
                     area=building.parent.name if building.parent else "",
                     area_parent=building.parent.parent.name if building.parent and building.parent.parent else None,
-                    latitude=float(round(Decimal(building.latitude if building.latitude else 0.0), 9)),
-                    longitude=float(round(Decimal(building.longitude if building.longitude else 0.0), 7)),
+                    latitude=float(round(Decimal(building.latitude), 9)) if building.latitude else None,
+                    longitude=float(round(Decimal(building.longitude), 7)) if building.longitude else None,
                     tenant=building.tenant.name if building.tenant else None,
                     uuid=building.id,
                 )


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>NTC-5084

## What's Changed
Setting the latitude and longitude on Nautobot adapter to None if no input instead of 0.0.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
