### PR TITLE
Fix custom log groupings being discarded when parallel adapter loading was enabled

### DIFF
--- a/changes/1183.fixed
+++ b/changes/1183.fixed
@@ -1,0 +1,1 @@
+Fixed custom log groupings being discarded when parallel adapter loading was enabled.

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -86,7 +86,7 @@ That's a **40% time savings** in this example! In practice, when both adapters i
 - The target adapter loads in another thread simultaneously
 - While one adapter waits for a network response, the other can keep working
 - All log messages from both adapters are collected and shown in chronological order
-- Each Job log shows whether it came from "source" or "target"
+- Log messages preserve any custom groupings set by integrations (e.g., "Loading Data", "Data Quality Issues"); messages without a custom grouping default to "source" or "target"
 - You'll see timing information for each adapter separately
 
 **When to disable parallel loading:**

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -281,13 +281,16 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
                 # Include exception information if present
                 message += "\n" + "".join(traceback.format_exception(*record.exc_info))
 
-            # Create JobLogEntry object with grouping set to adapter type
+            # Use the custom grouping from the log record's extra dict if present,
+            # falling back to adapter_type ("source"/"target") when not set.
+            grouping = record.__dict__.get("grouping", adapter_type)
+
             # Note: JobLogEntry fields may vary by Nautobot version, using common fields
             JobLogEntry.objects.create(
                 job_result=job_result,
                 log_level=log_level,
                 message=message,
-                grouping=adapter_type,  # Group by source or target adapter
+                grouping=grouping,
             )
 
         # Merge source and target logs by timestamp to show interleaved execution

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -283,7 +283,11 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
 
             # Use the custom grouping from the log record's extra dict if present,
             # falling back to adapter_type ("source"/"target") when not set.
-            grouping = record.__dict__.get("grouping", adapter_type)
+            custom_grouping = record.__dict__.get("grouping")
+            if custom_grouping:
+                grouping = f"{custom_grouping} ({adapter_type})"
+            else:
+                grouping = adapter_type
 
             # Note: JobLogEntry fields may vary by Nautobot version, using common fields
             JobLogEntry.objects.create(

--- a/nautobot_ssot/tests/test_jobs.py
+++ b/nautobot_ssot/tests/test_jobs.py
@@ -374,6 +374,59 @@ class BaseJobTestCase(TransactionTestCase):  # pylint: disable=too-many-public-m
         self.assertIn("Source adapter loading completed", log_messages)
         self.assertIn("Target adapter loading completed", log_messages)
 
+    def test_parallel_loading_preserves_custom_groupings(self):
+        """Test that custom log groupings from extra dict are preserved in parallel mode.
+
+        Regression test: previously, create_job_log_entry() hardcoded grouping=adapter_type
+        ("source"/"target"), discarding the custom grouping set via extra={"grouping": ...}.
+        """
+        mock_diff = self._create_mock_diff()
+
+        def load_source():
+            """Simulate source adapter loading with custom log groupings."""
+            logger = logging.getLogger(f"nautobot.extras.jobs.run_job[{self.job.job_result.id}]")
+            logger.info("Loading locations from ServiceNow", extra={"grouping": "Loading ServiceNow Data"})
+            logger.warning("Bad record skipped", extra={"grouping": "Data Quality Issues"})
+            source_adapter = Mock()
+            source_adapter.diff_to.return_value = mock_diff
+            self.job.source_adapter = source_adapter
+
+        def load_target():
+            """Simulate target adapter loading with custom log groupings."""
+            logger = logging.getLogger(f"nautobot.extras.jobs.run_job[{self.job.job_result.id}]")
+            logger.info("Loading devices from Nautobot", extra={"grouping": "Loading Nautobot Data"})
+            self.job.target_adapter = Mock()
+
+        self.job.load_source_adapter = load_source
+        self.job.load_target_adapter = load_target
+
+        self.job.run(dryrun=True, memory_profiling=False, parallel_loading=True)
+
+        log_entries = JobLogEntry.objects.filter(job_result=self.job.job_result)
+
+        # Custom groupings should be preserved, not collapsed to "source"/"target"
+        sn_data_logs = log_entries.filter(grouping="Loading ServiceNow Data")
+        self.assertGreater(sn_data_logs.count(), 0, "Custom grouping 'Loading ServiceNow Data' should be preserved")
+
+        dq_logs = log_entries.filter(grouping="Data Quality Issues")
+        self.assertGreater(dq_logs.count(), 0, "Custom grouping 'Data Quality Issues' should be preserved")
+
+        nb_data_logs = log_entries.filter(grouping="Loading Nautobot Data")
+        self.assertGreater(nb_data_logs.count(), 0, "Custom grouping 'Loading Nautobot Data' should be preserved")
+
+        # Verify the actual messages landed under the correct groupings
+        sn_messages = [e.message for e in sn_data_logs]
+        self.assertTrue(
+            any("Loading locations" in m for m in sn_messages),
+            f"Expected 'Loading locations' in ServiceNow Data logs, got: {sn_messages}",
+        )
+
+        dq_messages = [e.message for e in dq_logs]
+        self.assertTrue(
+            any("Bad record" in m for m in dq_messages),
+            f"Expected 'Bad record' in Data Quality Issues logs, got: {dq_messages}",
+        )
+
     def test_parallel_loading_timing_information(self):
         """Test that timing information is correctly recorded for parallel loading."""
         mock_diff = self._create_mock_diff()

--- a/nautobot_ssot/tests/test_jobs.py
+++ b/nautobot_ssot/tests/test_jobs.py
@@ -405,14 +405,15 @@ class BaseJobTestCase(TransactionTestCase):  # pylint: disable=too-many-public-m
         log_entries = JobLogEntry.objects.filter(job_result=self.job.job_result)
 
         # Custom groupings should be preserved, not collapsed to "source"/"target"
-        sn_data_logs = log_entries.filter(grouping="Loading ServiceNow Data")
-        self.assertGreater(sn_data_logs.count(), 0, "Custom grouping 'Loading ServiceNow Data' should be preserved")
 
-        dq_logs = log_entries.filter(grouping="Data Quality Issues")
-        self.assertGreater(dq_logs.count(), 0, "Custom grouping 'Data Quality Issues' should be preserved")
+        sn_data_logs = log_entries.filter(grouping="Loading ServiceNow Data (source)")
+        self.assertGreater(sn_data_logs.count(), 0, "Custom grouping 'Loading ServiceNow Data (source)' should be preserved")
 
-        nb_data_logs = log_entries.filter(grouping="Loading Nautobot Data")
-        self.assertGreater(nb_data_logs.count(), 0, "Custom grouping 'Loading Nautobot Data' should be preserved")
+        dq_logs = log_entries.filter(grouping="Data Quality Issues (source)")
+        self.assertGreater(dq_logs.count(), 0, "Custom grouping 'Data Quality Issues (source)' should be preserved")
+
+        nb_data_logs = log_entries.filter(grouping="Loading Nautobot Data (target)")
+        self.assertGreater(nb_data_logs.count(), 0, "Custom grouping 'Loading Nautobot Data (target)' should be preserved")
 
         # Verify the actual messages landed under the correct groupings
         sn_messages = [e.message for e in sn_data_logs]

--- a/nautobot_ssot/tests/test_jobs.py
+++ b/nautobot_ssot/tests/test_jobs.py
@@ -407,13 +407,17 @@ class BaseJobTestCase(TransactionTestCase):  # pylint: disable=too-many-public-m
         # Custom groupings should be preserved, not collapsed to "source"/"target"
 
         sn_data_logs = log_entries.filter(grouping="Loading ServiceNow Data (source)")
-        self.assertGreater(sn_data_logs.count(), 0, "Custom grouping 'Loading ServiceNow Data (source)' should be preserved")
+        self.assertGreater(
+            sn_data_logs.count(), 0, "Custom grouping 'Loading ServiceNow Data (source)' should be preserved"
+        )
 
         dq_logs = log_entries.filter(grouping="Data Quality Issues (source)")
         self.assertGreater(dq_logs.count(), 0, "Custom grouping 'Data Quality Issues (source)' should be preserved")
 
         nb_data_logs = log_entries.filter(grouping="Loading Nautobot Data (target)")
-        self.assertGreater(nb_data_logs.count(), 0, "Custom grouping 'Loading Nautobot Data (target)' should be preserved")
+        self.assertGreater(
+            nb_data_logs.count(), 0, "Custom grouping 'Loading Nautobot Data (target)' should be preserved"
+        )
 
         # Verify the actual messages landed under the correct groupings
         sn_messages = [e.message for e in sn_data_logs]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1183

A bug of sorts which masks detailed log messages through discarding their groupings. 

## What's Changed

When parallel adapter loading is enabled, the create_job_log_entry() function in _load_adapters_parallel() hardcoded grouping=adapter_type, which collapsed all custom log groupings (e.g., "Loading ServiceNow Data", "Data Quality Issues") to generic "source" or "target" labels.

The fix reads the custom grouping from the captured LogRecord's __dict__, falling back to adapter_type when no custom grouping was set:

#### Before
grouping=adapter_type

#### After
grouping = record.__dict__.get("grouping", adapter_type)

This affects all SSoT integrations that set extra={"grouping": ...} in their adapter log calls.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [X] Outline Remaining Work, Constraints from Design
