### PR TITLE
Optimized AristaCV device loading

### DIFF
--- a/changes/1206.changed
+++ b/changes/1206.changed
@@ -1,0 +1,1 @@
+Optimized AristaCV SSoT device loading by fetching interface modes, transceivers, and descriptions once per device.

--- a/changes/1206.fixed
+++ b/changes/1206.fixed
@@ -1,0 +1,1 @@
+Fixed AristaCV `get_ip_interfaces` overwriting interface state when CloudVision coalesces notifications for multiple interfaces into a single gRPC batch.

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -122,6 +122,9 @@ class CloudvisionAdapter(Adapter):
         port_info = port_channels + port_info
 
         member_map = cloudvision.get_port_channel_members(client=self.conn, dId=device.serial)
+        mode_map = cloudvision.get_all_interface_modes(client=self.conn, dId=device.serial)
+        transceiver_map = cloudvision.get_all_interface_transceivers(client=self.conn, dId=device.serial)
+        description_map = cloudvision.get_all_interface_descriptions(client=self.conn, dId=device.serial)
 
         if self.job.debug:
             self.job.logger.debug(f"Device being loaded: {device.name}. Port: {port_info}.")
@@ -130,20 +133,14 @@ class CloudvisionAdapter(Adapter):
             if self.job.debug:
                 self.job.logger.debug(f"Port {port['interface']} being loaded for {device.name}.")
 
-            port_mode = cloudvision.get_interface_mode(client=self.conn, dId=device.serial, interface=port["interface"])
-            transceiver = cloudvision.get_interface_transceiver(
-                client=self.conn, dId=device.serial, interface=port["interface"]
-            )
+            port_mode = mode_map.get(port["interface"], "Unknown")
+            transceiver = transceiver_map.get(port["interface"], "Unknown")
 
             if transceiver == "Unknown":
                 # Breakout transceivers, ie 40G -> 4x10G, shows up as 4 interfaces and requires looking at base interface to find transceiver, ie Ethernet1 if Ethernet1/1
                 base_port_name = re.sub(r"/\d", "", port["interface"])
-                transceiver = cloudvision.get_interface_transceiver(
-                    client=self.conn, dId=device.serial, interface=base_port_name
-                )
-            port_description = cloudvision.get_interface_description(
-                client=self.conn, dId=device.serial, interface=port["interface"]
-            )
+                transceiver = transceiver_map.get(base_port_name, "Unknown")
+            port_description = description_map.get(port["interface"], "")
             port_status = cloudvision.get_interface_status(port_info=port)
             port_type = cloudvision.get_port_type(port_info=port, transceiver=transceiver)
             if port["interface"] != "":

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -517,9 +517,7 @@ def get_interfaces_chassis(client: CloudvisionApi, dId):
     for lc in queryLC:
         pathElts = ["Sysdb", "interface", "status", "eth", "phy", "slice", lc, "intfStatus", Wildcard()]
 
-        query = [create_query([(pathElts, [])], dataset)]
-
-        for batch in client.get(query):
+        for batch in clean_query_results(pathElts, client, dataset):
             for notif in batch["notifications"]:
                 results = notif["updates"]
                 if not results.get("intfId"):
@@ -547,11 +545,9 @@ def get_interfaces_fixed(client: CloudvisionApi, dId: str):
         dId (str): Device ID to determine type for.
     """
     pathElts = ["Sysdb", "interface", "status", "eth", "phy", "slice", "1", "intfStatus", Wildcard()]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
     intfStatusFixed = []
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             results = notif["updates"]
             if not results.get("intfId"):
@@ -669,10 +665,8 @@ def get_interface_transceiver(client: CloudvisionApi, dId: str, interface: str):
         interface (str): Name of interface to get transceiver information for.
     """
     pathElts = ["Sysdb", "hardware", "archer", "xcvr", "status", "all", interface]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             if notif["updates"].get("actualIdEepromContents") and notif["updates"]["actualIdEepromContents"].get(
                 "mediaType"
@@ -685,6 +679,34 @@ def get_interface_transceiver(client: CloudvisionApi, dId: str, interface: str):
     return "Unknown"
 
 
+def get_all_interface_transceivers(client: CloudvisionApi, dId: str) -> dict:
+    """Fetch transceiver information for every interface on a device in a single query.
+
+    Args:
+        client (CloudvisionApi): CloudVision connection.
+        dId (str): Device ID to retrieve transceivers for.
+
+    Returns:
+        dict[str, str]: Mapping of interface name to transceiver media type. Interfaces
+        with no transceiver data are omitted; callers should fall back to "Unknown".
+    """
+    pathElts = ["Sysdb", "hardware", "archer", "xcvr", "status", "all", Wildcard()]
+
+    transceivers = {}
+    for batch in clean_query_results(pathElts, client, dId):
+        for notif in batch["notifications"]:
+            updates = notif["updates"]
+            intf = notif["path_elements"][-1]
+            eeprom = updates.get("actualIdEepromContents")
+            if isinstance(eeprom, dict) and eeprom.get("mediaType"):
+                transceivers[intf] = eeprom["mediaType"]
+            elif updates.get("mediaType"):
+                transceivers[intf] = updates["mediaType"]["Name"]
+            elif updates.get("localMediaType"):
+                transceivers[intf] = updates["localMediaType"]["Name"]
+    return transceivers
+
+
 def get_interface_mode(client: CloudvisionApi, dId: str, interface: str):
     """Gets interface mode, ie access/trunked.
 
@@ -694,14 +716,37 @@ def get_interface_mode(client: CloudvisionApi, dId: str, interface: str):
         interface (str): Name of interface to get mode information for.
     """
     pathElts = ["Sysdb", "bridging", "switchIntfConfig", "switchIntfConfig", interface]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             if notif["updates"].get("switchportMode"):
                 return notif["updates"]["switchportMode"]["Name"]
     return "Unknown"
+
+
+def get_all_interface_modes(client: CloudvisionApi, dId: str) -> dict:
+    """Fetch switchport modes for every interface on a device in a single query.
+
+    Args:
+        client (CloudvisionApi): CloudVision connection.
+        dId (str): Device ID to retrieve modes for.
+
+    Returns:
+        dict[str, str]: Mapping of interface name to switchport mode (e.g. "trunk",
+        "access"). Interfaces with no mode data are omitted; callers should fall back
+        to "Unknown".
+    """
+    pathElts = ["Sysdb", "bridging", "switchIntfConfig", "switchIntfConfig", Wildcard()]
+
+    modes = {}
+    for batch in clean_query_results(pathElts, client, dId):
+        for notif in batch["notifications"]:
+            mode = notif["updates"].get("switchportMode")
+            if not mode:
+                continue
+            intf = notif["path_elements"][-1]
+            modes[intf] = mode["Name"]
+    return modes
 
 
 def get_port_type(port_info: dict, transceiver: str) -> str:
@@ -762,14 +807,47 @@ def get_interface_description(client: CloudvisionApi, dId: str, interface: str):
         pathElts = ["Sysdb", "interface", "config", "eth", "lag", "intfConfig", interface]
     else:
         pathElts = ["Sysdb", "interface", "config", "eth", "phy", "slice", "1", "intfConfig", interface]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             if notif["updates"].get("description") and notif["updates"]["description"] is not None:
                 return notif["updates"]["description"]
     return ""
+
+
+def get_all_interface_descriptions(client: CloudvisionApi, dId: str) -> dict:
+    """Fetch descriptions for every interface on a device.
+
+    CloudVision stores interface descriptions under two different path shapes:
+    physical Ethernet at config/eth/phy/slice/<slice>/intfConfig/<intf>, and
+    everything else (Port-Channel, L3, Vlan, Loopback, ...) at config/<x>/<y>/intfConfig/<intf>.
+    Each Wildcard() matches exactly one segment, so two queries are required.
+
+    Args:
+        client (CloudvisionApi): CloudVision connection.
+        dId (str): Device ID to retrieve descriptions for.
+
+    Returns:
+        dict[str, str]: Mapping of interface name to description. Interfaces with no
+        description are omitted; callers should fall back to "".
+    """
+    paths = [
+        # Physical Ethernet: eth/phy/slice/<slice>/intfConfig/<intf>
+        ["Sysdb", "interface", "config", "eth", "phy", "slice", Wildcard(), "intfConfig", Wildcard()],
+        # Non-physical (Port-Channel, L3, Vlan, Loopback, ...): <x>/<y>/intfConfig/<intf>
+        ["Sysdb", "interface", "config", Wildcard(), Wildcard(), "intfConfig", Wildcard()],
+    ]
+
+    descriptions = {}
+    for pathElts in paths:
+        for batch in clean_query_results(pathElts, client, dId):
+            for notif in batch["notifications"]:
+                updates = notif["updates"]
+                intf = updates.get("intfId")
+                description = updates.get("description")
+                if intf and description:
+                    descriptions[intf] = description
+    return descriptions
 
 
 def get_routed_interface_description(client: CloudvisionApi, dId: str, interface: str) -> str:
@@ -784,9 +862,8 @@ def get_routed_interface_description(client: CloudvisionApi, dId: str, interface
         interface (str): Name of interface to get description for.
     """
     pathElts = ["Sysdb", "interface", "config", Wildcard(), Wildcard(), "intfConfig", Wildcard()]
-    query = [create_query([(pathElts, [])], dId)]
 
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             updates = notif["updates"]
             if updates.get("intfId") == interface:
@@ -803,10 +880,8 @@ def get_interface_vrf(client: CloudvisionApi, dId: str, interface: str) -> str:
         interface (str): Name of interface to get mode information for.
     """
     pathElts = ["Sysdb", "l3", "intf", "config", "intfConfig", interface]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
-    for batch in client.get(query):
+    for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
             if notif["updates"].get("vrf"):
                 return notif["updates"]["vrf"]["value"]
@@ -821,28 +896,27 @@ def get_ip_interfaces(client: CloudvisionApi, dId: str):
         dId (str): Device ID to retrieve IP Addresses and associated interfaces for.
     """
     pathElts = ["Sysdb", "ip", "config", "ipIntfConfig", Wildcard()]
-    query = [create_query([(pathElts, [])], dId)]
-    query = unfreeze_frozen_dict(query)
 
     ip_intfs = []
-    for batch in client.get(query):
-        new_intf = {}
-        addr_with_mask = None
-        virtual_addr_with_mask = None
+    for batch in clean_query_results(pathElts, client, dId):
+        # Group notifications by the wildcarded interface name from the path. gRPC can coalesce
+        # multiple interfaces into one batch, so per-batch accumulators would silently overwrite
+        # earlier interfaces' state.
+        per_intf = {}
         for notif in batch["notifications"]:
-            results = notif["updates"]
-            if results.get("intfId"):
-                new_intf["interface"] = results["intfId"]
-            if results.get("addrWithMask") and results["addrWithMask"] != "0.0.0.0/0":
-                addr_with_mask = results["addrWithMask"]
-            if results.get("virtualAddrWithMask") and results["virtualAddrWithMask"] != "0.0.0.0/0":
-                virtual_addr_with_mask = results["virtualAddrWithMask"]
-        if addr_with_mask:
-            new_intf["address"] = addr_with_mask
-        elif virtual_addr_with_mask:
-            new_intf["address"] = virtual_addr_with_mask
-        if new_intf.get("interface") and new_intf.get("address"):
-            ip_intfs.append(new_intf)
+            intf_name = notif["path_elements"][-1]
+            entry = per_intf.setdefault(intf_name, {})
+            updates = notif["updates"]
+            if updates.get("intfId"):
+                entry["interface"] = updates["intfId"]
+            if updates.get("addrWithMask") and updates["addrWithMask"] != "0.0.0.0/0":
+                entry["addr"] = updates["addrWithMask"]
+            if updates.get("virtualAddrWithMask") and updates["virtualAddrWithMask"] != "0.0.0.0/0":
+                entry["virtual_addr"] = updates["virtualAddrWithMask"]
+        for entry in per_intf.values():
+            address = entry.get("addr") or entry.get("virtual_addr")
+            if entry.get("interface") and address:
+                ip_intfs.append({"interface": entry["interface"], "address": address})
     return ip_intfs
 
 

--- a/nautobot_ssot/tests/aristacv/fixtures/fixtures.py
+++ b/nautobot_ssot/tests/aristacv/fixtures/fixtures.py
@@ -57,3 +57,9 @@ IP_INTF_SPLIT_NOTIF_QUERY = load_json(
 IP_INTF_SPLIT_NOTIF_FIXTURE = load_json(
     "./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_split_notif_response.json"
 )
+IP_INTF_COALESCED_BATCH_QUERY = load_json(
+    "./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_client_query.json"
+)
+IP_INTF_COALESCED_BATCH_FIXTURE = load_json(
+    "./nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_response.json"
+)

--- a/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_client_query.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_client_query.json
@@ -1,0 +1,84 @@
+[
+    {
+        "dataset": {
+            "name": "JPE12345678",
+            "type": "device"
+        },
+        "notifications": [
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet1"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093825
+                },
+                "updates": {
+                    "intfId": "Ethernet1"
+                }
+            },
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet1"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093826
+                },
+                "updates": {
+                    "addrWithMask": "10.0.0.1/30",
+                    "virtualAddrWithMask": "0.0.0.0/0"
+                }
+            },
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet2"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093827
+                },
+                "updates": {
+                    "intfId": "Ethernet2"
+                }
+            },
+            {
+                "deletes": [],
+                "path_elements": [
+                    "Sysdb",
+                    "ip",
+                    "config",
+                    "ipIntfConfig",
+                    "Ethernet2"
+                ],
+                "retracts": [],
+                "timestamp": {
+                    "seconds": 1666161641,
+                    "nanos": 192093828
+                },
+                "updates": {
+                    "addrWithMask": "10.0.0.5/30",
+                    "virtualAddrWithMask": "0.0.0.0/0"
+                }
+            }
+        ]
+    }
+]

--- a/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_response.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_ip_interfaces_coalesced_batch_response.json
@@ -1,0 +1,10 @@
+[
+    {
+        "interface": "Ethernet1",
+        "address": "10.0.0.1/30"
+    },
+    {
+        "interface": "Ethernet2",
+        "address": "10.0.0.5/30"
+    }
+]

--- a/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
@@ -38,14 +38,19 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
         self.cloudvision.get_interfaces_port_channel.return_value = fixtures.PORT_CHANNEL_INTERFACE_FIXTURE
         self.cloudvision.get_port_channel_members = MagicMock()
         self.cloudvision.get_port_channel_members.return_value = fixtures.PORT_CHANNEL_MEMBERS_FIXTURE
-        self.cloudvision.get_interface_mode = MagicMock()
-        self.cloudvision.get_interface_mode.return_value = "access"
-        self.cloudvision.get_interface_transceiver = MagicMock()
-        self.cloudvision.get_interface_transceiver.side_effect = lambda client, dId, interface: (
-            "Unknown" if interface.startswith("Port-Channel") else "1000BASE-T"
-        )
-        self.cloudvision.get_interface_description = MagicMock()
-        self.cloudvision.get_interface_description.return_value = "Uplink to DC1"
+        all_intf_names = [
+            port["interface"] for port in (*fixtures.PORT_CHANNEL_INTERFACE_FIXTURE, *fixtures.FIXED_INTERFACE_FIXTURE)
+        ]
+        self.cloudvision.get_all_interface_modes = MagicMock()
+        self.cloudvision.get_all_interface_modes.return_value = {name: "access" for name in all_intf_names}
+        self.cloudvision.get_all_interface_transceivers = MagicMock()
+        self.cloudvision.get_all_interface_transceivers.return_value = {
+            name: "1000BASE-T" for name in all_intf_names if not name.startswith("Port-Channel")
+        }
+        self.cloudvision.get_all_interface_descriptions = MagicMock()
+        self.cloudvision.get_all_interface_descriptions.return_value = {
+            name: "Uplink to DC1" for name in all_intf_names
+        }
         self.cloudvision.get_routed_interface_description = MagicMock()
         self.cloudvision.get_routed_interface_description.return_value = "hello!"
         self.cloudvision.get_ip_interfaces = MagicMock()
@@ -95,35 +100,37 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
         mock_device.serial = "JPE12345678"
         mock_device.device_model = "DCS-7280CR2-60"
 
-        with patch(
-            "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_device_type",
-            self.cloudvision.get_device_type,
-        ):
-            with patch(
+        with (
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_device_type",
+                self.cloudvision.get_device_type,
+            ),
+            patch(
                 "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interfaces_fixed",
                 self.cloudvision.get_interfaces_fixed,
-            ):
-                with patch(
-                    "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interfaces_port_channel",
-                    self.cloudvision.get_interfaces_port_channel,
-                ):
-                    with patch(
-                        "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_port_channel_members",
-                        self.cloudvision.get_port_channel_members,
-                    ):
-                        with patch(
-                            "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_mode",
-                            self.cloudvision.get_interface_mode,
-                        ):
-                            with patch(
-                                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_transceiver",
-                                self.cloudvision.get_interface_transceiver,
-                            ):
-                                with patch(
-                                    "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_description",
-                                    self.cloudvision.get_interface_description,
-                                ):
-                                    self.cvp.load_interfaces(mock_device)
+            ),
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interfaces_port_channel",
+                self.cloudvision.get_interfaces_port_channel,
+            ),
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_port_channel_members",
+                self.cloudvision.get_port_channel_members,
+            ),
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_modes",
+                self.cloudvision.get_all_interface_modes,
+            ),
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_transceivers",
+                self.cloudvision.get_all_interface_transceivers,
+            ),
+            patch(
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_descriptions",
+                self.cloudvision.get_all_interface_descriptions,
+            ),
+        ):
+            self.cvp.load_interfaces(mock_device)
         expected_ports = {
             f"{port['interface']}__mock_device"
             for port in (*fixtures.PORT_CHANNEL_INTERFACE_FIXTURE, *fixtures.FIXED_INTERFACE_FIXTURE)
@@ -174,16 +181,16 @@ class CloudvisionAdapterTestCase(TransactionTestCase):
                 self.cloudvision.get_port_channel_members,
             ),
             patch(
-                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_mode",
-                self.cloudvision.get_interface_mode,
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_modes",
+                self.cloudvision.get_all_interface_modes,
             ),
             patch(
-                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_transceiver",
-                self.cloudvision.get_interface_transceiver,
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_transceivers",
+                self.cloudvision.get_all_interface_transceivers,
             ),
             patch(
-                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_interface_description",
-                self.cloudvision.get_interface_description,
+                "nautobot_ssot.integrations.aristacv.utils.cloudvision.get_all_interface_descriptions",
+                self.cloudvision.get_all_interface_descriptions,
             ),
         ):
             self.cvp.load_interfaces(fake_device)

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -306,22 +306,9 @@ class TestCloudvisionUtils(TestCase):
 
     def test_get_interfaces_chassis(self):
         """Test get_interfaces_chassis method."""
-        mock_query = MagicMock()
-        mock_query.dataset.type = "device"
-        mock_query.dataset.name = "JPE12345678"
-        mock_query.paths.path_elements = [
-            "\304\005Sysdb",
-            "\304\tinterface",
-            "\304\006status",
-            "\304\003eth",
-            "\304\003phy",
-            "\304\005slice",
-        ]
+        mock_get_query = MagicMock(return_value={"Linecard1": None})
 
-        mock_lc = MagicMock()
-        mock_lc.return_value = {"Linecard1": None}
-
-        with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.unfreeze_frozen_dict", mock_lc):
+        with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.get_query", mock_get_query):
             self.client.get = MagicMock()
             self.client.get.return_value = fixtures.CHASSIS_INTF_QUERY
             results = cloudvision.get_interfaces_chassis(client=self.client, dId="JPE12345678")
@@ -627,3 +614,178 @@ class TestCloudvisionUtils(TestCase):
             results = cloudvision.get_ip_interfaces(client=self.client, dId="JPE12345678")
         expected = fixtures.IP_INTF_SPLIT_NOTIF_FIXTURE
         self.assertEqual(results, expected)
+
+    def test_get_all_interface_modes_bulk(self):
+        """Test get_all_interface_modes returns a dict keyed by interface name."""
+        batches = [
+            {
+                "notifications": [
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "bridging",
+                            "switchIntfConfig",
+                            "switchIntfConfig",
+                            "Ethernet1",
+                        ],
+                        "updates": {"switchportMode": {"Name": "trunk"}},
+                    },
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "bridging",
+                            "switchIntfConfig",
+                            "switchIntfConfig",
+                            "Ethernet2",
+                        ],
+                        "updates": {"switchportMode": {"Name": "access"}},
+                    },
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "bridging",
+                            "switchIntfConfig",
+                            "switchIntfConfig",
+                            "Ethernet3",
+                        ],
+                        "updates": {},
+                    },
+                ]
+            }
+        ]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(return_value=batches)
+            results = cloudvision.get_all_interface_modes(client=self.client, dId="JPE12345678")
+        self.assertEqual(results, {"Ethernet1": "trunk", "Ethernet2": "access"})
+
+    def test_get_all_interface_transceivers_bulk(self):
+        """Test get_all_interface_transceivers returns a dict keyed by interface name."""
+        batches = [
+            {
+                "notifications": [
+                    {
+                        "path_elements": ["Sysdb", "hardware", "archer", "xcvr", "status", "all", "Ethernet1"],
+                        "updates": {"actualIdEepromContents": {"mediaType": "40GBASE-PLR4"}},
+                    },
+                    {
+                        "path_elements": ["Sysdb", "hardware", "archer", "xcvr", "status", "all", "Ethernet2"],
+                        "updates": {"mediaType": {"Name": "xcvr10GBaseSR"}},
+                    },
+                    {
+                        "path_elements": ["Sysdb", "hardware", "archer", "xcvr", "status", "all", "Ethernet3"],
+                        "updates": {"localMediaType": {"Name": "xcvr1000BaseT"}},
+                    },
+                    {
+                        "path_elements": ["Sysdb", "hardware", "archer", "xcvr", "status", "all", "Ethernet4"],
+                        "updates": {},
+                    },
+                ]
+            }
+        ]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(return_value=batches)
+            results = cloudvision.get_all_interface_transceivers(client=self.client, dId="JPE12345678")
+        self.assertEqual(
+            results,
+            {
+                "Ethernet1": "40GBASE-PLR4",
+                "Ethernet2": "xcvr10GBaseSR",
+                "Ethernet3": "xcvr1000BaseT",
+            },
+        )
+
+    def test_get_all_interface_descriptions_bulk(self):
+        """Test get_all_interface_descriptions returns a dict keyed by intfId.
+
+        Two queries are issued (physical eth/phy/slice path and non-physical wildcard path);
+        each Wildcard() matches exactly one path segment, so a single wildcard query cannot
+        cover both shapes. The mock returns physical descriptions on the first call and
+        non-physical descriptions on the second.
+        """
+        physical_batch = [
+            {
+                "notifications": [
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "eth",
+                            "phy",
+                            "slice",
+                            "1",
+                            "intfConfig",
+                            "Ethernet1",
+                        ],
+                        "updates": {"intfId": "Ethernet1", "description": "uplink to spine"},
+                    },
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "eth",
+                            "phy",
+                            "slice",
+                            "1",
+                            "intfConfig",
+                            "Ethernet2",
+                        ],
+                        "updates": {"intfId": "Ethernet2", "description": ""},
+                    },
+                ]
+            }
+        ]
+        non_physical_batch = [
+            {
+                "notifications": [
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "eth",
+                            "lag",
+                            "intfConfig",
+                            "Port-Channel1",
+                        ],
+                        "updates": {"intfId": "Port-Channel1", "description": "bonded uplink"},
+                    },
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "l3",
+                            "intf",
+                            "intfConfig",
+                            "Loopback0",
+                        ],
+                        "updates": {"intfId": "Loopback0", "description": "router id"},
+                    },
+                ]
+            }
+        ]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(side_effect=[physical_batch, non_physical_batch])
+            results = cloudvision.get_all_interface_descriptions(client=self.client, dId="JPE12345678")
+        self.assertEqual(
+            results,
+            {
+                "Ethernet1": "uplink to spine",
+                "Port-Channel1": "bonded uplink",
+                "Loopback0": "router id",
+            },
+        )
+
+    def test_get_ip_interfaces_coalesced_batch(self):
+        """Test get_ip_interfaces when CloudVision coalesces multiple interfaces into one batch.
+
+        Regression: gRPC can pack notifications for several interfaces into a single batch when
+        the query uses Wildcard(). Per-batch accumulators would silently merge or overwrite
+        interfaces. Group by notif["path_elements"][-1] (interface name) instead.
+        """
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(return_value=fixtures.IP_INTF_COALESCED_BATCH_QUERY)
+            results = cloudvision.get_ip_interfaces(client=self.client, dId="JPE12345678")
+        self.assertEqual(results, fixtures.IP_INTF_COALESCED_BATCH_FIXTURE)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1206

## What's Changed

I noticed while working on various PRs for the Arista CV SSoT that it was fetching single interface descriptions, modes and transceiver information. This PR adds a few bulk get functions to get all of the information in as few as API calls as possible to improve loading performance.

I also fixed a bug in the `get_ip_interfaces` where we were overriding state sometimes.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests