### PR TITLE
Update tests to fix LocationType parent handling

### DIFF
--- a/changes/1213.fixed
+++ b/changes/1213.fixed
@@ -1,0 +1,1 @@
+Fixed unittests for integrations that used outdated default LocationType parents

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
@@ -54,7 +54,7 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         self.ny_region = Location.objects.create(name="NY", location_type=region_type, status=self.status_active)
         self.ny_region.validated_save()
 
-        site_type = LocationType.objects.get_or_create(name="Site", parent=region_type)[0]
+        site_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
         site_type.content_types.add(ContentType.objects.get_for_model(Device))
         self.job.dc_loctype = site_type
         self.job.parent_location = self.ny_region

--- a/nautobot_ssot/tests/citrix_adm/test_models_nautobot.py
+++ b/nautobot_ssot/tests/citrix_adm/test_models_nautobot.py
@@ -28,7 +28,7 @@ class TestNautobotDatacenter(TransactionTestCase):
         self.test_dc = NautobotDatacenter(name="Test", region="", latitude=None, longitude=None, uuid=None)
         region_lt = LocationType.objects.get_or_create(name="Region")[0]
         self.global_region = Location.objects.create(name="Global", location_type=region_lt, status=self.status_active)
-        site_lt = LocationType.objects.get_or_create(name="Site", parent=region_lt)[0]
+        site_lt, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_lt})
         site_lt.content_types.add(ContentType.objects.get_for_model(Device))
         self.site_obj = Location.objects.create(
             name="HQ",
@@ -99,7 +99,7 @@ class TestNautobotAddress(TransactionTestCase):  # pylint: disable=too-many-inst
         self.status_active = Status.objects.get(name="Active")
         region_lt = LocationType.objects.get_or_create(name="Region")[0]
         self.global_region = Location.objects.create(name="Global", location_type=region_lt, status=self.status_active)
-        site_lt = LocationType.objects.get_or_create(name="Site", parent=region_lt)[0]
+        site_lt, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_lt})
         site_lt.content_types.add(ContentType.objects.get_for_model(Device))
         self.site_obj = Location.objects.create(
             name="HQ",

--- a/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
@@ -74,7 +74,9 @@ class TestDnaCenterAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
         self.status_active = Status.objects.get(name="Active")
         self.reg_loc_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
         self.hq_area = Location.objects.create(name="NY", location_type=self.reg_loc_type, status=self.status_active)
-        self.site_loc_type = LocationType.objects.get_or_create(name="Site", parent=self.reg_loc_type)[0]
+        self.site_loc_type, _ = LocationType.objects.update_or_create(
+            name="Site", defaults={"parent": self.reg_loc_type}
+        )
         self.site_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
         self.hq_site = Location.objects.create(
             name="HQ", parent=self.hq_area, location_type=self.site_loc_type, status=self.status_active

--- a/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
@@ -39,7 +39,9 @@ class NautobotDiffSyncTestCase(TransactionTestCase):  # pylint: disable=too-many
         super().setUp()
         self.status_active = Status.objects.get(name="Active")
         self.reg_loc_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        self.site_loc_type = LocationType.objects.get_or_create(name="Site", parent=self.reg_loc_type)[0]
+        self.site_loc_type, _ = LocationType.objects.update_or_create(
+            name="Site", defaults={"parent": self.reg_loc_type}
+        )
         self.site_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
         self.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=self.site_loc_type)[0]
         self.floor_loc_type.content_types.add(ContentType.objects.get_for_model(Device))

--- a/nautobot_ssot/tests/dna_center/test_models_nautobot.py
+++ b/nautobot_ssot/tests/dna_center/test_models_nautobot.py
@@ -79,7 +79,7 @@ class TestNautobotBuilding(TransactionTestCase):
         super().setUp()
 
         self.reg_loc = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        loc_type = LocationType.objects.get_or_create(name="Site", parent=self.reg_loc)[0]
+        loc_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": self.reg_loc})
         self.adapter = Adapter()
         self.adapter.job = MagicMock()
         self.adapter.job.debug = True

--- a/nautobot_ssot/tests/solarwinds/test_jobs.py
+++ b/nautobot_ssot/tests/solarwinds/test_jobs.py
@@ -80,7 +80,7 @@ class SolarWindsDataSourceTestCase(TransactionTestCase):
 
     def test_validate_location_configuration_missing_device_contenttype(self):
         """Validate handling of validate_location_configuration() when Device ContentType on the specified LocationType."""
-        site_lt = LocationType.objects.get(name="Site")
+        site_lt, _ = LocationType.objects.get_or_create(name="Site")
         dev_ct = site_lt.content_types.filter(app_label="dcim", model="device").first()
         if dev_ct:
             site_lt.content_types.remove(dev_ct)

--- a/nautobot_ssot/tests/solarwinds/test_jobs.py
+++ b/nautobot_ssot/tests/solarwinds/test_jobs.py
@@ -59,7 +59,7 @@ class SolarWindsDataSourceTestCase(TransactionTestCase):
     def test_validate_location_configuration_extra_parent(self):
         """Validate handling of validate_location_configuration() when parent Location is specified, but not required."""
         reg_lt = LocationType.objects.create(name="Region")
-        site_lt = LocationType.objects.get(name="Site")
+        site_lt, _ = LocationType.objects.get_or_create(name="Site")
         self.job.location_type = site_lt
         self.job.parent = reg_lt
         with self.assertRaises(JobConfigError):

--- a/nautobot_ssot/tests/solarwinds/test_jobs.py
+++ b/nautobot_ssot/tests/solarwinds/test_jobs.py
@@ -49,7 +49,7 @@ class SolarWindsDataSourceTestCase(TransactionTestCase):
     def test_validate_location_configuration_missing_parent(self):
         """Validate handling of validate_location_configuration() when parent Location isn't specified but required."""
         reg_lt = LocationType.objects.create(name="Region")
-        site_lt = LocationType.objects.create(name="Site", parent=reg_lt)
+        site_lt, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": reg_lt})
         self.job.location_type = site_lt
         self.job.parent = None
         with self.assertRaises(JobConfigError):
@@ -59,7 +59,7 @@ class SolarWindsDataSourceTestCase(TransactionTestCase):
     def test_validate_location_configuration_extra_parent(self):
         """Validate handling of validate_location_configuration() when parent Location is specified, but not required."""
         reg_lt = LocationType.objects.create(name="Region")
-        site_lt = LocationType.objects.create(name="Site")
+        site_lt = LocationType.objects.get(name="Site")
         self.job.location_type = site_lt
         self.job.parent = reg_lt
         with self.assertRaises(JobConfigError):
@@ -80,7 +80,10 @@ class SolarWindsDataSourceTestCase(TransactionTestCase):
 
     def test_validate_location_configuration_missing_device_contenttype(self):
         """Validate handling of validate_location_configuration() when Device ContentType on the specified LocationType."""
-        site_lt = LocationType.objects.create(name="Site")
+        site_lt = LocationType.objects.get(name="Site")
+        dev_ct = site_lt.content_types.filter(app_label="dcim", model="device").first()
+        if dev_ct:
+            site_lt.content_types.remove(dev_ct)
         self.job.location_type = site_lt
         self.job.parent = None
         with self.assertRaises(JobConfigError):

--- a/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
+++ b/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
@@ -31,12 +31,13 @@ class TestSolarWindsAdapterTestCase(TransactionTestCase):  # pylint: disable=too
 
         self.containers = "HQ"
 
-        self.location_type = LocationType.objects.get_or_create(name="Site")[0]
+        region_type, _ = LocationType.objects.get_or_create(name="Region")
+        self.location_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
         self.location_type.content_types.add(ContentType.objects.get_for_model(Device))
 
-        self.parent = Location.objects.get_or_create(
-            name="USA", location_type=LocationType.objects.get_or_create(name="Region")[0], status=self.status_active
-        )[0]
+        self.parent, _ = Location.objects.get_or_create(
+            name="USA", location_type=region_type, status=self.status_active
+        )
 
         self.job = SolarWindsDataSource()
         self.job.debug = True


### PR DESCRIPTION
# Closes: #8980

## What's Changed
Updated unittest fixtures to use update_or_create to set expected `Region` to `Site` parent relationships when the default `Site` LocationType is already created with no parent and `Region` isn't defined at all. The existing tests were built on the standards for 1.x but in a fresh 3.x install a LocationType for `Region` is not created. This covers all cases of created, partially created or not created.

- [X] Explanation of Change(s)
- [X] Added change log fragment(s)
- [X] Unit, Integration Tests
