### PR TITLE
fix: Arista CV integration get ip address not accounting for multiple responses.

### DIFF
--- a/changes/1182.fixed
+++ b/changes/1182.fixed
@@ -1,0 +1,1 @@
+Fixed the Arista CV integration get ip interfaces not accounting for intfID and ip address being in seperate query responses.

--- a/changes/1182.fixed
+++ b/changes/1182.fixed
@@ -1,1 +1,1 @@
-Fixed the Arista CV integration get ip interfaces not accounting for intfID and ip address being in seperate query responses.
+Fixed the Arista CV integration get ip interfaces not accounting for intfID and ip address being in separate query responses.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -655,19 +655,23 @@ def get_ip_interfaces(client: CloudvisionApi, dId: str):
 
     ip_intfs = []
     for batch in client.get(query):
+        new_intf = {}
+        addr_with_mask = None
+        virtual_addr_with_mask = None
         for notif in batch["notifications"]:
             results = notif["updates"]
-            if results.get("intfId") and results.get("addrWithMask"):
-                ip_intfs.append(
-                    {
-                        "interface": results["intfId"],
-                        "address": (
-                            results["addrWithMask"]
-                            if results["addrWithMask"] != "0.0.0.0/0"
-                            else results.get("virtualAddrWithMask")
-                        ),
-                    }
-                )
+            if results.get("intfId"):
+                new_intf["interface"] = results["intfId"]
+            if results.get("addrWithMask"):
+                addr_with_mask = results["addrWithMask"]
+            if results.get("virtualAddrWithMask"):
+                virtual_addr_with_mask = results["virtualAddrWithMask"]
+        if addr_with_mask and addr_with_mask != "0.0.0.0/0":
+            new_intf["address"] = addr_with_mask
+        elif virtual_addr_with_mask:
+            new_intf["address"] = virtual_addr_with_mask
+        if new_intf.get("interface") and new_intf.get("address"):
+            ip_intfs.append(new_intf)
     return ip_intfs
 
 

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -662,11 +662,11 @@ def get_ip_interfaces(client: CloudvisionApi, dId: str):
             results = notif["updates"]
             if results.get("intfId"):
                 new_intf["interface"] = results["intfId"]
-            if results.get("addrWithMask"):
+            if results.get("addrWithMask") and results["addrWithMask"] != "0.0.0.0/0":
                 addr_with_mask = results["addrWithMask"]
-            if results.get("virtualAddrWithMask"):
+            if results.get("virtualAddrWithMask") and results["virtualAddrWithMask"] != "0.0.0.0/0":
                 virtual_addr_with_mask = results["virtualAddrWithMask"]
-        if addr_with_mask and addr_with_mask != "0.0.0.0/0":
+        if addr_with_mask:
             new_intf["address"] = addr_with_mask
         elif virtual_addr_with_mask:
             new_intf["address"] = virtual_addr_with_mask

--- a/nautobot_ssot/tests/aristacv/fixtures/fixtures.py
+++ b/nautobot_ssot/tests/aristacv/fixtures/fixtures.py
@@ -29,3 +29,9 @@ ACCESS_INTF_MODE_QUERY = load_json(
 )
 IP_INTF_QUERY = load_json("./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_client_query.json")
 IP_INTF_FIXTURE = load_json("./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_response.json")
+IP_INTF_SPLIT_NOTIF_QUERY = load_json(
+    "./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_client_query.json"
+)
+IP_INTF_SPLIT_NOTIF_FIXTURE = load_json(
+    "./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_response.json"
+)

--- a/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_client_query.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_client_query.json
@@ -1,0 +1,93 @@
+[
+    {
+        "dataset": {
+            "name": "JPE12345678",
+            "type": "device"
+        },
+        "notifications": [
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet1"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093825
+                },
+                "updates": {
+                    "intfId": "Ethernet1"
+                }
+            },
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet1"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093826
+                },
+                "updates": {
+                    "addrWithMask": "10.0.0.1/30",
+                    "virtualAddrWithMask": "0.0.0.0/0"
+                }
+            }
+        ]
+    },
+    {
+        "dataset": {
+            "name": "JPE12345678",
+            "type": "device"
+        },
+        "notifications": [
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Vlan100"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093825
+                },
+                "updates": {
+                    "intfId": "Vlan100",
+                    "addrWithMask": "0.0.0.0/0",
+                    "virtualAddrWithMask": "0.0.0.0/0"
+                }
+            },
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Vlan100"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093826
+                },
+                "updates": {
+                    "virtualAddrWithMask": "192.168.1.1/24"
+                }
+            }
+        ]
+    }
+]

--- a/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_response.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_response.json
@@ -1,0 +1,10 @@
+[
+    {
+        "interface": "Ethernet1",
+        "address": "10.0.0.1/30"
+    },
+    {
+        "interface": "Vlan100",
+        "address": "192.168.1.1/24"
+    }
+]

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -397,3 +397,23 @@ class TestCloudvisionUtils(TestCase):
             results = cloudvision.get_ip_interfaces(client=self.client, dId="JPE12345678")
         expected = fixtures.IP_INTF_FIXTURE
         self.assertEqual(results, expected)
+
+    def test_get_ip_interfaces_split_notifications(self):
+        """Test get_ip_interfaces when intfId and addrWithMask are in separate gRPC notifications."""
+        mock_query = MagicMock()
+        mock_query.dataset.type = "device"
+        mock_query.dataset.name = "JPE12345678"
+        mock_query.paths.path_elements = [
+            "\304\005Sysdb",
+            "\304\002ip",
+            "\304\006config",
+            "\304\014ipIntfConfig",
+            "\307\00\001",
+        ]
+
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", mock_query):
+            self.client.get = MagicMock()
+            self.client.get.return_value = fixtures.IP_INTF_SPLIT_NOTIF_QUERY
+            results = cloudvision.get_ip_interfaces(client=self.client, dId="JPE12345678")
+        expected = fixtures.IP_INTF_SPLIT_NOTIF_FIXTURE
+        self.assertEqual(results, expected)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1182 <ISSUE NUMBER GOES HERE>

## What's Changed
Arista CV integration get ip address function accounts for intfID and IP address to be in multiple responses for the query.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
