### PR TITLE
Fixed the link to the API View for the Sync model

### DIFF
--- a/changes/1211.fixed
+++ b/changes/1211.fixed
@@ -1,0 +1,1 @@
+Fixed the link on the Advanced tab for the Sync model to point to the API view.

--- a/nautobot_ssot/models.py
+++ b/nautobot_ssot/models.py
@@ -100,10 +100,6 @@ class Sync(BaseModel):  # pylint: disable=nb-string-field-blank-null
         """String representation of a Sync instance."""
         return f"{self.source} → {self.target}, {date_format(self.start_time, format=settings.SHORT_DATETIME_FORMAT)}"
 
-    def get_absolute_url(self, api=False):
-        """Get the detail-view URL for this instance."""
-        return reverse("plugins:nautobot_ssot:sync", kwargs={"pk": self.pk})
-
     @classmethod
     def annotated_queryset(cls):
         """Construct an efficient queryset for this model and related data."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1211

## What's Changed
This erases the vestigial `get_absolute_url` method on the Sync model that was introduced all the way back in #1. It's no longer needed as it can just inherit from `BaseModel` and it was breaking the link to the API view.

```python
In [1]: sync = Sync.objects.first()

In [2]: sync.get_absolute_url()
Out[2]: '/plugins/ssot/history/a9392af5-a837-4cbc-a9ed-9ba4ff8ba9ab/'

In [3]: sync.get_absolute_url(api=True)
Out[3]: '/api/plugins/ssot/history/a9392af5-a837-4cbc-a9ed-9ba4ff8ba9ab/'
```

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
