### PR TITLE
fix: DNAC adapters to account for mtu=0 as an output from DNAC.

### DIFF
--- a/changes/NTC-5652.fixed
+++ b/changes/NTC-5652.fixed
@@ -1,0 +1,1 @@
+Change MTU in DNA Center integration to account for 0 as an output from DNAC and save it in Nautobot as None.

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -578,7 +578,7 @@ class DnaCenterAdapter(Adapter):
                     "port_type": port_type,
                     "port_mode": "tagged" if port["portMode"] == "trunk" else "access",
                     "mac_addr": port["macAddress"].upper() if port.get("macAddress") else None,
-                    "mtu": port["mtu"] if port.get("mtu", "0") != "0" else None,
+                    "mtu": port["mtu"] if port.get("mtu") and port.get("mtu") != "0" else None,
                     "status": port_status,
                     "uuid": None,
                 },

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/dna_center.py
@@ -578,7 +578,7 @@ class DnaCenterAdapter(Adapter):
                     "port_type": port_type,
                     "port_mode": "tagged" if port["portMode"] == "trunk" else "access",
                     "mac_addr": port["macAddress"].upper() if port.get("macAddress") else None,
-                    "mtu": port["mtu"] if port.get("mtu") else 1500,
+                    "mtu": port["mtu"] if port.get("mtu", "0") != "0" else None,
                     "status": port_status,
                     "uuid": None,
                 },

--- a/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/dna_center/diffsync/adapters/nautobot.py
@@ -231,7 +231,7 @@ class NautobotAdapter(Adapter):
                 port_type=port.type,
                 port_mode=port.mode,
                 mac_addr=str(port.mac_address) if getattr(port, "mac_address") else None,
-                mtu=port.mtu if port.mtu else 1500,
+                mtu=port.mtu if port.mtu and port.mtu != 0 else None,
                 status=port.status.name,
                 uuid=port.id,
             )

--- a/nautobot_ssot/tests/dna_center/fixtures/get_port_info.json
+++ b/nautobot_ssot/tests/dna_center/fixtures/get_port_info.json
@@ -120,7 +120,7 @@
         "mappedPhysicalInterfaceId": null,
         "mappedPhysicalInterfaceName": null,
         "mediaType": null,
-        "mtu": "1500",
+        "mtu": "",
         "name": null,
         "nativeVlanId": "1",
         "networkdevice_id": 295295,

--- a/nautobot_ssot/tests/dna_center/fixtures/get_port_info.json
+++ b/nautobot_ssot/tests/dna_center/fixtures/get_port_info.json
@@ -28,7 +28,7 @@
         "mappedPhysicalInterfaceId": null,
         "mappedPhysicalInterfaceName": null,
         "mediaType": null,
-        "mtu": "1500",
+        "mtu": "0",
         "name": null,
         "nativeVlanId": "",
         "networkdevice_id": 295295,

--- a/nautobot_ssot/tests/dna_center/fixtures/get_port_info_recv.json
+++ b/nautobot_ssot/tests/dna_center/fixtures/get_port_info_recv.json
@@ -29,7 +29,7 @@
             "mappedPhysicalInterfaceId": null,
             "mappedPhysicalInterfaceName": null,
             "mediaType": null,
-            "mtu": "1500",
+            "mtu": "0",
             "name": null,
             "nativeVlanId": "",
             "networkdevice_id": 295295,

--- a/nautobot_ssot/tests/dna_center/fixtures/get_port_info_recv.json
+++ b/nautobot_ssot/tests/dna_center/fixtures/get_port_info_recv.json
@@ -121,7 +121,7 @@
             "mappedPhysicalInterfaceId": null,
             "mappedPhysicalInterfaceName": null,
             "mediaType": null,
-            "mtu": "1500",
+            "mtu": "",
             "name": null,
             "nativeVlanId": "1",
             "networkdevice_id": 295295,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: # NTC-5652<ISSUE NUMBER GOES HERE>

## What's Changed
Changed default value of MTU to be None instead of 1500 and account for 0 as input.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
