### PR TITLE
fix(vsphere): handle missing VMware Tools in load_vm_interfaces

### DIFF
--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
@@ -303,7 +303,10 @@ class VsphereDiffSync(Adapter):
             diffsync_virtualmachine.add_child(diffsync_vminterface)
             # Get detail interfaces w/ ip's from VM - Only if VM is Enabled
             if vsphere_virtual_machine_details["power_state"] == "POWERED_ON":
-                vm_interfaces = self.client.get_vm_interfaces(vm_id=vm_id).json()["value"]
+                # VMware Tools may not be installed/running; the guest networking API
+                # returns an error dict without "value" in that case — treat as no IPs.
+                _resp = self.client.get_vm_interfaces(vm_id=vm_id).json()
+                vm_interfaces = _resp.get("value", []) if isinstance(_resp, dict) else []
 
                 # Load any IP addresses associated to this NIC/MAC
                 ipv4_addresses, ipv6_addresses = self.load_ip_addresses(


### PR DESCRIPTION
## Summary

When VMware Tools is not installed or not running on a powered-on VM, the vSphere guest networking API (`GET /rest/vcenter/vm/{id}/guest/networking/interfaces`) returns an error response (e.g. `com.vmware.vapi.std.errors.service_unavailable`) that does **not** contain a `"value"` key.

The current code does an unconditional `["value"]` dict lookup which raises `KeyError: 'value'` and aborts the entire sync job — no VMs are imported at all.

## Fix

Use `.get("value", [])` so that VMs without VMware Tools are imported without IP data, rather than crashing the job for all VMs.

```python
# Before
vm_interfaces = self.client.get_vm_interfaces(vm_id=vm_id).json()["value"]

# After
_resp = self.client.get_vm_interfaces(vm_id=vm_id).json()
vm_interfaces = _resp.get("value", []) if isinstance(_resp, dict) else []
```

## Reproduction

- vSphere 6.x environment with one or more powered-on VMs that have VMware Tools not installed or stopped
- Run the **VMWare vSphere ⟹ Nautobot** SSoT job with `use_clusters=False`
- Job fails immediately with `KeyError: 'value'` / `Error during parallel adapter loading`

## Test plan

- [ ] Job completes successfully when some VMs have VMware Tools and some do not
- [ ] VMs without Tools are imported with interfaces but no IP addresses
- [ ] VMs with Tools continue to have IPs populated as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)