### PR TITLE
fix: Missing update_network_container method call in the model and add get ref in container.

### DIFF
--- a/changes/1208.fixed
+++ b/changes/1208.fixed
@@ -1,0 +1,1 @@
+Fixed Infoblox SSoT sync not updating prefixes with `container` network type.

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/infoblox.py
@@ -68,11 +68,19 @@ class InfobloxNetwork(Network):
             network_view_to_namespace_map=self.adapter.config.infoblox_network_view_to_namespace_map,
             direction="ns_to_nv",
         )
-        self.adapter.conn.update_network(
-            prefix=self.get_identifiers()["network"],
-            network_view=network_view,
-            comment=attrs.get("description", ""),
-        )
+        network_type = attrs.get("network_type", self.network_type)
+        if network_type != "container":
+            self.adapter.conn.update_network(
+                prefix=self.get_identifiers()["network"],
+                network_view=network_view,
+                comment=attrs.get("description", ""),
+            )
+        else:
+            self.adapter.conn.update_network_container(
+                prefix=self.get_identifiers()["network"],
+                network_view=network_view,
+                comment=attrs.get("description", ""),
+            )
         if attrs.get("ranges"):
             self.adapter.job.logger.warning(
                 f"Prefix, {self.network}-{self.namespace}, has a change of Ranges in Nautobot, but"

--- a/nautobot_ssot/integrations/infoblox/utils/client.py
+++ b/nautobot_ssot/integrations/infoblox/utils/client.py
@@ -279,7 +279,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             logger.error(response.text)
             return response.text
         if results and len(results):
-            return results[0]
+            return results[0].get("_ref")
         return None
 
     def get_all_ipv4address_networks(self, prefixes):


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1208 

## What's Changed
Added update_network_container method call to the Infoblox model update method. Fixes errors with api calls for network containers and sync job misses.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
