### PR TITLE
Fix TemplateDoesNotExist error on Sync Job Logs tab with Nautobot 3.1.0

### DIFF
--- a/changes/1189.fixed
+++ b/changes/1189.fixed
@@ -1,0 +1,1 @@
+Removed reference to deleted `extras/inc/jobresult_js.html` template that was removed in Nautobot 3.1.0, which caused a `TemplateDoesNotExist` error on the Sync Job Logs tab.

--- a/nautobot_ssot/templates/nautobot_ssot/inc/jobresult_tab.html
+++ b/nautobot_ssot/templates/nautobot_ssot/inc/jobresult_tab.html
@@ -4,7 +4,3 @@
         {% include "extras/inc/jobresult.html" with result=object.job_result %}
     </div>
 </div>
-
-{% block javascript %}
-    {% include "extras/inc/jobresult_js.html" with result=object.job_result %}
-{% endblock javascript %}


### PR DESCRIPTION
# Closes: #1189 

## What's Changed

Removes reference to extras/inc/jobresult_js.html which was deleted in Nautobot core PR [nautobot/nautobot#8788](https://github.com/nautobot/nautobot/issues/8788)
The HTMX-based log refresh is now self-contained within extras/inc/jobresult.html, so the separate JS include is no longer needed

Behavioral Note
The old jobresult_js.html + job_result.js provided three features via jQuery AJAX polling:

- Live status badge updates in the Summary panel
- Live log table refresh
- Auto page reload on job completion

With the Nautobot 3.1 HTMX migration, only the log table refresh is preserved (via hx-trigger="every 3s"). The status badge update and auto-reload on completion are no longer present — however this is consistent with how Nautobot core's own Job Result detail page now behaves in 3.1. Any restoration of those features should be addressed in Nautobot core.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
