### PR TITLE
Fixed creating and assigning device software for the Arista SSoT inte…

### DIFF
--- a/changes/1173.fixed
+++ b/changes/1173.fixed
@@ -1,0 +1,2 @@
+Fixed Arista SSoT integration to assign a device's software version on the first sync run.
+Fixed Arista SSoT integration to create new SoftwareVersion records with an Active status.

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -7,7 +7,6 @@ from nautobot.core.settings_funcs import is_truthy
 from nautobot.dcim.models import Device as OrmDevice
 from nautobot.dcim.models import Interface as OrmInterface
 from nautobot.dcim.models import Platform as OrmPlatform
-from nautobot.dcim.models import SoftwareVersion
 from nautobot.extras.models import Status as OrmStatus
 from nautobot.ipam.models import IPAddress as OrmIPAddress
 from nautobot.ipam.models import IPAddressToInterface
@@ -76,6 +75,9 @@ class NautobotDevice(Device):
             platform = OrmPlatform.objects.get(name=ARISTA_PLATFORM)
 
         device_type_object = nautobot.verify_device_type_object(attrs["device_model"])
+        software_version_object = (
+            nautobot.verify_software_version_object(attrs["version"], platform) if attrs.get("version") else None
+        )
 
         new_device = OrmDevice(
             status=OrmStatus.objects.get(name=attrs["status"]),
@@ -85,6 +87,7 @@ class NautobotDevice(Device):
             location=site,
             name=ids["name"],
             serial=attrs["serial"] if attrs.get("serial") else "",
+            software_version=software_version_object,
         )
 
         if config.apply_import_tag:
@@ -109,11 +112,11 @@ class NautobotDevice(Device):
             dev.device_type = nautobot.verify_device_type_object(attrs["device_model"])
         if "serial" in attrs:
             dev.serial = attrs["serial"]
-        if "version" in attrs:
-            dev.software_version = SoftwareVersion.objects.get_or_create(
-                version=attrs["version"],
-                platform=dev.platform,
-            )[0]
+        if attrs.get("version"):
+            dev.software_version = nautobot.verify_software_version_object(attrs["version"], dev.platform)
+        # If version is in attrs, but didn't trigger the condition directly above, it must be changing to None
+        elif "version" in attrs and dev.software_version:
+            dev.software_version = None
         try:
             dev.validated_save()
             return super().update(attrs)

--- a/nautobot_ssot/integrations/aristacv/utils/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/utils/nautobot.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from nautobot.core.models.utils import slugify
 from nautobot.core.settings_funcs import is_truthy
-from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
+from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer, SoftwareVersion
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.models import (
     ExternalIntegration,
@@ -226,6 +226,25 @@ def verify_device_type_object(device_type):
         device_type_obj = DeviceType(manufacturer=Manufacturer.objects.get(name="Arista"), model=device_type)
         device_type_obj.validated_save()
     return device_type_obj
+
+
+def verify_software_version_object(version, platform):
+    """Verifies whether SoftwareVersion object already exists in Nautobot. If not, creates it with Active status.
+
+    Args:
+        version (str): EOS software version string gathered from CloudVision.
+        platform (Platform): Platform ORM object the SoftwareVersion belongs to.
+    """
+    try:
+        software_version_obj = SoftwareVersion.objects.get(version=version, platform=platform)
+    except SoftwareVersion.DoesNotExist:
+        software_version_obj = SoftwareVersion(
+            version=version,
+            platform=platform,
+            status=Status.objects.get(name="Active"),
+        )
+        software_version_obj.validated_save()
+    return software_version_obj
 
 
 def verify_device_role_object(role_name, role_color):

--- a/nautobot_ssot/integrations/aristacv/utils/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/utils/nautobot.py
@@ -234,6 +234,9 @@ def verify_software_version_object(version, platform):
     Args:
         version (str): EOS software version string gathered from CloudVision.
         platform (Platform): Platform ORM object the SoftwareVersion belongs to.
+
+    Returns:
+        SoftwareVersion: SoftwareVersion object.
     """
     try:
         software_version_obj = SoftwareVersion.objects.get(version=version, platform=platform)

--- a/nautobot_ssot/tests/aristacv/test_models_nautobot.py
+++ b/nautobot_ssot/tests/aristacv/test_models_nautobot.py
@@ -1,15 +1,24 @@
-"""Unit tests for Arista CV Nautobot DiffSync model delete behavior."""
+"""Unit tests for Arista CV Nautobot DiffSync model behavior."""
 
 from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
+from diffsync import Adapter
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from nautobot.core.testing import TransactionTestCase
-from nautobot.extras.models import Status
+from nautobot.dcim.models import Device as OrmDevice
+from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer, Platform, SoftwareVersion
+from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import Namespace as OrmNamespace
 from nautobot.ipam.models import Prefix as OrmPrefix
 
-from nautobot_ssot.integrations.aristacv.diffsync.models.nautobot import NautobotNamespace, NautobotPrefix
+from nautobot_ssot.integrations.aristacv.constants import ARISTA_PLATFORM
+from nautobot_ssot.integrations.aristacv.diffsync.models.nautobot import (
+    NautobotDevice,
+    NautobotNamespace,
+    NautobotPrefix,
+)
 from nautobot_ssot.integrations.aristacv.utils.nautobot import get_config
 
 
@@ -98,3 +107,117 @@ class TestNautobotPrefixDelete(TransactionTestCase):
         model.delete()
         self.assertEqual(len(self.adapter.objects_to_delete["prefixes"]), 1)
         self.assertEqual(self.adapter.objects_to_delete["prefixes"][0].id, self.prefix.id)
+
+
+@override_settings(
+    PLUGINS_CONFIG={
+        "nautobot_ssot": {
+            "aristacv_cvaas_url": "https://www.arista.io",
+            "aristacv_cvp_user": "admin",
+            "aristacv_from_cloudvision_default_site": "TestSite",
+            "aristacv_from_cloudvision_default_device_role": "Edge Router",
+        },
+    },
+)
+class TestNautobotDeviceVersion(TransactionTestCase):
+    """Test that NautobotDevice.create() and update() correctly assign software_version."""
+
+    databases = ("default", "job_logs")
+
+    ATTRS = {
+        "device_model": "DCS-7150S-24",
+        "serial": "ABC123",
+        "status": "Active",
+        "version": "4.28.1F",
+    }
+    IDS = {"name": "switch-01"}
+
+    def setUp(self):
+        """Set up adapter with job and app_config plus baseline ORM objects."""
+        super().setUp()
+        # spec=Adapter so pydantic's is_instance_of check on DiffSyncModel.adapter passes.
+        self.adapter = MagicMock(spec=Adapter)
+        self.adapter.job = MagicMock()
+        self.adapter.job.debug = False
+        self.adapter.job.app_config = get_config()
+        self.status_active = Status.objects.get(name="Active")
+        arista_manu = Manufacturer.objects.get_or_create(name="Arista")[0]
+        self.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=arista_manu)[0]
+        self.device_type = DeviceType.objects.get_or_create(model="DCS-7150S-24", manufacturer=arista_manu)[0]
+        device_ct = ContentType.objects.get_for_model(OrmDevice)
+        self.role = Role.objects.get_or_create(name="Edge Router", color="ff0000")[0]
+        self.role.content_types.add(device_ct)
+        location_type = LocationType.objects.get_or_create(name="Site")[0]
+        location_type.content_types.add(device_ct)
+        self.location = Location.objects.create(
+            name="UpdateSite",
+            location_type=location_type,
+            status=self.status_active,
+        )
+
+    def test_create_assigns_software_version(self):
+        """Regression for #1173: create() must assign software_version on the first sync."""
+        NautobotDevice.create(adapter=self.adapter, ids=self.IDS, attrs=self.ATTRS)
+        device = OrmDevice.objects.get(name="switch-01")
+        self.assertIsNotNone(device.software_version)
+        self.assertEqual(device.software_version.version, "4.28.1F")
+        self.assertEqual(device.software_version.platform, self.arista_platform)
+        self.assertEqual(device.software_version.status, self.status_active)
+
+    def test_create_without_version_leaves_software_version_unset(self):
+        """When attrs has no version, create() leaves software_version unset."""
+        attrs = {**self.ATTRS, "version": None}
+        NautobotDevice.create(adapter=self.adapter, ids=self.IDS, attrs=attrs)
+        device = OrmDevice.objects.get(name="switch-01")
+        self.assertIsNone(device.software_version)
+
+    def _build_device(self, software_version=None):
+        """Create a real OrmDevice for use in update() tests."""
+        return OrmDevice.objects.create(
+            name="switch-02",
+            status=self.status_active,
+            device_type=self.device_type,
+            role=self.role,
+            platform=self.arista_platform,
+            location=self.location,
+            software_version=software_version,
+        )
+
+    def test_update_assigns_software_version(self):
+        """update() with a new version assigns it via the helper."""
+        device = self._build_device()
+        model = NautobotDevice(
+            name=device.name,
+            device_model=self.device_type.model,
+            serial="",
+            status="Active",
+            version=None,
+            uuid=device.id,
+        )
+        model.adapter = self.adapter
+        model.update({"version": "4.28.1F"})
+        device.refresh_from_db()
+        self.assertIsNotNone(device.software_version)
+        self.assertEqual(device.software_version.version, "4.28.1F")
+        self.assertEqual(device.software_version.status, self.status_active)
+
+    def test_update_clears_software_version_when_version_set_none(self):
+        """update() with version=None clears an existing software_version."""
+        existing_sv = SoftwareVersion.objects.create(
+            version="4.28.1F",
+            platform=self.arista_platform,
+            status=self.status_active,
+        )
+        device = self._build_device(software_version=existing_sv)
+        model = NautobotDevice(
+            name=device.name,
+            device_model=self.device_type.model,
+            serial="",
+            status="Active",
+            version="4.28.1F",
+            uuid=device.id,
+        )
+        model.adapter = self.adapter
+        model.update({"version": None})
+        device.refresh_from_db()
+        self.assertIsNone(device.software_version)

--- a/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
@@ -2,9 +2,10 @@
 
 from django.test import override_settings
 from nautobot.core.testing import TestCase
-from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer
+from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer, Platform, SoftwareVersion
 from nautobot.extras.models import Role, Status, Tag
 
+from nautobot_ssot.integrations.aristacv.constants import ARISTA_PLATFORM
 from nautobot_ssot.integrations.aristacv.utils import nautobot
 
 
@@ -16,6 +17,7 @@ class TestNautobotUtils(TestCase):
     def setUp(self):
         """Configure shared test vars."""
         self.arista_manu = Manufacturer.objects.get_or_create(name="Arista")[0]
+        self.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=self.arista_manu)[0]
 
     def test_verify_site_success(self):
         """Test the verify_site method for existing Site."""
@@ -43,6 +45,24 @@ class TestNautobotUtils(TestCase):
         result = nautobot.verify_device_type_object(device_type="DCS-7150S-24")
         self.assertEqual(result.model, "DCS-7150S-24")
         self.assertTrue(isinstance(result, DeviceType))
+
+    def test_verify_software_version_object_success(self):
+        """Test the verify_software_version_object method for existing SoftwareVersion."""
+        existing = SoftwareVersion.objects.create(
+            version="4.28.1F",
+            platform=self.arista_platform,
+            status=Status.objects.get(name="Active"),
+        )
+        result = nautobot.verify_software_version_object(version="4.28.1F", platform=self.arista_platform)
+        self.assertEqual(result, existing)
+
+    def test_verify_software_version_object_fail(self):
+        """Test the verify_software_version_object method for non-existing SoftwareVersion."""
+        result = nautobot.verify_software_version_object(version="4.29.0F", platform=self.arista_platform)
+        self.assertEqual(result.version, "4.29.0F")
+        self.assertEqual(result.platform, self.arista_platform)
+        self.assertEqual(result.status, Status.objects.get(name="Active"))
+        self.assertTrue(isinstance(result, SoftwareVersion))
 
     def test_verify_device_role_object_success(self):
         """Test the verify_device_role_object method for existing DeviceRole."""


### PR DESCRIPTION
…gration

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1173

## What's Changed
During the Arista SSoT job, we were gathering the software version (`sw_ver`) from CloudVision but not assigning it to the device. However, we were assigning it during an update. This PR fixes that. In addition, we weren't setting the status on the Software object so if it encountered a new software and attempted to create one then it would fail as well.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5548