### PR TITLE
IP Fabric integration caching and optimization

### DIFF
--- a/changes/1214.added
+++ b/changes/1214.added
@@ -1,0 +1,1 @@
+Added thread safe caching for Nautobot objects an prefetching to reduce query overhead

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
@@ -108,7 +108,9 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
         managed_ipv4 = defaultdict(dict)
         stacks, interfaces = defaultdict(list), defaultdict(list)
 
-        vlans = self.client.fetch_all("tables/vlan/site-summary")
+        vlans_by_location = defaultdict(list)
+        for vlan in self.client.fetch_all("tables/vlan/site-summary"):
+            vlans_by_location[vlan["siteName"]].append(vlan)
 
         ip_columns = ["sn", "intName", "net", "ip", "type"]
         ip_filter = {"type": ["eq", "primary"]}
@@ -125,33 +127,38 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
             columns=["master", "member", "memberSn", "pn", "sn"]
         ):
             stacks[stack["sn"]].append(stack)
-        return managed_ipv4, vlans, stacks, interfaces
+        return managed_ipv4, vlans_by_location, stacks, interfaces
 
     def load(self):  # pylint: disable=too-many-locals,too-many-statements
         """Load data from IP Fabric."""
         self.load_sites()
-        managed_ipv4, vlans, stacks, interfaces = self.load_data()
+        managed_ipv4, vlans_by_location, stacks, interfaces = self.load_data()
 
         for location in self.get_all(self.location):
             if location.name is None:
                 continue
-            location_vlans = [vlan for vlan in vlans if vlan["siteName"] == location.name]
-            for vlan in location_vlans:
-                if not vlan["vlanId"] or (vlan["vlanId"] < 1 or vlan["vlanId"] > 4094):
+            location_vlans = vlans_by_location.get(location.name, [])
+            for vlan_record in location_vlans:
+                vlan_name = vlan_record.get("vlanName")
+                vlan_id = vlan_record["vlanId"]
+                vlan_desc = vlan_record.get("dscr")
+                if not vlan_id or not (1 <= vlan_id <= 4094):
                     logger.warning(
-                        f"Not syncing VLAN, NAME: {vlan.get('vlanName')} due to invalid VLAN ID: {vlan.get('vlanId')}."
+                        f"Not syncing VLAN, NAME: {vlan_name} due to invalid VLAN ID: {vlan_id}."
                     )
                     continue
-                description = vlan.get("dscr") if vlan.get("dscr") else f"VLAN ID: {vlan['vlanId']}"
-                vlan_name = vlan.get("vlanName") if vlan.get("vlanName") else f"{vlan['siteName']}:{vlan['vlanId']}"
-                if len(vlan_name) > name_max_length:
-                    logger.warning(f"Not syncing VLAN, {vlan_name} due to character limit exceeding {name_max_length}.")
+                description = vlan_desc if vlan_desc else f"VLAN ID: {vlan_id}"
+                vlan_label = vlan_name if vlan_name else f"{vlan_record['siteName']}:{vlan_id}"
+                if len(vlan_label) > name_max_length:
+                    logger.warning(
+                        f"Not syncing VLAN, {vlan_label} due to character limit exceeding {name_max_length}."
+                    )
                     continue
                 try:
                     vlan = self.vlan(
-                        name=vlan_name,
-                        location=vlan["siteName"],
-                        vid=vlan["vlanId"],
+                        name=vlan_label,
+                        location=vlan_record["siteName"],
+                        vid=vlan_id,
                         status="Active",
                         description=description,
                     )

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
@@ -194,8 +194,8 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
                         # using `or` syntax in case memberSn is defined as None
                         member_sn = member.get("memberSn") or ""
                         args = base_args.copy()
-                        if _ := member.get("pn"):
-                            args["model"] = _
+                        if pn := member.get("pn"):
+                            args["model"] = pn
                         args.update(
                             {
                                 "serial_number": member_sn if len(member_sn) < device_serial_max_length else "",

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_ipfabric.py
@@ -142,10 +142,8 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
                 vlan_name = vlan_record.get("vlanName")
                 vlan_id = vlan_record["vlanId"]
                 vlan_desc = vlan_record.get("dscr")
-                if not vlan_id or not (1 <= vlan_id <= 4094):
-                    logger.warning(
-                        f"Not syncing VLAN, NAME: {vlan_name} due to invalid VLAN ID: {vlan_id}."
-                    )
+                if not vlan_id or not 1 <= vlan_id <= 4094:
+                    logger.warning(f"Not syncing VLAN, NAME: {vlan_name} due to invalid VLAN ID: {vlan_id}.")
                     continue
                 description = vlan_desc if vlan_desc else f"VLAN ID: {vlan_id}"
                 vlan_label = vlan_name if vlan_name else f"{vlan_record['siteName']}:{vlan_id}"

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -186,13 +186,13 @@ class NautobotDiffSync(DiffSyncModelAdapters):
             location.add_child(device)
             self.load_interfaces(device_record=device_record, diffsync_device=device)
 
-    def load_vlans(self, filtered_vlans: List, location):
+    def load_vlans(self, filtered_vlans: List, location, location_record):
         """Add Nautobot VLAN objects as DiffSync VLAN models."""
         for vlan_record in filtered_vlans:
             vlan = self.vlan(
                 name=vlan_record.name,
-                location=vlan_record.location.name,
-                status=vlan_record.status.name if vlan_record.status else "Active",
+                location=location_record.name,
+                status=vlan_record.status.name,
                 vid=vlan_record.vid,
                 vlan_pk=vlan_record.pk,
                 description=vlan_record.description,
@@ -259,10 +259,12 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                     self.load_device(nautobot_location_devices, location)
 
                     # Load Location Children - Vlans, if any.
-                    nautobot_location_vlans = VLAN.objects.filter(location=location_record).select_related(
-                        "location", "status"
+                    nautobot_location_vlans = (
+                        VLAN.objects.filter(location=location_record)
+                        .select_related("status")
+                        .prefetch_related("locations")
                     )
-                    self.load_vlans(nautobot_location_vlans, location)
+                    self.load_vlans(nautobot_location_vlans, location, location_record)
                 except Location.DoesNotExist:
                     logger.error("Unable to find Location, %s.", location_record)
         else:

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -91,11 +91,14 @@ class NautobotDiffSync(DiffSyncModelAdapters):
             device_primary_ip = device_record.primary_ip6
 
         for interface_record in device_record.interfaces.all():
-            ip_address_obj = interface_record.ip_addresses.first()
-            if ip_address_obj:
+            # Use .all() and [0] instead of .first() to preserve prefetch cache
+            ip_addresses = interface_record.ip_addresses.all()
+            if ip_addresses:
+                ip_address_obj = ip_addresses[0]
                 ip_address = ip_address_obj.host
                 subnet_mask = cidr_to_netmask(ip_address_obj.mask_length)
             else:
+                ip_address_obj = None
                 ip_address = None
                 subnet_mask = None
             interface = self.interface(
@@ -123,7 +126,14 @@ class NautobotDiffSync(DiffSyncModelAdapters):
     def load_device(self, filtered_devices: List, location):
         """Load Devices from Nautobot."""
         optimized_query = filtered_devices.select_related(
-            "location", "device_type__manufacturer", "role", "status", "platform", "virtual_chassis",
+            "location",
+            "device_type__manufacturer",
+            "primary_ip4",
+            "primary_ip6",
+            "role",
+            "status",
+            "platform",
+            "virtual_chassis",
         ).prefetch_related(
             "interfaces__ip_addresses", "interfaces__tags"
         ).iterator(1000)
@@ -202,7 +212,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                 location_objects = Location.objects.filter(name=self.location_filter.name)
             else:
                 location_objects = Location.objects.all()
-        return location_objects
+        return location_objects.select_related("status")
 
     @transaction.atomic
     def load_data(self):

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -217,7 +217,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
         location_objects = self.get_initial_location(ssot_tag)
         # The parent object that stores all children, is the Location.
         if self.job.debug:
-            logger.debug("Found %s Nautobot Location objects to start sync from", location_objects.count())
+            logger.debug("Found %s Nautobot Location objects to start sync from", len(location_objects))
 
         if location_objects:
             for location_record in location_objects:
@@ -241,13 +241,10 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                         )
                     else:
                         nautobot_location_devices = Device.objects.filter(location=location_record)
-                    if nautobot_location_devices.exists():
-                        self.load_device(nautobot_location_devices, location)
+                    self.load_device(nautobot_location_devices, location)
 
                     # Load Location Children - Vlans, if any.
-                    nautobot_location_vlans = VLAN.objects.filter(location=location_record)
-                    if not nautobot_location_vlans.exists():
-                        continue
+                    nautobot_location_vlans = VLAN.objects.filter(location=location_record).select_related("location", "status")
                     self.load_vlans(nautobot_location_vlans, location)
                 except Location.DoesNotExist:
                     logger.error("Unable to find Location, %s.", location_record)

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -122,7 +122,12 @@ class NautobotDiffSync(DiffSyncModelAdapters):
 
     def load_device(self, filtered_devices: List, location):
         """Load Devices from Nautobot."""
-        for device_record in filtered_devices:
+        optimized_query = filtered_devices.select_related(
+            "location", "device_type__manufacturer", "role", "status", "platform", "virtual_chassis",
+        ).prefetch_related(
+            "interfaces__ip_addresses", "interfaces__tags"
+        ).iterator(1000)
+        for device_record in optimized_query:
             if self.job.debug:
                 logger.debug("Loading Nautobot Device: %s", device_record.name)
             device_role = (

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -173,8 +173,6 @@ class NautobotDiffSync(DiffSyncModelAdapters):
     def load_vlans(self, filtered_vlans: List, location):
         """Add Nautobot VLAN objects as DiffSync VLAN models."""
         for vlan_record in filtered_vlans:
-            if not vlan_record:
-                continue
             vlan = self.vlan(
                 name=vlan_record.name,
                 location=vlan_record.location.name,

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -125,18 +125,20 @@ class NautobotDiffSync(DiffSyncModelAdapters):
 
     def load_device(self, filtered_devices: List, location):
         """Load Devices from Nautobot."""
-        optimized_query = filtered_devices.select_related(
-            "location",
-            "device_type__manufacturer",
-            "primary_ip4",
-            "primary_ip6",
-            "role",
-            "status",
-            "platform",
-            "virtual_chassis",
-        ).prefetch_related(
-            "interfaces__ip_addresses", "interfaces__tags"
-        ).iterator(1000)
+        optimized_query = (
+            filtered_devices.select_related(
+                "location",
+                "device_type__manufacturer",
+                "primary_ip4",
+                "primary_ip6",
+                "role",
+                "status",
+                "platform",
+                "virtual_chassis",
+            )
+            .prefetch_related("interfaces__ip_addresses", "interfaces__tags")
+            .iterator(1000)
+        )
         for device_record in optimized_query:
             if self.job.debug:
                 logger.debug("Loading Nautobot Device: %s", device_record.name)
@@ -247,7 +249,9 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                     self.load_device(nautobot_location_devices, location)
 
                     # Load Location Children - Vlans, if any.
-                    nautobot_location_vlans = VLAN.objects.filter(location=location_record).select_related("location", "status")
+                    nautobot_location_vlans = VLAN.objects.filter(location=location_record).select_related(
+                        "location", "status"
+                    )
                     self.load_vlans(nautobot_location_vlans, location)
                 except Location.DoesNotExist:
                     logger.error("Unable to find Location, %s.", location_record)

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -91,7 +91,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
             device_primary_ip = device_record.primary_ip6
 
         for interface_record in device_record.interfaces.all():
-            # Use .all() and [0] instead of .first() to preserve prefetch cache
+            # Avoid .first() to preserve prefetch cache
             ip_addresses = interface_record.ip_addresses.all()
             if ip_addresses:
                 ip_address_obj = ip_addresses[0]

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -140,11 +140,8 @@ class NautobotDiffSync(DiffSyncModelAdapters):
         for device_record in optimized_query:
             if self.job.debug:
                 logger.debug("Loading Nautobot Device: %s", device_record.name)
-            device_role = (
-                str(device_record.role.cf.get("ipfabric_type"))
-                if device_record.role.cf.get("ipfabric_type")
-                else device_record.role.name
-            )
+            ipfabric_type = device_record.role.cf.get("ipfabric_type")
+            device_role = str(ipfabric_type) if ipfabric_type else device_record.role.name
             device = self.device(
                 name=device_record.name,
                 model=str(device_record.device_type),

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -152,8 +152,9 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                 "status",
                 "platform",
                 "virtual_chassis",
+                "virtual_chassis__master"
             )
-            .prefetch_related("interfaces__ip_addresses", "interfaces__tags")
+            .prefetch_related("interfaces__ip_addresses")
             .iterator(1000)
         )
         for device_record in optimized_query:

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -18,6 +18,7 @@ from nautobot.ipam.models import VLAN, Interface
 from netutils.ip import cidr_to_netmask
 from netutils.mac import mac_to_format
 
+import nautobot_ssot.integrations.ipfabric.utilities.nbutils as tonb_utils
 from nautobot_ssot.integrations.ipfabric.constants import (
     DEFAULT_INTERFACE_MAC,
     DEFAULT_INTERFACE_MTU,
@@ -53,6 +54,22 @@ class NautobotDiffSync(DiffSyncModelAdapters):
         self.sync = sync
         self.sync_ipfabric_tagged_only = sync_ipfabric_tagged_only
         self.location_filter = location_filter
+        self.ssot_tag = tonb_utils.get_or_create_tag_object(
+            tag_name="SSoT Synced from IPFabric",
+            tag_color=ColorChoices.COLOR_LIGHT_GREEN,
+            description="Object synced at some point from IPFabric to Nautobot",
+            app_label="dcim",
+            model="device",
+            logger=self.job.logger,
+        )
+        self.safe_delete_tag = tonb_utils.get_or_create_tag_object(
+            tag_name="SSoT Safe Delete",
+            tag_color=ColorChoices.COLOR_RED,
+            description="Safe Delete Mode tag to flag an object, but not delete from Nautobot.",
+            app_label="dcim",
+            model="device",
+            logger=self.job.logger,
+        )
 
     def sync_complete(self, source: Adapter, *args, **kwargs):
         """Clean up function for DiffSync sync.
@@ -212,14 +229,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
     @transaction.atomic
     def load_data(self):
         """Add Nautobot Location objects as DiffSync Location models."""
-        ssot_tag, _ = Tag.objects.get_or_create(
-            name="SSoT Synced from IPFabric",
-            defaults={
-                "description": "Object synced at some point from IPFabric to Nautobot",
-                "color": ColorChoices.COLOR_LIGHT_GREEN,
-            },
-        )
-        location_objects = self.get_initial_location(ssot_tag)
+        location_objects = self.get_initial_location(self.ssot_tag)
         # The parent object that stores all children, is the Location.
         if self.job.debug:
             logger.debug("Found %s Nautobot Location objects to start sync from", len(location_objects))
@@ -242,7 +252,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                     # Load Location's Children - Devices with Interfaces, if any.
                     if self.sync_ipfabric_tagged_only:
                         nautobot_location_devices = Device.objects.filter(
-                            Q(location=location_record) & Q(tags__name=ssot_tag.name)
+                            Q(location=location_record) & Q(tags=self.ssot_tag)
                         )
                     else:
                         nautobot_location_devices = Device.objects.filter(location=location_record)

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -152,7 +152,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                 "status",
                 "platform",
                 "virtual_chassis",
-                "virtual_chassis__master"
+                "virtual_chassis__master",
             )
             .prefetch_related("interfaces__ip_addresses")
             .iterator(1000)

--- a/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/adapter_nautobot.py
@@ -198,9 +198,7 @@ class NautobotDiffSync(DiffSyncModelAdapters):
         if self.sync_ipfabric_tagged_only:
             location_objects = Location.objects.filter(tags__name=ssot_tag.name)
             if self.location_filter:
-                location_objects = Location.objects.filter(
-                    Q(name=self.location_filter.name) & Q(tags__name=ssot_tag.name)
-                )
+                location_objects = location_objects.filter(name=self.location_filter.name)
                 if not location_objects:
                     logger.warning(
                         f"{self.location_filter.name} was used to filter, alongside SSoT Tag. {self.location_filter.name} is not tagged."

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -601,7 +601,7 @@ class Interface(DiffSyncExtras):
                         if ip_address_obj.ip_version == 4:
                             device_obj.primary_ip4 = ip_address_obj
                             device_obj.save()
-                        if ip_address_obj.ip_version == 6:
+                        elif ip_address_obj.ip_version == 6:
                             device_obj.primary_ip6 = ip_address_obj
                             device_obj.save()
                 else:

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -329,7 +329,6 @@ class Device(DiffSyncExtras):
                                 master=attrs.get("vc_master", False),
                                 position=attrs.get("vc_position"),
                                 priority=attrs.get("vc_priority"),
-                                logger=adapter.job.logger,
                             )
                     except (DjangoBaseDBError, ValidationError):
                         adapter.job.logger.error(f"Unable to update Device {device_name} with VirtualChassis data")
@@ -463,7 +462,6 @@ class Device(DiffSyncExtras):
                             master=attrs.get("vc_master", False),
                             position=attrs.get("vc_position"),
                             priority=attrs.get("vc_priority"),
-                            logger=self.adapter.job.logger,
                         )
                 except (DjangoBaseDBError, ValidationError):
                     self.adapter.job.logger.error(f"Unable to update VirtualChassis {vc_name} for Device {self.name}")

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -908,7 +908,7 @@ class Vlan(DiffSyncExtras):
                     if device_tags.exists():
                         vlan.tags.remove(safe_delete_tag)
                 if attrs.get("description"):
-                    vlan.description = vlan.description
+                    vlan.description = attrs.get("description")
             try:
                 tonb_nbutils.tag_object(nautobot_object=vlan, custom_field=LAST_SYNCHRONIZED_CF_NAME)
             except (DjangoBaseDBError, ValidationError):

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -10,24 +10,18 @@ from uuid import UUID
 from diffsync import DiffSyncModel
 from django.core.exceptions import ValidationError
 from django.db import Error as DjangoBaseDBError
-from django.db.models import Q
 from nautobot.core.choices import ColorChoices
 from nautobot.dcim.models import (
     Device as NautobotDevice,
 )
-from nautobot.dcim.models import (
-    DeviceType,
-    Manufacturer,
-    VirtualChassis,
-)
+from nautobot.dcim.models import DeviceType, Manufacturer
 from nautobot.dcim.models import (
     Interface as NautobotInterface,
 )
 from nautobot.dcim.models import (
     Location as NautobotLocation,
 )
-from nautobot.extras.models import Role, Tag
-from nautobot.extras.models.statuses import Status
+from nautobot.extras.models import Tag
 from nautobot.ipam.models import VLAN, IPAddress
 from netutils.ip import netmask_to_cidr
 
@@ -55,7 +49,12 @@ class DiffSyncExtras(DiffSyncModel):
 
     safe_delete_mode: ClassVar[bool] = True
 
-    def safe_delete(self, nautobot_object: Any, safe_delete_status: Optional[str] = None):
+    def safe_delete(
+        self,
+        nautobot_object: Any,
+        safe_delete_status: Optional[str] = None,
+        safe_delete_tag: Optional[Tag] = None,
+    ):
         """Safe delete an object, by adding tags or changing it's default status.
 
         Args:
@@ -71,7 +70,9 @@ class DiffSyncExtras(DiffSyncModel):
             super().delete()
         else:
             if safe_delete_status:
-                safe_delete_status = Status.objects.get(name=safe_delete_status.capitalize())
+                safe_delete_status = tonb_nbutils.get_or_create_status_object(
+                    safe_delete_status.capitalize(), ColorChoices.COLOR_RED
+                )
                 if hasattr(nautobot_object, "status"):
                     if not nautobot_object.status == safe_delete_status:
                         nautobot_object.status = safe_delete_status
@@ -80,25 +81,15 @@ class DiffSyncExtras(DiffSyncModel):
                 else:
                     # Not everything has a status. This may come in handy once more models are synced.
                     logger.warning(f"{nautobot_object} has no Status attribute.")
-            if hasattr(nautobot_object, "tags"):
-                ssot_safe_tag, _ = Tag.objects.get_or_create(
-                    name="SSoT Safe Delete",
-                    defaults={
-                        "description": "Safe Delete Mode tag to flag an object, but not delete from Nautobot.",
-                        "color": ColorChoices.COLOR_RED,
-                    },
-                )
-                object_tags = nautobot_object.tags.all()
-                # No exception raised for empty iterator, safe to do this any
-                if not any(obj_tag for obj_tag in object_tags if obj_tag.name == ssot_safe_tag.name):
-                    nautobot_object.tags.add(ssot_safe_tag)
+            if hasattr(nautobot_object, "tags") and safe_delete_tag:
+                if not nautobot_object.tags.filter(id=safe_delete_tag.id).exists():
+                    nautobot_object.tags.add(safe_delete_tag)
                     logger.warning(f"Tagging {nautobot_object} with `SSoT Safe Delete`.")
                     update = True
+                else:
+                    logger.warning(f"{nautobot_object} has previously been tagged with `SSoT Safe Delete`. Skipping...")
             if update:
                 tonb_nbutils.tag_object(nautobot_object=nautobot_object, custom_field=LAST_SYNCHRONIZED_CF_NAME)
-            else:
-                logger.warning(f"{nautobot_object} has previously been tagged with `SSoT Safe Delete`. Skipping...")
-
         return self
 
 
@@ -119,7 +110,7 @@ class Location(DiffSyncExtras):
     @classmethod
     def create(cls, adapter, ids, attrs):
         """Create Location in Nautobot."""
-        location = tonb_nbutils.create_location(
+        location = tonb_nbutils.get_or_create_location_object(
             location_name=ids["name"],
             location_id=attrs["site_id"],
             logger=adapter.job.logger,
@@ -142,6 +133,7 @@ class Location(DiffSyncExtras):
             self.safe_delete(
                 location,
                 SAFE_DELETE_LOCATION_STATUS,
+                self.adapter.safe_delete_tag,
             )
             return super().delete()
         return None
@@ -162,12 +154,9 @@ class Location(DiffSyncExtras):
                 location.custom_field_data["ipfabric_site_id"] = site_id
             active_status = attrs.get("status")
             if active_status == "Active":
-                safe_delete_tag, _ = Tag.objects.get_or_create(name="SSoT Safe Delete")
                 if location.status != active_status:
-                    location.status = Status.objects.get(name=active_status)
-                device_tags = location.tags.filter(pk=safe_delete_tag.pk)
-                if device_tags.exists():
-                    location.tags.remove(safe_delete_tag)
+                    location.status = tonb_nbutils.get_or_create_status_object(active_status, ColorChoices.COLOR_GREEN)
+                location.tags.remove(self.adapter.safe_delete_tag)
             try:
                 # Calls validated_save() on the object
                 tonb_nbutils.tag_object(nautobot_object=location, custom_field=LAST_SYNCHRONIZED_CF_NAME)
@@ -222,11 +211,10 @@ class Device(DiffSyncExtras):
         device_name = ids["name"]
         device_type_name = attrs["model"]
         device_type_filter = DeviceType.objects.filter(model=device_type_name)
-        if device_type_filter.exists():
-            device_type_object = device_type_filter.first()
-        else:
+        device_type_object = device_type_filter.first()
+        if not device_type_object:
             vendor_name = attrs["vendor"]
-            device_type_object = tonb_nbutils.create_device_type_object(
+            device_type_object = tonb_nbutils.get_or_create_device_type_object(
                 device_type=device_type_name,
                 vendor_name=vendor_name,
                 logger=adapter.job.logger,
@@ -239,7 +227,7 @@ class Device(DiffSyncExtras):
         # Get Platform
         platform = attrs.get("platform")
         if platform and device_type_object:
-            platform_object = tonb_nbutils.create_platform_object(
+            platform_object = tonb_nbutils.get_or_create_platform_object(
                 platform=platform,
                 manufacturer_obj=device_type_object.manufacturer,
                 logger=adapter.job.logger,
@@ -259,54 +247,44 @@ class Device(DiffSyncExtras):
 
         # Get Role, update if missing cf and create otherwise
         role_name = attrs.get("role") or DEFAULT_DEVICE_ROLE
-        device_role_filter = Role.objects.filter(name=role_name)
-        if device_role_filter.exists():
-            device_role_object = device_role_filter.first()
-            device_role_object.cf["ipfabric_type"] = role_name
-            try:
-                device_role_object.validated_save()
-            except (DjangoBaseDBError, ValidationError):
-                adapter.job.logger.error(
-                    f"Unable to perform a validated_save() on Role {role_name} with an ID of {device_role_object.id}"
-                )
+        device_role_object = tonb_nbutils.get_or_create_device_role_object(
+            role_name=role_name,
+            role_color=DEFAULT_DEVICE_ROLE_COLOR,
+            logger=adapter.job.logger,
+        )
+        if device_role_object:
+            if device_role_object.cf.get("ipfabric_type") != role_name:
+                device_role_object.cf["ipfabric_type"] = role_name
+                try:
+                    device_role_object.validated_save()
+                except (DjangoBaseDBError, ValidationError):
+                    adapter.job.logger.error(
+                        f"Unable to perform a validated_save() on Role {role_name} with an ID of {device_role_object.id}"
+                    )
         else:
-            device_role_object = tonb_nbutils.get_or_create_device_role_object(
-                role_name=role_name,
-                role_color=DEFAULT_DEVICE_ROLE_COLOR,
-                logger=adapter.job.logger,
+            adapter.job.logger.warning(
+                f"Unable to create a Device with the name {device_name} because of a failure "
+                f"to get or create a Role named {role_name}"
             )
-            if not device_role_object:
-                adapter.job.logger.warning(
-                    f"Unable to create a Device with the name {device_name} because of a failure "
-                    f"to get or create a Role named {role_name}"
-                )
         # Get Status
-        device_status_filter = Status.objects.filter(name=DEFAULT_DEVICE_STATUS)
-        if device_status_filter.exists():
-            device_status_object = device_status_filter.first()
-        else:
-            device_status_object = tonb_nbutils.create_status(
-                DEFAULT_DEVICE_STATUS,
-                DEFAULT_DEVICE_STATUS_COLOR,
-                logger=adapter.job.logger,
+        device_status_object = tonb_nbutils.get_or_create_status_object(
+            DEFAULT_DEVICE_STATUS,
+            DEFAULT_DEVICE_STATUS_COLOR,
+            logger=adapter.job.logger,
+        )
+        if not device_status_object:
+            adapter.job.logger.warning(
+                f"Unable to create a Device with the name {device_name} because of a failure "
+                f"to get or create a Status named {DEFAULT_DEVICE_STATUS}"
             )
-            if not device_status_object:
-                adapter.job.logger.warning(
-                    f"Unable to create a Device with the name {device_name} because of a failure "
-                    f"to get or create a Status named {DEFAULT_DEVICE_STATUS}"
-                )
         # Get Location
         location_name = attrs["location_name"]
-        location_object_filter = NautobotLocation.objects.filter(name=location_name)
-        if location_object_filter.exists():
-            location_object = location_object_filter.first()
-        else:
-            location_object = tonb_nbutils.create_location(location_name, logger=adapter.job.logger)
-            if not location_object:
-                adapter.job.logger.warning(
-                    f"Unable to create Device with name {device_name} because of a failure "
-                    f"to get or create a Location named {location_name}"
-                )
+        location_object = tonb_nbutils.get_or_create_location_object(location_name, logger=adapter.job.logger)
+        if not location_object:
+            adapter.job.logger.warning(
+                f"Unable to create Device with name {device_name} because of a failure "
+                f"to get or create a Location named {location_name}"
+            )
 
         if device_type_object and location_object and device_role_object and device_status_object:
             try:
@@ -342,17 +320,19 @@ class Device(DiffSyncExtras):
 
                 vc_name = attrs.get("vc_name")
                 if vc_name:
-                    vc_master = attrs.get("vc_master", False)
-                    vc_position = attrs.get("vc_position")
-                    vc_priority = attrs.get("vc_priority")
                     try:
-                        cls._get_or_create_virtual_chassis(
-                            vc_name, new_device, adapter.job.logger, vc_master, vc_position, vc_priority
-                        )
+                        vc = tonb_nbutils.get_or_create_virtual_chassis_object(vc_name, logger=adapter.job.logger)
+                        if vc:
+                            tonb_nbutils.assign_device_to_virtual_chassis(
+                                new_device,
+                                vc,
+                                master=attrs.get("vc_master", False),
+                                position=attrs.get("vc_position"),
+                                priority=attrs.get("vc_priority"),
+                                logger=adapter.job.logger,
+                            )
                     except (DjangoBaseDBError, ValidationError):
-                        adapter.job.logger.error(
-                            f"Unable to update Device {device_name} with an ID of {new_device.id} with VirtualChassis data"
-                        )
+                        adapter.job.logger.error(f"Unable to update Device {device_name} with VirtualChassis data")
                 return super().create(ids=ids, adapter=adapter, attrs=attrs)
         return None
 
@@ -370,6 +350,7 @@ class Device(DiffSyncExtras):
             self.safe_delete(
                 device_object,
                 SAFE_DELETE_DEVICE_STATUS,
+                self.adapter.safe_delete_tag,
             )
             return super().delete()
         return None
@@ -387,17 +368,14 @@ class Device(DiffSyncExtras):
         else:
             return_super = True
             if attrs.get("status") == "Active":
-                safe_delete_tag, _ = Tag.objects.get_or_create(name="SSoT Safe Delete")
-                if not _device.status == "Active":
-                    _device.status = Status.objects.get(name="Active")
-                device_tags = _device.tags.filter(pk=safe_delete_tag.pk)
-                if device_tags.exists():
-                    _device.tags.remove(safe_delete_tag)
+                if not _device.status.name == "Active":
+                    _device.status = tonb_nbutils.get_or_create_status_object("Active", ColorChoices.COLOR_GREEN)
+                _device.tags.remove(self.adapter.safe_delete_tag)
 
             vendor_name = attrs.get("vendor") or self.vendor
             device_type_name = attrs.get("model")
             if device_type_name:
-                device_type_object = tonb_nbutils.create_device_type_object(
+                device_type_object = tonb_nbutils.get_or_create_device_type_object(
                     device_type=device_type_name,
                     vendor_name=vendor_name,
                     logger=self.adapter.job.logger,
@@ -426,7 +404,7 @@ class Device(DiffSyncExtras):
                     )
                     return_super = False
                 else:
-                    platform_object = tonb_nbutils.create_platform_object(
+                    platform_object = tonb_nbutils.get_or_create_platform_object(
                         platform=platform_name,
                         manufacturer_obj=manufacturer_object,
                         logger=self.adapter.job.logger,
@@ -441,7 +419,7 @@ class Device(DiffSyncExtras):
 
             location_name = attrs.get("location_name")
             if location_name:
-                location = tonb_nbutils.create_location(location_name, logger=self.adapter.job.logger)
+                location = tonb_nbutils.get_or_create_location_object(location_name, logger=self.adapter.job.logger)
                 if location:
                     _device.location = location
                 else:
@@ -473,62 +451,26 @@ class Device(DiffSyncExtras):
                 )
                 return_super = False
 
-            vc_name = attrs.get("vc_name")
-            vc_master = attrs.get("vc_master", False)
-            vc_position = attrs.get("vc_position")
-            vc_priority = attrs.get("vc_priority")
-            if vc_name or vc_master or vc_position or vc_priority:
-                if not vc_name:
-                    vc_name = self.vc_name
+            vc_name = attrs.get("vc_name") or self.vc_name
+            vc_attrs_present = any(k in attrs for k in ("vc_name", "vc_master", "vc_position", "vc_priority"))
+            if vc_attrs_present and vc_name:
                 try:
-                    self._get_or_create_virtual_chassis(
-                        vc_name, _device, self.adapter.job.logger, vc_master, vc_position, vc_priority
-                    )
+                    vc = tonb_nbutils.get_or_create_virtual_chassis_object(vc_name, logger=self.adapter.job.logger)
+                    if vc:
+                        tonb_nbutils.assign_device_to_virtual_chassis(
+                            _device,
+                            vc,
+                            master=attrs.get("vc_master", False),
+                            position=attrs.get("vc_position"),
+                            priority=attrs.get("vc_priority"),
+                            logger=self.adapter.job.logger,
+                        )
                 except (DjangoBaseDBError, ValidationError):
                     self.adapter.job.logger.error(f"Unable to update VirtualChassis {vc_name} for Device {self.name}")
                     return_super = False
             if return_super:
                 return super().update(attrs)
         return None
-
-    @staticmethod
-    def _get_or_create_virtual_chassis(  # pylint: disable=too-many-arguments
-        name: str,
-        device: NautobotDevice,
-        job_logger: logging.Logger,
-        master: bool = False,
-        position: Optional[int] = None,
-        priority: Optional[int] = None,
-    ) -> VirtualChassis:
-        virtual_chassis, _ = VirtualChassis.objects.get_or_create(name=name)
-        device.virtual_chassis = virtual_chassis
-        if position:
-            device.vc_position = position
-        if priority and device.vc_position:  # An update might already have vc_position assigned
-            device.vc_priority = priority
-        elif priority:
-            job_logger.warning(
-                f"Device {device.name} assigned to VirtualChassis {name} has a "
-                f"priority of {priority}, but this cannot be set without a vc_position"
-            )
-        try:
-            device.validated_save()
-        except (DjangoBaseDBError, ValidationError) as error:
-            job_logger.error(f"Unable to perform validated_save() on Device named {device.name}")
-            raise error
-
-        if master:
-            virtual_chassis.master = device
-            try:
-                virtual_chassis.validated_save()
-            except (DjangoBaseDBError, ValidationError) as error:
-                job_logger.error(
-                    f"Unable to perform validated_save() on VirtualChassis {name}, "
-                    "the VirtualChassis will not have a Device designated as master"
-                )
-                raise error
-
-        return virtual_chassis
 
 
 class Interface(DiffSyncExtras):
@@ -573,9 +515,7 @@ class Interface(DiffSyncExtras):
         interface_name = ids["name"]
         ip_address = attrs["ip_address"]
         subnet_mask = attrs["subnet_mask"]  # TODO: switch to cidr notation since both APIs use that format
-        ssot_tag, _ = Tag.objects.get_or_create(name="SSoT Synced from IPFabric")
-        device_obj = NautobotDevice.objects.filter(Q(name=device_name) & Q(tags__name=ssot_tag.name)).first()
-
+        device_obj = tonb_nbutils.get_tagged_device(device_name)
         if device_obj:
             return_super = True
             if not attrs.get("mac_address"):
@@ -586,8 +526,7 @@ class Interface(DiffSyncExtras):
                 logger=adapter.job.logger,
             )
             if interface_obj and ip_address:
-                if interface_obj.ip_addresses.exists():
-                    interface_obj.ip_addresses.all().delete()
+                interface_obj.ip_addresses.set([])
                 ip_address_obj = tonb_nbutils.create_ip(
                     ip_address=ip_address,
                     subnet_mask=subnet_mask,
@@ -639,12 +578,11 @@ class Interface(DiffSyncExtras):
 
     def delete(self) -> Optional["DiffSyncModel"]:
         """Delete Interface Object."""
-        ssot_tag, _ = Tag.objects.get_or_create(name="SSoT Synced from IPFabric")
-        device = NautobotDevice.objects.filter(Q(name=self.device_name) & Q(tags__name=ssot_tag.name)).first()
+        device = tonb_nbutils.get_tagged_device(self.device_name)
         if device:
             return_super = True
             try:
-                interface = device.interfaces.get(name=self.name)
+                interface = device.interfaces.prefetch_related("ip_addresses").get(name=self.name)
             except NautobotInterface.MultipleObjectsReturned:
                 self.adapter.job.logger.error(
                     f"Multiple Interfaces found with the name {self.name}, on Device named {self.device_name} "
@@ -658,11 +596,14 @@ class Interface(DiffSyncExtras):
                 return_super = False
             else:
                 # Access the addr within an interface, change the status if necessary
-                if interface.ip_addresses.first():
-                    self.safe_delete(interface.ip_addresses.first(), SAFE_DELETE_IPADDRESS_STATUS)
+                for ip_address in interface.ip_addresses.all():
+                    if not ip_address.interfaces.exclude(id=interface.id).exists():
+                        # IP's can be associated to multiple Interfaces.
+                        # Only mark IPs with no other interface associtations as safe to delete.
+                        self.safe_delete(ip_address, SAFE_DELETE_IPADDRESS_STATUS, self.adapter.safe_delete_tag)
                 # Then do the parent interface
                 # Attached interfaces do not have a status to update.
-                self.safe_delete(interface)
+                self.safe_delete(interface, None, self.adapter.safe_delete_tag)
             if return_super:
                 return super().delete()
         else:
@@ -676,12 +617,11 @@ class Interface(DiffSyncExtras):
 
     def update(self, attrs):  # pylint: disable=too-many-branches
         """Update Interface object in Nautobot."""
-        ssot_tag, _ = Tag.objects.get_or_create(name="SSoT Synced from IPFabric")
-        device = NautobotDevice.objects.filter(Q(name=self.device_name) & Q(tags__name=ssot_tag.name)).first()
+        device = tonb_nbutils.get_tagged_device(self.device_name)
         if device:  # pylint: disable=too-many-nested-blocks
             return_super = True
             try:
-                interface = device.interfaces.get(name=self.name)
+                interface = device.interfaces.prefetch_related("ip_addresses").get(name=self.name)
             except NautobotInterface.MultipleObjectsReturned:
                 self.adapter.job.logger.error(
                     f"Multiple Interfaces found with the name {self.name} on Device named {device.name} "
@@ -713,9 +653,9 @@ class Interface(DiffSyncExtras):
                 ip_address = attrs.get("ip_address")
                 subnet_mask = attrs.get("subnet_mask", "255.255.255.255")
                 if ip_address:
-                    if interface.ip_addresses.all().exists():
+                    if interface.ip_addresses.all():
                         logger.info(f"Replacing IP from interface {self.name} on {device.name}")
-                        interface.ip_addresses.all().delete()
+                        interface.ip_addresses.set([])
                     ip_address_obj = tonb_nbutils.create_ip(
                         ip_address=ip_address,
                         subnet_mask=subnet_mask,
@@ -764,7 +704,7 @@ class Interface(DiffSyncExtras):
                             if interface_obj.ip_version == 4:
                                 device.primary_ip4 = interface_obj
                                 device.save()
-                            if interface_obj.ip_version == 6:
+                            elif interface_obj.ip_version == 6:
                                 device.primary_ip6 = interface_obj
                                 device.save()
                         except (DjangoBaseDBError, ValidationError):
@@ -820,7 +760,7 @@ class Vlan(DiffSyncExtras):
         status = attrs["status"].lower().capitalize()
         location_name = ids["location"]
         vlan_id = attrs["vid"]
-        vlan_name = ids["name"] if ids["name"] else f"VLAN{vlan_id}"
+        vlan_name = ids["name"]
         try:
             location = NautobotLocation.objects.get(name=ids["location"])
         except NautobotLocation.MultipleObjectsReturned:
@@ -865,6 +805,7 @@ class Vlan(DiffSyncExtras):
             self.safe_delete(
                 vlan,
                 SAFE_DELETE_VLAN_STATUS,
+                self.adapter.safe_delete_tag,
             )
             return super().delete()
         return None
@@ -878,45 +819,41 @@ class Vlan(DiffSyncExtras):
                 f"Multiple Locations found with the name {self.location}, unable to "
                 f"Retrieve the VLAN named {self.name} to perform updates"
             )
+            return None
         except NautobotLocation.DoesNotExist:
             self.adapter.job.logger.error(
                 f"Could not find a Location with the name {self.location}, unable to "
                 f"Retrieve the VLAN named {self.name} to perform updates"
             )
-        else:
-            try:
-                vlan = VLAN.objects.get(name=self.name, vid=self.vid, location=location_obj)
-            except VLAN.MultipleObjectsReturned:
-                self.adapter.job.logger.error(
-                    f"Multiple VLANs found with a name {self.name} and VLAN ID {self.vid} "
-                    f"at a Location named {self.location}, unable to perform updates"
-                )
-                return None
-            except VLAN.DoesNotExist:
-                self.adapter.job.logger.error(
-                    f"Could not find a VLAN named {self.name} and VLAN ID {self.vid} "
-                    f"at a Location named {self.location}, unable to perform updates"
-                )
-                return None
-            else:
-                if attrs.get("status") == "Active":
-                    safe_delete_tag, _ = Tag.objects.get_or_create(name="SSoT Safe Delete")
-                    if not vlan.status == "Active":
-                        vlan.status = Status.objects.get(name="Active")
-                    device_tags = vlan.tags.filter(pk=safe_delete_tag.pk)
-                    if device_tags.exists():
-                        vlan.tags.remove(safe_delete_tag)
-                if attrs.get("description"):
-                    vlan.description = attrs.get("description")
-            try:
-                tonb_nbutils.tag_object(nautobot_object=vlan, custom_field=LAST_SYNCHRONIZED_CF_NAME)
-            except (DjangoBaseDBError, ValidationError):
-                self.adapter.job.logger.warning(
-                    f"Unable to perform a validated_save() on VLAN {self.name} with an ID of {vlan.id}"
-                )
-                return None
-            return super().update(attrs)
-        return None
+            return None
+        try:
+            vlan = VLAN.objects.get(name=self.name, vid=self.vid, location=location_obj)
+        except VLAN.MultipleObjectsReturned:
+            self.adapter.job.logger.error(
+                f"Multiple VLANs found with a name {self.name} and VLAN ID {self.vid} "
+                f"at a Location named {self.location}, unable to perform updates"
+            )
+            return None
+        except VLAN.DoesNotExist:
+            self.adapter.job.logger.error(
+                f"Could not find a VLAN named {self.name} and VLAN ID {self.vid} "
+                f"at a Location named {self.location}, unable to perform updates"
+            )
+            return None
+        if attrs.get("status") == "Active":
+            if not vlan.status == "Active":
+                vlan.status = tonb_nbutils.get_or_create_status_object("Active", ColorChoices.COLOR_GREEN)
+            vlan.tags.remove(self.adapter.safe_delete_tag)
+        if attrs.get("description"):
+            vlan.description = attrs.get("description")
+        try:
+            tonb_nbutils.tag_object(nautobot_object=vlan, custom_field=LAST_SYNCHRONIZED_CF_NAME)
+        except (DjangoBaseDBError, ValidationError):
+            self.adapter.job.logger.warning(
+                f"Unable to perform a validated_save() on VLAN {self.name} with an ID of {vlan.id}"
+            )
+            return None
+        return super().update(attrs)
 
 
 Location.model_rebuild()

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -884,7 +884,6 @@ class Vlan(DiffSyncExtras):
                 f"Retrieve the VLAN named {self.name} to perform updates"
             )
         else:
-            return_super = True
             try:
                 vlan = VLAN.objects.get(name=self.name, vid=self.vid, location=location_obj)
             except VLAN.MultipleObjectsReturned:
@@ -892,13 +891,13 @@ class Vlan(DiffSyncExtras):
                     f"Multiple VLANs found with a name {self.name} and VLAN ID {self.vid} "
                     f"at a Location named {self.location}, unable to perform updates"
                 )
-                return_super = False
+                return None
             except VLAN.DoesNotExist:
                 self.adapter.job.logger.error(
                     f"Could not find a VLAN named {self.name} and VLAN ID {self.vid} "
                     f"at a Location named {self.location}, unable to perform updates"
                 )
-                return_super = False
+                return None
             else:
                 if attrs.get("status") == "Active":
                     safe_delete_tag, _ = Tag.objects.get_or_create(name="SSoT Safe Delete")
@@ -915,9 +914,8 @@ class Vlan(DiffSyncExtras):
                 self.adapter.job.logger.warning(
                     f"Unable to perform a validated_save() on VLAN {self.name} with an ID of {vlan.id}"
                 )
-                return_super = False
-            if return_super:
-                return super().update(attrs)
+                return None
+            return super().update(attrs)
         return None
 
 

--- a/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
+++ b/nautobot_ssot/integrations/ipfabric/diffsync/diffsync_models.py
@@ -580,7 +580,7 @@ class Interface(DiffSyncExtras):
         if device:
             return_super = True
             try:
-                interface = device.interfaces.prefetch_related("ip_addresses").get(name=self.name)
+                interface = device.interfaces.prefetch_related("ip_addresses__interfaces").get(name=self.name)
             except NautobotInterface.MultipleObjectsReturned:
                 self.adapter.job.logger.error(
                     f"Multiple Interfaces found with the name {self.name}, on Device named {self.device_name} "

--- a/nautobot_ssot/integrations/ipfabric/utilities/__init__.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/__init__.py
@@ -1,6 +1,7 @@
 """Utilities."""
 
 from .nbutils import (
+    assign_device_to_virtual_chassis,
     create_interface,
     create_ip,
     create_vlan,
@@ -10,10 +11,14 @@ from .nbutils import (
     get_or_create_manufacturer_object,
     get_or_create_platform_object,
     get_or_create_status_object,
+    get_or_create_tag_object,
+    get_or_create_virtual_chassis_object,
+    get_tagged_device,
 )
 from .test_utils import clean_slate, json_fixture
 
 __all__ = (
+    "assign_device_to_virtual_chassis",
     "create_ip",
     "create_interface",
     "json_fixture",
@@ -25,4 +30,7 @@ __all__ = (
     "get_or_create_manufacturer_object",
     "get_or_create_platform_object",
     "get_or_create_status_object",
+    "get_or_create_tag_object",
+    "get_or_create_virtual_chassis_object",
+    "get_tagged_device",
 )

--- a/nautobot_ssot/integrations/ipfabric/utilities/__init__.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/__init__.py
@@ -1,28 +1,28 @@
 """Utilities."""
 
 from .nbutils import (
-    create_device_type_object,
     create_interface,
     create_ip,
-    create_location,
-    create_manufacturer,
-    create_platform_object,
-    create_status,
     create_vlan,
     get_or_create_device_role_object,
+    get_or_create_device_type_object,
+    get_or_create_location_object,
+    get_or_create_manufacturer_object,
+    get_or_create_platform_object,
+    get_or_create_status_object,
 )
 from .test_utils import clean_slate, json_fixture
 
 __all__ = (
-    "create_location",
-    "create_device_type_object",
-    "create_manufacturer",
-    "create_platform_object",
-    "get_or_create_device_role_object",
-    "create_status",
     "create_ip",
     "create_interface",
     "json_fixture",
     "create_vlan",
     "clean_slate",
+    "get_or_create_device_role_object",
+    "get_or_create_device_type_object",
+    "get_or_create_location_object",
+    "get_or_create_manufacturer_object",
+    "get_or_create_platform_object",
+    "get_or_create_status_object",
 )

--- a/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
@@ -368,11 +368,11 @@ def get_or_create_tag_object(  # pylint: disable=too-many-arguments
         )
     except (DjangoBaseDBError, ValidationError):
         if logger:
-            logger.error(f"Unable to create a new Status named {tag_name}")
+            logger.error(f"Unable to create a new Tag named {tag_name}")
         return None
-    except Status.MultipleObjectsReturned:
+    except Tag.MultipleObjectsReturned:
         if logger:
-            logger.error(f"Multiple Statuses returned with the name {tag_name}")
+            logger.error(f"Multiple Tags returned with the name {tag_name}")
         return None
     tag_obj.content_types.add(content_type)
     return tag_obj

--- a/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
@@ -536,53 +536,41 @@ def create_interface(
     """
     interface_name = interface_details.pop("name")
     status = interface_details.pop("status", "Active")
+    status_obj = get_or_create_status_object(status, app_label="dcim", model="interface", logger=logger)
+    if not status_obj:
+        if logger:
+            logger.error(
+                f"Unable to set Status of {status} for Interface named {interface_name} on Device named {device_obj.name}"
+            )
+        return None
+    interface_fields = (
+        "description",
+        "enabled",
+        "mac_address",
+        "mtu",
+        "type",
+        "mgmt_only",
+    )
+    defaults = {k: v for k, v in interface_details.items() if k in interface_fields and v}
     try:
-        status_obj = Status.objects.get_for_model(Interface).get(name=status)
-    except Status.MultipleObjectsReturned:
-        if logger:
-            logger.error(
-                f"Multiple Statuses returned with name {status}, "
-                f"and therefore cannot create an Interface named {interface_name}"
-            )
-    except Status.DoesNotExist:
-        if logger:
-            logger.error(
-                f"Unable to find a Status with the name {status}, "
-                f"and therefore cannot create an Interface named {interface_name}"
-            )
-    else:
-        interface_fields = (
-            "description",
-            "enabled",
-            "mac_address",
-            "mtu",
-            "type",
-            "mgmt_only",
+        interface_obj, _ = device_obj.interfaces.get_or_create(
+            name=interface_name, status=status_obj, defaults=defaults
         )
-        defaults = {k: v for k, v in interface_details.items() if k in interface_fields and v}
+    except Interface.MultipleObjectsReturned:
+        if logger:
+            logger.error(f"Multiple Interfaces returned with name {interface_name} on Device named {device_obj.name}")
+    except (DjangoBaseDBError, ValidationError):
+        if logger:
+            logger.error(f"Unable to create a new Interface named {interface_name} on Device named {device_obj.name}")
+    else:
         try:
-            interface_obj, _ = device_obj.interfaces.get_or_create(
-                name=interface_name, status=status_obj, defaults=defaults
-            )
-        except Interface.MultipleObjectsReturned:
-            if logger:
-                logger.error(
-                    f"Multiple Interfaces returned with name {interface_name} on Device named {device_obj.name}"
-                )
+            tag_object(nautobot_object=interface_obj, custom_field=LAST_SYNCHRONIZED_CF_NAME)
         except (DjangoBaseDBError, ValidationError):
             if logger:
-                logger.error(
-                    f"Unable to create a new Interface named {interface_name} on Device named {device_obj.name}"
+                logger.warning(
+                    f"Unable to perform validated_save() on Interface named {interface_name} on Device named {device_obj.name}"
                 )
-        else:
-            try:
-                tag_object(nautobot_object=interface_obj, custom_field=LAST_SYNCHRONIZED_CF_NAME)
-            except (DjangoBaseDBError, ValidationError):
-                if logger:
-                    logger.warning(
-                        f"Unable to perform validated_save() on Interface named {interface_name} on Device named {device_obj.name}"
-                    )
-            return interface_obj
+        return interface_obj
     return None
 
 

--- a/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import Error as DjangoBaseDBError
+from django.db.models import Q
 from nautobot.core.choices import ColorChoices
 from nautobot.dcim.models import (
     Device,
@@ -18,6 +19,7 @@ from nautobot.dcim.models import (
     LocationType,
     Manufacturer,
     Platform,
+    VirtualChassis,
 )
 from nautobot.extras.choices import CustomFieldTypeChoices
 from nautobot.extras.models import CustomField, Role, Tag
@@ -28,11 +30,13 @@ from netutils.ip import netmask_to_cidr
 from netutils.lib_mapper import NAPALM_LIB_MAPPER
 
 from nautobot_ssot.integrations.ipfabric.constants import LAST_SYNCHRONIZED_CF_NAME
+from nautobot_ssot.integrations.ipfabric.utilities.utils import job_scoped_cache
 
 # pylint: disable=too-many-branches
 
 
-def create_location(
+@job_scoped_cache
+def get_or_create_location_object(
     location_name: str,
     location_id: Optional[str] = None,
     logger: Optional[logging.Logger] = None,
@@ -94,7 +98,10 @@ def create_location(
     return None
 
 
-def create_manufacturer(vendor_name: str, logger: Optional[logging.Logger] = None) -> Optional[Manufacturer]:
+@job_scoped_cache
+def get_or_create_manufacturer_object(
+    vendor_name: str, logger: Optional[logging.Logger] = None
+) -> Optional[Manufacturer]:
     """Create specified manufacturer in Nautobot.
 
     Args:
@@ -125,7 +132,8 @@ def create_manufacturer(vendor_name: str, logger: Optional[logging.Logger] = Non
     return None
 
 
-def create_device_type_object(
+@job_scoped_cache
+def get_or_create_device_type_object(
     device_type: str,
     vendor_name: str,
     logger: Optional[logging.Logger] = None,
@@ -141,7 +149,7 @@ def create_device_type_object(
         DeviceType: When a DeviceType Object is retrieved or created.
         None: When there is a failure in getting or creating a DeviceType.
     """
-    manufacturer_obj = create_manufacturer(vendor_name, logger=logger)
+    manufacturer_obj = get_or_create_manufacturer_object(vendor_name, logger=logger)
     if manufacturer_obj:
         try:
             device_type_obj, _ = DeviceType.objects.get_or_create(
@@ -174,7 +182,8 @@ def create_device_type_object(
     return None
 
 
-def create_platform_object(
+@job_scoped_cache
+def get_or_create_platform_object(
     platform: str,
     manufacturer_obj: Manufacturer,
     logger: Optional[logging.Logger] = None,
@@ -235,9 +244,10 @@ def create_platform_object(
     return None
 
 
+@job_scoped_cache
 def get_or_create_device_role_object(
     role_name: str,
-    role_color: str,
+    role_color: str = ColorChoices.COLOR_GREY,
     logger: Optional[logging.Logger] = None,
 ) -> Optional[Role]:
     """Create specified device role in Nautobot.
@@ -278,9 +288,10 @@ def get_or_create_device_role_object(
     return None
 
 
-def create_status(  # pylint: disable=too-many-arguments
+@job_scoped_cache
+def get_or_create_status_object(  # pylint: disable=too-many-arguments
     status_name: str,
-    status_color: str,
+    status_color: str = ColorChoices.COLOR_GREY,
     description: str = "",
     app_label: str = "dcim",
     model: str = "device",
@@ -320,6 +331,96 @@ def create_status(  # pylint: disable=too-many-arguments
         if logger:
             logger.error(f"Multiple Statuses returned with the name {status_name}")
     return None
+
+
+@job_scoped_cache
+def get_or_create_tag_object(  # pylint: disable=too-many-arguments
+    tag_name: str,
+    tag_color: str = ColorChoices.COLOR_GREY,
+    description: str = "",
+    app_label: str = "dcim",
+    model: str = "device",
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Tag]:
+    """Verify Tag object exists in Nautobot. If not, creates specified Tag. Defaults to dcim | device.
+
+    Args:
+        tag_name: Status name.
+        tag_color: Status color.
+        description: Description
+        app_label: App Label ("DCIM")
+        model: Django Model ("DEVICE")
+        logger: Logger to use for messaging.
+
+    Returns:
+        Tag: When a Tag Object is retrieved or created.
+        None: When there is a failure in getting or creating a Tag.
+    """
+    content_type = ContentType.objects.get(app_label=app_label, model=model)
+    try:
+        tag_obj, _ = Tag.objects.get_or_create(
+            name__iexact=tag_name,
+            defaults={
+                "name": tag_name,
+                "color": tag_color,
+                "description": description,
+            },
+        )
+    except (DjangoBaseDBError, ValidationError):
+        if logger:
+            logger.error(f"Unable to create a new Status named {tag_name}")
+        return None
+    except Status.MultipleObjectsReturned:
+        if logger:
+            logger.error(f"Multiple Statuses returned with the name {tag_name}")
+        return None
+    tag_obj.content_types.add(content_type)
+    return tag_obj
+
+
+@job_scoped_cache
+def get_or_create_virtual_chassis_object(name: str, logger=None) -> Optional[VirtualChassis]:
+    """Get or create a VirtualChassis by name."""
+    try:
+        vc, _ = VirtualChassis.objects.get_or_create(name=name)
+        return vc
+    except (DjangoBaseDBError, ValidationError) as err:
+        if logger:
+            logger.error(f"Unable to get or create VirtualChassis named {name}. Error: {err}")
+    return None
+
+
+def assign_device_to_virtual_chassis(device, virtual_chassis, master=False, position=None, priority=None, logger=None):  # pylint: disable=too-many-arguments
+    """Assign an existing device to an existing VirtualChassis. Update attributes if required."""
+    updated = False
+    if device.virtual_chassis != virtual_chassis:
+        device.virtual_chassis = virtual_chassis
+        updated = True
+    if position and device.vc_position != position:
+        device.vc_position = position
+        updated = True
+    if priority and device.vc_position:
+        if device.vc_priority != priority:
+            device.vc_priority = priority
+            updated = True
+    elif priority and logger:
+        logger.warning(
+            f"Device {device.name} assigned to VirtualChassis {virtual_chassis.name} has a "
+            f"priority of {priority}, but this cannot be set without a vc_position"
+        )
+    if updated:
+        device.validated_save()
+    if master and virtual_chassis.master != device:
+        virtual_chassis.master = device
+        virtual_chassis.validated_save()
+    return virtual_chassis
+
+
+@job_scoped_cache
+def get_tagged_device(device_name: str) -> Device:
+    """Cached lookup for Devices, used in interface operations."""
+    ssot_tag = get_or_create_tag_object(tag_name="SSoT Synced from IPFabric")
+    return Device.objects.filter(Q(name=device_name) & Q(tags=ssot_tag)).first()
 
 
 def create_ip(  # pylint: disable=too-many-statements
@@ -424,6 +525,7 @@ def create_ip(  # pylint: disable=too-many-statements
     return None
 
 
+# Not cached, as it is unhashable, but not useful to cache anyway
 def create_interface(
     device_obj: Device, interface_details: dict, logger: Optional[logging.Logger] = None
 ) -> Optional[Interface]:
@@ -490,6 +592,7 @@ def create_interface(
     return None
 
 
+@job_scoped_cache
 def create_vlan(  # pylint: disable=too-many-arguments
     vlan_name: str,
     vlan_id: int,
@@ -552,16 +655,14 @@ def tag_object(nautobot_object: Any, custom_field: str, tag_name: Optional[str] 
         custom_field (str): Name of custom field to update
         tag_name (Optional[str], optional): Tag name. Defaults to "SSoT Synced From IPFabric".
     """
-    if tag_name == "SSoT Synced from IPFabric":
-        tag, _ = Tag.objects.get_or_create(
-            name="SSoT Synced from IPFabric",
-            defaults={
-                "description": "Object synced at some point from IPFabric to Nautobot",
-                "color": ColorChoices.COLOR_LIGHT_GREEN,
-            },
-        )
-    else:
-        tag, _ = Tag.objects.get_or_create(name=tag_name)
+    ct = ContentType.objects.get_for_model(nautobot_object)
+    tag = get_or_create_tag_object(
+        tag_name=tag_name,
+        tag_color=ColorChoices.COLOR_LIGHT_GREEN,
+        description="Object synced at some point from IPFabric to Nautobot",
+        app_label=ct.app_label,
+        model=ct.model,
+    )
 
     today = datetime.date.today().isoformat()
 

--- a/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
@@ -345,8 +345,8 @@ def get_or_create_tag_object(  # pylint: disable=too-many-arguments
     """Verify Tag object exists in Nautobot. If not, creates specified Tag. Defaults to dcim | device.
 
     Args:
-        tag_name: Status name.
-        tag_color: Status color.
+        tag_name: Tag name.
+        tag_color: Tag color.
         description: Description
         app_label: App Label ("DCIM")
         model: Django Model ("DEVICE")

--- a/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/nbutils.py
@@ -390,7 +390,7 @@ def get_or_create_virtual_chassis_object(name: str, logger=None) -> Optional[Vir
     return None
 
 
-def assign_device_to_virtual_chassis(device, virtual_chassis, master=False, position=None, priority=None, logger=None):  # pylint: disable=too-many-arguments
+def assign_device_to_virtual_chassis(device, virtual_chassis, position, master=False, priority=None):  # pylint: disable=too-many-arguments
     """Assign an existing device to an existing VirtualChassis. Update attributes if required."""
     updated = False
     if device.virtual_chassis != virtual_chassis:
@@ -399,15 +399,9 @@ def assign_device_to_virtual_chassis(device, virtual_chassis, master=False, posi
     if position and device.vc_position != position:
         device.vc_position = position
         updated = True
-    if priority and device.vc_position:
-        if device.vc_priority != priority:
-            device.vc_priority = priority
-            updated = True
-    elif priority and logger:
-        logger.warning(
-            f"Device {device.name} assigned to VirtualChassis {virtual_chassis.name} has a "
-            f"priority of {priority}, but this cannot be set without a vc_position"
-        )
+    if priority and device.vc_priority != priority:
+        device.vc_priority = priority
+        updated = True
     if updated:
         device.validated_save()
     if master and virtual_chassis.master != device:

--- a/nautobot_ssot/integrations/ipfabric/utilities/utils.py
+++ b/nautobot_ssot/integrations/ipfabric/utilities/utils.py
@@ -1,6 +1,9 @@
 """General utils for IPFabric."""
 
 import re
+import threading
+from collections import defaultdict
+from functools import wraps
 
 from nautobot_ssot.integrations.ipfabric.constants import DEFAULT_INTERFACE_TYPE
 
@@ -158,3 +161,98 @@ def convert_media_type(  # pylint: disable=too-many-return-statements,too-many-b
                 return iface_type
 
     return DEFAULT_INTERFACE_TYPE
+
+
+class job_scoped_cache:  # pylint: disable=invalid-name
+    """Drop-in replacement for @lru_cache, safe for concurrent job runs.
+
+    Each thread/process gets its own isolated cache store.
+
+    Usage:
+        @job_scoped_cache
+        def get_status(name):
+            return Status.objects.get(name=name)
+
+        @job_scoped_cache(group="facility_circuits")
+        def get_service_type(code):
+            return ServiceType.objects.filter(service_type_code=code).first()
+
+        # Clear only one group:
+        job_scoped_cache.clear_group("facility_circuits")
+
+        # Clear everything (backward-compatible):
+        job_scoped_cache.clear_all()
+    """
+
+    _all_instances = []
+    _groups = defaultdict(list)
+    _local = threading.local()
+
+    def __init__(self, fn=None, *, group=None):
+        """Initialize the cache."""
+        self._group = group
+        if fn is not None:
+            # Called as @job_scoped_cache (no arguments)
+            self._init_fn(fn)
+
+    def _init_fn(self, fn):
+        """Initialize function."""
+        self._fn = fn
+        self._id = id(self)
+        wraps(fn)(self)
+        job_scoped_cache._all_instances.append(self)
+        if self._group:
+            job_scoped_cache._groups[self._group].append(self)
+
+    def __call__(self, *args, **kwargs):
+        """Handle call to function, checks cache, calls function if missing and caches result."""
+        if not hasattr(self, "_fn"):
+            # Called as @job_scoped_cache(group="...") — receives the function
+            self._init_fn(args[0])
+            return self
+        state = self._get_state()
+        key = (args, tuple(sorted(kwargs.items())))
+        if key in state["store"]:
+            state["hits"] += 1
+            return state["store"][key]
+        state["misses"] += 1
+        result = self._fn(*args, **kwargs)
+        state["store"][key] = result
+        return result
+
+    def _get_state(self):
+        """Return state of cache."""
+        stores = getattr(job_scoped_cache._local, "stores", None)
+        if stores is None:
+            stores = {}
+            job_scoped_cache._local.stores = stores
+        if self._id not in stores:
+            stores[self._id] = {"store": {}, "hits": 0, "misses": 0}
+        return stores[self._id]
+
+    def cache_clear(self):
+        """Clear all cache info for an instance."""
+        state = self._get_state()
+        state["store"].clear()
+        state["hits"] = 0
+        state["misses"] = 0
+
+    def cache_info(self):
+        """Returns cache info."""
+        from collections import namedtuple  # pylint: disable=import-outside-toplevel
+
+        state = self._get_state()
+        _CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+        return _CacheInfo(state["hits"], state["misses"], None, len(state["store"]))
+
+    @classmethod
+    def clear_group(cls, group):
+        """Clear caches for all functions registered under a specific group."""
+        for instance in cls._groups.get(group, []):
+            instance.cache_clear()
+
+    @classmethod
+    def clear_all(cls):
+        """Clears all cache info on all instances and groups."""
+        for instance in cls._all_instances:
+            instance.cache_clear()

--- a/nautobot_ssot/tests/ipfabric/fixtures/get_vlans.json
+++ b/nautobot_ssot/tests/ipfabric/fixtures/get_vlans.json
@@ -76,5 +76,17 @@
       "vlanName":"dbvlan0001",
       "vlanId":393,
       "dscr":"None"
+   },
+   {
+      "siteName":"JCY-SPINE-01.INFRA.NTC.COM_1",
+      "vlanName":"badvlan0001",
+      "vlanId":0,
+      "dscr":"None"
+   },
+   {
+      "siteName":"JCY-SPINE-01.INFRA.NTC.COM_1",
+      "vlanName":"badvlan0002",
+      "vlanId":5000,
+      "dscr":"None"
    }
 ]

--- a/nautobot_ssot/tests/ipfabric/test_diffsync_models.py
+++ b/nautobot_ssot/tests/ipfabric/test_diffsync_models.py
@@ -6,6 +6,8 @@ calls, regression guards for fixed bugs. Nautobot ORM calls and the
 test suites.
 """
 
+import contextlib
+from types import SimpleNamespace
 from unittest import mock
 
 from django.test import SimpleTestCase
@@ -19,6 +21,18 @@ from nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models import (
     Vlan,
 )
 
+# ============================================================
+# Shared helpers
+# ============================================================
+
+_UNSET = object()
+_NBUTILS = "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils"
+
+
+def _nb_patch(name, **kwargs):
+    """Patch a helper attribute on `tonb_nbutils` referenced from the model module."""
+    return mock.patch(f"{_NBUTILS}.{name}", **kwargs)
+
 
 def _make_adapter():
     """Minimal mock adapter sufficient for invoking model methods directly."""
@@ -31,59 +45,107 @@ def _make_adapter():
     return adapter
 
 
+def _active_device_mock():
+    """Return a Nautobot Device mock whose status reads 'Active'."""
+    nb_device = mock.MagicMock()
+    nb_device.status.name = "Active"
+    return nb_device
+
+
+@contextlib.contextmanager
+def _patch_device_create_helpers(
+    *,
+    device_type=_UNSET,
+    role=_UNSET,
+    status=_UNSET,
+    location=_UNSET,
+    platform=_UNSET,
+):
+    """Patch the five `Device.create` collaborator helpers in one shot.
+
+    Each kwarg overrides the helper's `return_value`. `_UNSET` defaults to a fresh
+    `MagicMock()`. Pass `None` to trigger the helper-failure branch.
+    """
+    helpers = (
+        ("get_or_create_device_type_object", device_type),
+        ("get_or_create_device_role_object", role),
+        ("get_or_create_status_object", status),
+        ("get_or_create_location_object", location),
+        ("get_or_create_platform_object", platform),
+    )
+    with contextlib.ExitStack() as stack:
+        ns = SimpleNamespace()
+        for helper_name, value in helpers:
+            return_value = mock.MagicMock() if value is _UNSET else value
+            setattr(ns, helper_name, stack.enter_context(_nb_patch(helper_name, return_value=return_value)))
+        yield ns
+
+
+class _ModelTestBase(SimpleTestCase):
+    """Shared scaffolding for diffsync model tests."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+
+    def _assert_log_contains(self, logger_method, fragment):
+        """Assert at least one call to `logger_method` contains the substring `fragment`."""
+        self.assertTrue(
+            any(fragment in str(c.args[0]) for c in logger_method.call_args_list),
+            f"Expected log containing {fragment!r}; got {logger_method.call_args_list!r}",
+        )
+
+
 # ============================================================
 # DiffSyncExtras.safe_delete
 # ============================================================
 
 
-class TestSafeDelete(SimpleTestCase):
+class TestSafeDelete(_ModelTestBase):
     """Test `DiffSyncExtras.safe_delete` branching logic."""
 
     def setUp(self):
-        self.adapter = _make_adapter()
-        # Vlan is the smallest model; any model would work since safe_delete
-        # is defined on the shared base class.
+        super().setUp()
+        # Vlan is the smallest model; safe_delete is defined on the shared base.
         self.diff_model = Vlan(name="v", vid=10, status="Active", location="loc")
         self.diff_model.adapter = self.adapter
 
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
+    @_nb_patch("tag_object")
+    @_nb_patch("get_or_create_status_object")
     def test_safe_delete_changes_status_and_tags_when_status_differs(self, mock_status, mock_tag_object):
         """Status differs -> status updated, tag added, tag_object called once."""
         mock_status.return_value = "safe-deleted-status"
-        nautobot_obj = mock.MagicMock()
-        nautobot_obj.status = "active-status"
-        nautobot_obj.tags.filter.return_value.exists.return_value = False
+        nb_obj = mock.MagicMock()
+        nb_obj.status = "active-status"
+        nb_obj.tags.filter.return_value.exists.return_value = False
 
-        self.diff_model.safe_delete(nautobot_obj, "Decommissioning", self.adapter.safe_delete_tag)
+        self.diff_model.safe_delete(nb_obj, "Decommissioning", self.adapter.safe_delete_tag)
 
-        self.assertEqual(nautobot_obj.status, "safe-deleted-status")
-        nautobot_obj.tags.add.assert_called_once_with(self.adapter.safe_delete_tag)
+        self.assertEqual(nb_obj.status, "safe-deleted-status")
+        nb_obj.tags.add.assert_called_once_with(self.adapter.safe_delete_tag)
         mock_tag_object.assert_called_once()
 
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
+    @_nb_patch("tag_object")
+    @_nb_patch("get_or_create_status_object")
     def test_safe_delete_skips_when_tag_already_present_and_status_unchanged(self, mock_status, mock_tag_object):
         """Tag already on object and status already correct -> no save, no tag_object."""
-        already_status = "safe-deleted-status"
-        mock_status.return_value = already_status
-        nautobot_obj = mock.MagicMock()
-        nautobot_obj.status = already_status  # already matches
-        nautobot_obj.tags.filter.return_value.exists.return_value = True  # tag already present
+        mock_status.return_value = "safe-deleted-status"
+        nb_obj = mock.MagicMock()
+        nb_obj.status = "safe-deleted-status"  # already matches
+        nb_obj.tags.filter.return_value.exists.return_value = True  # tag already present
 
-        self.diff_model.safe_delete(nautobot_obj, "Decommissioning", self.adapter.safe_delete_tag)
+        self.diff_model.safe_delete(nb_obj, "Decommissioning", self.adapter.safe_delete_tag)
 
-        nautobot_obj.tags.add.assert_not_called()
+        nb_obj.tags.add.assert_not_called()
         mock_tag_object.assert_not_called()
 
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
+    @_nb_patch("tag_object")
     def test_safe_delete_no_tag_arg_is_a_noop_for_tagging(self, mock_tag_object):
         """Defensive guard: when safe_delete_tag is None, tags.add is never called."""
-        nautobot_obj = mock.MagicMock(spec=["tags"])  # has tags but no status attr
+        nb_obj = mock.MagicMock(spec=["tags"])  # has tags but no status attr
 
-        self.diff_model.safe_delete(nautobot_obj, safe_delete_status=None, safe_delete_tag=None)
+        self.diff_model.safe_delete(nb_obj, safe_delete_status=None, safe_delete_tag=None)
 
-        nautobot_obj.tags.add.assert_not_called()
+        nb_obj.tags.add.assert_not_called()
         mock_tag_object.assert_not_called()
 
 
@@ -92,30 +154,22 @@ class TestSafeDelete(SimpleTestCase):
 # ============================================================
 
 
-class TestLocationModel(SimpleTestCase):
+class TestLocationModel(_ModelTestBase):
     """Test `Location.create/update/delete` branching logic."""
 
-    def setUp(self):
-        self.adapter = _make_adapter()
-
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
-        return_value=None,
-    )
+    @_nb_patch("get_or_create_location_object", return_value=None)
     def test_create_returns_none_when_helper_fails(self, _mock_helper):
-        """If `get_or_create_location_object` returns None, `create` returns None and does not call super()."""
-        with mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super_create:
+        """If `get_or_create_location_object` returns None, `create` returns None and skips super()."""
+        with mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super:
             result = Location.create(
                 adapter=self.adapter,
                 ids={"name": "X"},
                 attrs={"site_id": "Y", "status": "Active"},
             )
         self.assertIsNone(result)
-        mock_super_create.assert_not_called()
+        mock_super.assert_not_called()
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object"
-    )
+    @_nb_patch("get_or_create_location_object")
     def test_create_calls_super_when_helper_succeeds(self, mock_helper):
         """Successful helper call leads to super().create() being invoked."""
         mock_helper.return_value = mock.MagicMock()
@@ -129,7 +183,7 @@ class TestLocationModel(SimpleTestCase):
         mock_super.assert_called_once()
 
     def test_delete_returns_none_when_location_does_not_exist(self):
-        """`DoesNotExist` lookup -> logged and `super().delete()` not invoked."""
+        """DoesNotExist lookup -> logged and super().delete() not invoked."""
         diff_model = Location(name="missing", site_id=None, status="Active")
         diff_model.adapter = self.adapter
 
@@ -147,132 +201,301 @@ class TestLocationModel(SimpleTestCase):
         mock_super_delete.assert_not_called()
         self.adapter.job.logger.error.assert_called_once()
 
+    def test_update_status_active_sets_status_and_removes_safe_tag(self):
+        """Status flip to Active rewrites status and removes the safe-delete tag."""
+        diff_model = Location(name="X", site_id=None, status="Decommissioning")
+        diff_model.adapter = self.adapter
+
+        nb_loc = mock.MagicMock()
+        nb_loc.status = "Decommissioning"  # differs from "Active"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=nb_loc),
+            _nb_patch("get_or_create_status_object", return_value="active-status-obj") as mock_status,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            result = diff_model.update({"status": "Active"})
+
+        mock_status.assert_called_once()
+        self.assertEqual(nb_loc.status, "active-status-obj")
+        nb_loc.tags.remove.assert_called_once_with(self.adapter.safe_delete_tag)
+        self.assertEqual(result, "ok")
+
 
 # ============================================================
 # Device lifecycle
 # ============================================================
 
 
-class TestDeviceModel(SimpleTestCase):
+class TestDeviceModel(_ModelTestBase):
     """Test `Device.create/update` branching and regression guards."""
 
-    def setUp(self):
-        self.adapter = _make_adapter()
-        self.adapter.job.debug = False
+    _BASE_CREATE_ATTRS = {"model": "m", "vendor": "v", "location_name": "loc"}
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
-        return_value=None,
-    )
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
-    )
-    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.DeviceType.objects.filter")
-    def test_create_short_circuits_when_location_missing(self, mock_dt_filter, mock_role, mock_status, _mock_loc):
+    def _call_device_create(self, **attr_overrides):
+        """Invoke `Device.create` with the standard ids and attrs (with overrides merged in)."""
+        attrs = {**self._BASE_CREATE_ATTRS, **attr_overrides}
+        return Device.create(adapter=self.adapter, ids={"name": "d1"}, attrs=attrs)
+
+    def test_create_short_circuits_when_location_missing(self):
         """Any required helper returning None means Device.create returns None without saving."""
-        mock_dt_filter.return_value.first.return_value = mock.MagicMock()
-        mock_role.return_value = mock.MagicMock()
-        mock_status.return_value = mock.MagicMock()
-
-        with mock.patch.object(diffsync_models.NautobotDevice.objects, "get_or_create") as mock_get_or_create:
-            result = Device.create(
-                adapter=self.adapter,
-                ids={"name": "d1"},
-                attrs={"model": "m", "vendor": "v", "location_name": "loc"},
-            )
+        with (
+            _patch_device_create_helpers(location=None),
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get_or_create") as mock_get_or_create,
+        ):
+            mock_dt_filter.return_value.first.return_value = mock.MagicMock()
+            result = self._call_device_create()
 
         self.assertIsNone(result)
         mock_get_or_create.assert_not_called()
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
-    )
-    def test_create_skips_role_cf_save_when_value_already_matches(self, mock_role_helper):
+    def test_create_skips_role_cf_save_when_value_already_matches(self):
         """Regression: Role.validated_save() must not run when cf['ipfabric_type'] already matches role_name."""
         role_obj = mock.MagicMock()
         role_obj.cf.get.return_value = "DesiredRole"  # already matches
-        mock_role_helper.return_value = role_obj
 
-        # Force the rest of the create() to bail before super() by making location lookup fail
+        # Force bail before super() by making location lookup fail
         with (
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
-                return_value=None,
-            ),
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object"
-            ),
+            _patch_device_create_helpers(role=role_obj, location=None),
             mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
         ):
-            Device.create(
-                adapter=self.adapter,
-                ids={"name": "d1"},
-                attrs={"model": "m", "vendor": "v", "role": "DesiredRole", "location_name": "loc"},
-            )
+            self._call_device_create(role="DesiredRole")
 
         role_obj.validated_save.assert_not_called()
-        # cf was never written either
         role_obj.cf.__setitem__.assert_not_called()
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
-    )
-    def test_create_writes_and_saves_role_cf_when_value_differs(self, mock_role_helper):
+    def test_create_writes_and_saves_role_cf_when_value_differs(self):
         """When cf['ipfabric_type'] does not match, set it and run validated_save() exactly once."""
         role_obj = mock.MagicMock()
         role_obj.cf.get.return_value = "OldRole"  # differs from DesiredRole
-        mock_role_helper.return_value = role_obj
 
         with (
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
-                return_value=None,
-            ),
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object"
-            ),
+            _patch_device_create_helpers(role=role_obj, location=None),
             mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
         ):
-            Device.create(
-                adapter=self.adapter,
-                ids={"name": "d1"},
-                attrs={"model": "m", "vendor": "v", "role": "DesiredRole", "location_name": "loc"},
-            )
+            self._call_device_create(role="DesiredRole")
 
         role_obj.cf.__setitem__.assert_called_once_with("ipfabric_type", "DesiredRole")
         role_obj.validated_save.assert_called_once()
 
-    def test_update_detects_vc_attrs_present_for_non_name_keys(self):
-        """Regression: ``vc_attrs_present`` must be True if any VC-prefixed key is in attrs.
+    def test_create_uses_helper_when_devicetype_filter_empty(self):
+        """Empty DeviceType filter -> calls `get_or_create_device_type_object` helper."""
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            # Helper for DT supplied here, location=None bails early
+            _patch_device_create_helpers(location=None) as helpers,
+        ):
+            mock_dt_filter.return_value.first.return_value = None  # filter is empty
+            self._call_device_create()
 
-        The previous implementation used ``vc_name or vc_master or vc_position or vc_priority`` and
-        could miss legitimate ``vc_master=False`` or zero-valued updates. Now membership is checked
-        via ``any(k in attrs for k in (...))``.
-        """
-        diff_model = Device(name="d", location_name="loc", vc_name="stack-A")
-        diff_model.adapter = self.adapter
+        helpers.get_or_create_device_type_object.assert_called_once_with(
+            device_type="m", vendor_name="v", logger=self.adapter.job.logger
+        )
 
-        _device = mock.MagicMock()
-        _device.status.name = "Active"
+    def test_create_warns_when_devicetype_helper_returns_none(self):
+        """DeviceType helper also fails -> warning logged."""
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            _patch_device_create_helpers(device_type=None),
+        ):
+            mock_dt_filter.return_value.first.return_value = None
+            result = self._call_device_create()
+
+        self.assertIsNone(result)
+        self._assert_log_contains(self.adapter.job.logger.warning, "DeviceType")
+
+    def test_create_warns_when_platform_helper_returns_none(self):
+        """Platform + device_type_object both set -> helper called; None return warns."""
+        device_type_obj = mock.MagicMock()
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            _patch_device_create_helpers(platform=None, location=None) as helpers,
+        ):
+            mock_dt_filter.return_value.first.return_value = device_type_obj
+            self._call_device_create(platform="ios")
+
+        helpers.get_or_create_platform_object.assert_called_once()
+        self._assert_log_contains(self.adapter.job.logger.warning, "will not have a Platform assigned")
+
+    def test_create_warns_when_platform_set_but_devicetype_missing(self):
+        """No device_type_object but platform supplied -> warning."""
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            _patch_device_create_helpers(device_type=None),
+        ):
+            mock_dt_filter.return_value.first.return_value = None
+            self._call_device_create(platform="ios")
+
+        self._assert_log_contains(self.adapter.job.logger.warning, "since the DeviceType could not be retrieved")
+
+    def test_create_logs_error_when_role_validated_save_fails(self):
+        """Role validated_save raises -> error logged, create continues."""
+        role_obj = mock.MagicMock()
+        role_obj.cf.get.return_value = "OldRole"  # mismatch triggers the save path
+        role_obj.validated_save.side_effect = diffsync_models.ValidationError("boom")
 
         with (
-            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=_device),
-            mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object"),
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_virtual_chassis_object"
-            ) as mock_get_vc,
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.assign_device_to_virtual_chassis"
-            ) as mock_assign,
+            _patch_device_create_helpers(role=role_obj, location=None),
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
+        ):
+            self._call_device_create(role="DesiredRole")
+
+        role_obj.validated_save.assert_called_once()
+        self._assert_log_contains(self.adapter.job.logger.error, "Unable to perform a validated_save() on Role")
+
+    def test_create_warns_when_role_helper_returns_none(self):
+        """Role helper returns None -> warning, no cf write."""
+        with (
+            _patch_device_create_helpers(role=None, location=None),
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
+        ):
+            result = self._call_device_create()
+
+        self.assertIsNone(result)
+        self._assert_log_contains(self.adapter.job.logger.warning, "to get or create a Role")
+
+    def test_create_warns_when_status_helper_returns_none(self):
+        """Status helper returns None -> warning."""
+        with _patch_device_create_helpers(status=None), mock.patch.object(diffsync_models.DeviceType.objects, "filter"):
+            result = self._call_device_create()
+
+        self.assertIsNone(result)
+        self._assert_log_contains(self.adapter.job.logger.warning, "to get or create a Status")
+
+    def test_create_with_vc_assigns_to_virtual_chassis(self):
+        """With vc_name set -> VC helpers called and super().create() runs."""
+        new_device = mock.MagicMock()
+        vc_obj = mock.MagicMock()
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            _patch_device_create_helpers(),
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get_or_create", return_value=(new_device, True)),
+            _nb_patch("tag_object"),
+            _nb_patch("get_or_create_virtual_chassis_object", return_value=vc_obj) as mock_vc_helper,
+            _nb_patch("assign_device_to_virtual_chassis") as mock_assign,
+            mock.patch.object(diffsync_models.DiffSyncModel, "create", return_value="ok"),
+        ):
+            mock_dt_filter.return_value.first.return_value = mock.MagicMock()
+            result = self._call_device_create(vc_name="stack-A", vc_position=1, vc_priority=5, vc_master=True)
+
+        mock_vc_helper.assert_called_once_with("stack-A", logger=self.adapter.job.logger)
+        mock_assign.assert_called_once()
+        self.assertEqual(result, "ok")
+
+    def test_create_handles_vc_helper_exception(self):
+        """VC helper raises -> error logged, super().create() still runs."""
+        new_device = mock.MagicMock()
+        with (
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter") as mock_dt_filter,
+            _patch_device_create_helpers(),
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get_or_create", return_value=(new_device, True)),
+            _nb_patch("tag_object"),
+            _nb_patch(
+                "get_or_create_virtual_chassis_object",
+                side_effect=diffsync_models.ValidationError("vc boom"),
+            ),
+            mock.patch.object(diffsync_models.DiffSyncModel, "create", return_value="ok"),
+        ):
+            mock_dt_filter.return_value.first.return_value = mock.MagicMock()
+            self._call_device_create(vc_name="stack-A")
+
+        self._assert_log_contains(self.adapter.job.logger.error, "VirtualChassis data")
+
+    # --- Device.update -----------------------------------------------------
+
+    def _setup_update(self, **device_kwargs):
+        """Build a Device diffsync model and its 'Active' Nautobot stand-in."""
+        diff_model = Device(name="d", location_name="loc", **device_kwargs)
+        diff_model.adapter = self.adapter
+        return diff_model, _active_device_mock()
+
+    def test_update_detects_vc_attrs_present_for_non_name_keys(self):
+        """Regression: vc_attrs_present must be True if any VC-prefixed key is in attrs.
+
+        Previous impl used `vc_name or vc_master or vc_position or vc_priority` and could
+        miss legitimate `vc_master=False` or zero-valued updates. Membership check now used.
+        """
+        diff_model, nb_device = self._setup_update(vc_name="stack-A")
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=nb_device),
+            _nb_patch("tag_object"),
+            _nb_patch("get_or_create_virtual_chassis_object") as mock_get_vc,
+            _nb_patch("assign_device_to_virtual_chassis") as mock_assign,
             mock.patch.object(diffsync_models.DiffSyncModel, "update"),
         ):
             mock_get_vc.return_value = mock.MagicMock()
-            # vc_position alone in attrs (no vc_name) should still trigger the VC code path
+            # vc_position alone in attrs (no vc_name) must still trigger the VC code path.
             diff_model.update({"vc_position": 3})
 
         mock_get_vc.assert_called_once_with("stack-A", logger=self.adapter.job.logger)
         mock_assign.assert_called_once()
+
+    def test_update_status_active_sets_status_and_removes_safe_tag(self):
+        """Status flip to Active rewrites status and removes safe-delete tag."""
+        diff_model, nb_device = self._setup_update()
+        nb_device.status.name = "Decommissioning"  # differs from "Active"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=nb_device),
+            _nb_patch("get_or_create_status_object", return_value="active-status-obj") as mock_status,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"status": "Active"})
+
+        mock_status.assert_called_once()
+        self.assertEqual(nb_device.status, "active-status-obj")
+        nb_device.tags.remove.assert_called_once_with(self.adapter.safe_delete_tag)
+
+    def test_update_calls_device_type_helper_when_model_in_attrs(self):
+        """`model` in attrs -> `get_or_create_device_type_object` is called."""
+        diff_model, nb_device = self._setup_update(vendor="cisco")
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=nb_device),
+            _nb_patch("get_or_create_device_type_object", return_value=mock.MagicMock()) as mock_dt_helper,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"model": "new-model"})
+
+        mock_dt_helper.assert_called_once_with(
+            device_type="new-model", vendor_name="cisco", logger=self.adapter.job.logger
+        )
+
+    def test_update_calls_platform_helper_when_platform_in_attrs(self):
+        """`platform` in attrs + Manufacturer found -> `get_or_create_platform_object` called."""
+        diff_model, nb_device = self._setup_update(vendor="cisco")
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=nb_device),
+            mock.patch.object(diffsync_models.Manufacturer.objects, "get", return_value="mfg"),
+            _nb_patch("get_or_create_platform_object", return_value=mock.MagicMock()) as mock_plat_helper,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"platform": "ios"})
+
+        mock_plat_helper.assert_called_once_with(platform="ios", manufacturer_obj="mfg", logger=self.adapter.job.logger)
+
+    def test_update_calls_location_helper_when_location_name_in_attrs(self):
+        """`location_name` in attrs -> `get_or_create_location_object` called and assigned."""
+        diff_model, nb_device = self._setup_update()
+        new_location = mock.MagicMock(name="new_location")
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=nb_device),
+            _nb_patch("get_or_create_location_object", return_value=new_location) as mock_loc_helper,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"location_name": "new-loc"})
+
+        mock_loc_helper.assert_called_once_with("new-loc", logger=self.adapter.job.logger)
+        self.assertIs(nb_device.location, new_location)
 
 
 # ============================================================
@@ -280,78 +503,64 @@ class TestDeviceModel(SimpleTestCase):
 # ============================================================
 
 
-class TestInterfaceModel(SimpleTestCase):
+class TestInterfaceModel(_ModelTestBase):
     """Test `Interface.create/update/delete` branching and regression guards."""
 
-    def setUp(self):
-        self.adapter = _make_adapter()
+    _BASE_CREATE_IDS = {"name": "eth0", "device_name": "d1"}
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
-        return_value=None,
-    )
+    def _call_interface_create(self, **attr_overrides):
+        attrs = {"ip_address": None, "subnet_mask": None, "status": "Active"}
+        attrs.update(attr_overrides)
+        return Interface.create(adapter=self.adapter, ids=self._BASE_CREATE_IDS, attrs=attrs)
+
+    @_nb_patch("get_tagged_device", return_value=None)
     def test_create_warns_when_tagged_device_not_found(self, _mock_get_device):
         """Missing parent device -> warning logged, no super().create()."""
         with mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super:
-            result = Interface.create(
-                adapter=self.adapter,
-                ids={"name": "eth0", "device_name": "nope"},
-                attrs={
-                    "ip_address": None,
-                    "subnet_mask": None,
-                    "status": "Active",
-                },
-            )
+            result = self._call_interface_create()
         self.assertIsNone(result)
         mock_super.assert_not_called()
         self.adapter.job.logger.warning.assert_called_once()
 
-    def test_create_primary_ipv4_saves_device_only_once(self):
-        """Regression: ip_version dispatch uses ``if/elif`` so device.save() is called exactly once."""
+    def _exercise_create_primary_ip(self, ip_version, ip_address):
+        """Shared helper for the IPv4/IPv6 primary-IP create paths."""
         device_obj = mock.MagicMock()
         interface_obj = mock.MagicMock()
         ip_obj = mock.MagicMock()
-        ip_obj.ip_version = 4
+        ip_obj.ip_version = ip_version
 
         with (
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
-                return_value=device_obj,
-            ),
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_interface",
-                return_value=interface_obj,
-            ),
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_ip",
-                return_value=ip_obj,
-            ),
+            _nb_patch("get_tagged_device", return_value=device_obj),
+            _nb_patch("create_interface", return_value=interface_obj),
+            _nb_patch("create_ip", return_value=ip_obj),
             mock.patch.object(diffsync_models.DiffSyncModel, "create"),
         ):
-            Interface.create(
-                adapter=self.adapter,
-                ids={"name": "eth0", "device_name": "d1"},
-                attrs={
-                    "ip_address": "10.0.0.1",
-                    "subnet_mask": "255.255.255.0",
-                    "ip_is_primary": True,
-                    "status": "Active",
-                },
+            self._call_interface_create(
+                ip_address=ip_address,
+                subnet_mask="255.255.255.0",
+                ip_is_primary=True,
             )
+        return device_obj, ip_obj
 
-        # IPv4 path sets primary_ip4 and saves once; primary_ip6 should not be touched.
+    def test_create_primary_ipv4_saves_device_only_once(self):
+        """Regression: ip_version dispatch uses if/elif so device.save() is called exactly once."""
+        device_obj, ip_obj = self._exercise_create_primary_ip(ip_version=4, ip_address="10.0.0.1")
         self.assertIs(device_obj.primary_ip4, ip_obj)
+        device_obj.save.assert_called_once()
+
+    def test_create_primary_ipv6_saves_device_only_once(self):
+        """`ip_version == 6` takes the elif branch; primary_ip6 set, save called once."""
+        device_obj, ip_obj = self._exercise_create_primary_ip(ip_version=6, ip_address="2001:db8::1")
+        self.assertIs(device_obj.primary_ip6, ip_obj)
         device_obj.save.assert_called_once()
 
     def test_delete_only_safe_deletes_unshared_ips(self):
         """Regression: when an IP is also on another interface, the IP must not be safe-deleted."""
-        adapter = self.adapter
-        # Build the interface returned from the prefetch chain.
         shared_ip = mock.MagicMock(name="shared_ip")
-        shared_ip.interfaces.exclude.return_value.exists.return_value = True  # on another interface
+        shared_ip.interfaces.exclude.return_value.exists.return_value = True
 
         exclusive_ip = mock.MagicMock(name="exclusive_ip")
-        exclusive_ip.interfaces.exclude.return_value.exists.return_value = False  # only this interface
+        exclusive_ip.interfaces.exclude.return_value.exists.return_value = False
 
         interface_obj = mock.MagicMock()
         interface_obj.id = "iface-uuid"
@@ -361,24 +570,64 @@ class TestInterfaceModel(SimpleTestCase):
         device.interfaces.prefetch_related.return_value.get.return_value = interface_obj
 
         diff_model = Interface(name="eth0", device_name="d1", status="Active")
-        diff_model.adapter = adapter
+        diff_model.adapter = self.adapter
 
         with (
-            mock.patch(
-                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
-                return_value=device,
-            ),
+            _nb_patch("get_tagged_device", return_value=device),
             mock.patch.object(DiffSyncExtras, "safe_delete") as mock_safe_delete,
             mock.patch.object(diffsync_models.DiffSyncModel, "delete"),
         ):
             diff_model.delete()
 
-        # safe_delete called exactly twice: once for exclusive_ip, once for the interface itself.
-        # NEVER called for shared_ip.
-        safe_delete_targets = [call.args[0] for call in mock_safe_delete.call_args_list]
-        self.assertIn(exclusive_ip, safe_delete_targets)
-        self.assertIn(interface_obj, safe_delete_targets)
-        self.assertNotIn(shared_ip, safe_delete_targets)
+        targets = [call.args[0] for call in mock_safe_delete.call_args_list]
+        self.assertIn(exclusive_ip, targets)
+        self.assertIn(interface_obj, targets)
+        self.assertNotIn(shared_ip, targets)
+
+    def _setup_interface_update(self):
+        """Build a diff model + a mocked device/interface returned from the prefetch chain."""
+        diff_model = Interface(name="eth0", device_name="d1", status="Active")
+        diff_model.adapter = self.adapter
+
+        device = mock.MagicMock(name="device")
+        interface_obj = mock.MagicMock(name="interface")
+        device.interfaces.prefetch_related.return_value.get.return_value = interface_obj
+        return diff_model, device, interface_obj
+
+    def test_update_replaces_existing_ip_address(self):
+        """Update flows through prefetch, clears existing IPs, adds new."""
+        diff_model, device, interface_obj = self._setup_interface_update()
+        interface_obj.ip_addresses.all.return_value = [mock.MagicMock()]  # existing IPs present
+        new_ip = mock.MagicMock()
+
+        with (
+            _nb_patch("get_tagged_device", return_value=device),
+            _nb_patch("create_ip", return_value=new_ip),
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            result = diff_model.update({"ip_address": "10.0.0.5", "subnet_mask": "255.255.255.0"})
+
+        interface_obj.ip_addresses.set.assert_called_once_with([])
+        interface_obj.ip_addresses.add.assert_called_once_with(new_ip)
+        self.assertEqual(result, "ok")
+
+    def test_update_primary_ipv6_saves_device(self):
+        """`ip_version == 6` -> primary_ip6 set and `device.save()` called once."""
+        diff_model, device, interface_obj = self._setup_interface_update()
+        existing_ip = mock.MagicMock()
+        existing_ip.ip_version = 6
+        interface_obj.ip_addresses.first.return_value = existing_ip
+
+        with (
+            _nb_patch("get_tagged_device", return_value=device),
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"ip_is_primary": True})
+
+        self.assertIs(device.primary_ip6, existing_ip)
+        device.save.assert_called_once()
 
 
 # ============================================================
@@ -386,60 +635,78 @@ class TestInterfaceModel(SimpleTestCase):
 # ============================================================
 
 
-class TestVlanModel(SimpleTestCase):
+class TestVlanModel(_ModelTestBase):
     """Test `Vlan.create/update/delete` branching and regression guards."""
 
-    def setUp(self):
-        self.adapter = _make_adapter()
+    def _make_vlan_diff(self, location="loc"):
+        diff_model = Vlan(name="v", vid=10, status="Active", location=location)
+        diff_model.adapter = self.adapter
+        return diff_model
 
     def test_update_writes_attrs_description_to_vlan(self):
-        """Regression: ``vlan.description = attrs['description']`` (was ``vlan.description = vlan.description``).
+        """Regression: `vlan.description = attrs['description']` (was `vlan.description = vlan.description`).
 
         Without this fix, VLAN description changes would silently no-op.
         """
-        diff_model = Vlan(name="v", vid=10, status="Active", location="loc")
-        diff_model.adapter = self.adapter
-
-        nautobot_vlan = mock.MagicMock()
-        nautobot_vlan.status = "Active"
-        nautobot_vlan.description = "old"
+        diff_model = self._make_vlan_diff()
+        nb_vlan = mock.MagicMock()
+        nb_vlan.status = "Active"
+        nb_vlan.description = "old"
 
         with (
             mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=mock.MagicMock()),
-            mock.patch.object(diffsync_models.VLAN.objects, "get", return_value=nautobot_vlan),
-            mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object"),
+            mock.patch.object(diffsync_models.VLAN.objects, "get", return_value=nb_vlan),
+            _nb_patch("tag_object"),
             mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
         ):
             result = diff_model.update({"description": "new"})
 
-        self.assertEqual(nautobot_vlan.description, "new")
+        self.assertEqual(nb_vlan.description, "new")
         self.assertEqual(result, "ok")
 
-    def test_update_returns_none_when_location_missing(self):
-        """`Location.DoesNotExist` -> error log, no VLAN lookup attempted, no super().update()."""
-        diff_model = Vlan(name="v", vid=10, status="Active", location="ghost")
-        diff_model.adapter = self.adapter
+    def _assert_vlan_update_returns_none(self, *, location_side_effect=None, vlan_side_effect=None):
+        """Shared assertion: VLAN.update bails out (returns None, super() not invoked)."""
+        diff_model = self._make_vlan_diff()
+        location_kw = (
+            {"side_effect": location_side_effect} if location_side_effect else {"return_value": mock.MagicMock()}
+        )
+        vlan_kw = {"side_effect": vlan_side_effect} if vlan_side_effect else {"return_value": mock.MagicMock()}
 
         with (
-            mock.patch.object(
-                diffsync_models.NautobotLocation.objects,
-                "get",
-                side_effect=diffsync_models.NautobotLocation.DoesNotExist,
-            ),
-            mock.patch.object(diffsync_models.VLAN.objects, "get") as mock_vlan_get,
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", **location_kw),
+            mock.patch.object(diffsync_models.VLAN.objects, "get", **vlan_kw) as mock_vlan_get,
             mock.patch.object(diffsync_models.DiffSyncModel, "update") as mock_super,
         ):
             result = diff_model.update({"description": "new"})
 
         self.assertIsNone(result)
-        mock_vlan_get.assert_not_called()
         mock_super.assert_not_called()
         self.adapter.job.logger.error.assert_called_once()
+        return mock_vlan_get
 
-    @mock.patch(
-        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_vlan",
-        return_value=None,
-    )
+    def test_update_returns_none_when_location_missing(self):
+        """`Location.DoesNotExist` -> error log, no VLAN lookup attempted, no super().update()."""
+        mock_vlan_get = self._assert_vlan_update_returns_none(
+            location_side_effect=diffsync_models.NautobotLocation.DoesNotExist
+        )
+        mock_vlan_get.assert_not_called()
+
+    def test_update_returns_none_when_location_multiple_objects(self):
+        """`Location.MultipleObjectsReturned` -> error log + return None."""
+        mock_vlan_get = self._assert_vlan_update_returns_none(
+            location_side_effect=diffsync_models.NautobotLocation.MultipleObjectsReturned
+        )
+        mock_vlan_get.assert_not_called()
+
+    def test_update_returns_none_when_vlan_multiple_objects(self):
+        """`VLAN.MultipleObjectsReturned` -> error log + return None."""
+        self._assert_vlan_update_returns_none(vlan_side_effect=diffsync_models.VLAN.MultipleObjectsReturned)
+
+    def test_update_returns_none_when_vlan_does_not_exist(self):
+        """`VLAN.DoesNotExist` -> error log + return None."""
+        self._assert_vlan_update_returns_none(vlan_side_effect=diffsync_models.VLAN.DoesNotExist)
+
+    @_nb_patch("create_vlan", return_value=None)
     def test_create_returns_none_when_helper_fails(self, _mock_create_vlan):
         """When `create_vlan` returns None, `Vlan.create` short-circuits without calling super()."""
         with (
@@ -454,3 +721,40 @@ class TestVlanModel(SimpleTestCase):
 
         self.assertIsNone(result)
         mock_super.assert_not_called()
+
+    def test_update_status_active_sets_status_and_removes_safe_tag(self):
+        """Status flip to Active rewrites VLAN status and removes safe-delete tag."""
+        diff_model = self._make_vlan_diff()
+        nb_vlan = mock.MagicMock()
+        nb_vlan.status = "Decommissioning"  # differs from "Active"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=mock.MagicMock()),
+            mock.patch.object(diffsync_models.VLAN.objects, "get", return_value=nb_vlan),
+            _nb_patch("get_or_create_status_object", return_value="active-status-obj") as mock_status,
+            _nb_patch("tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            diff_model.update({"status": "Active"})
+
+        mock_status.assert_called_once()
+        self.assertEqual(nb_vlan.status, "active-status-obj")
+        nb_vlan.tags.remove.assert_called_once_with(self.adapter.safe_delete_tag)
+
+    def test_update_returns_none_when_tag_object_fails(self):
+        """`tag_object` raises -> warning log + return None (no super().update())."""
+        diff_model = self._make_vlan_diff()
+        nb_vlan = mock.MagicMock()
+        nb_vlan.status = "Active"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=mock.MagicMock()),
+            mock.patch.object(diffsync_models.VLAN.objects, "get", return_value=nb_vlan),
+            _nb_patch("tag_object", side_effect=diffsync_models.ValidationError("tag boom")),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update") as mock_super,
+        ):
+            result = diff_model.update({"description": "new"})
+
+        self.assertIsNone(result)
+        mock_super.assert_not_called()
+        self.adapter.job.logger.warning.assert_called_once()

--- a/nautobot_ssot/tests/ipfabric/test_diffsync_models.py
+++ b/nautobot_ssot/tests/ipfabric/test_diffsync_models.py
@@ -1,0 +1,456 @@
+"""Tests for IPFabric diffsync models.
+
+Focused on the model-specific branching logic — early returns, conditional
+calls, regression guards for fixed bugs. Nautobot ORM calls and the
+`nbutils` helpers are mocked; the heavy lifting is covered by their own
+test suites.
+"""
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from nautobot_ssot.integrations.ipfabric.diffsync import diffsync_models
+from nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models import (
+    Device,
+    DiffSyncExtras,
+    Interface,
+    Location,
+    Vlan,
+)
+
+
+def _make_adapter():
+    """Minimal mock adapter sufficient for invoking model methods directly."""
+    adapter = mock.MagicMock()
+    adapter.job = mock.MagicMock()
+    adapter.job.debug = False
+    adapter.ssot_tag = mock.MagicMock(name="ssot_tag")
+    adapter.safe_delete_tag = mock.MagicMock(name="safe_delete_tag")
+    adapter.safe_delete_tag.id = "tag-uuid"
+    return adapter
+
+
+# ============================================================
+# DiffSyncExtras.safe_delete
+# ============================================================
+
+
+class TestSafeDelete(SimpleTestCase):
+    """Test `DiffSyncExtras.safe_delete` branching logic."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+        # Vlan is the smallest model; any model would work since safe_delete
+        # is defined on the shared base class.
+        self.diff_model = Vlan(name="v", vid=10, status="Active", location="loc")
+        self.diff_model.adapter = self.adapter
+
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
+    def test_safe_delete_changes_status_and_tags_when_status_differs(self, mock_status, mock_tag_object):
+        """Status differs -> status updated, tag added, tag_object called once."""
+        mock_status.return_value = "safe-deleted-status"
+        nautobot_obj = mock.MagicMock()
+        nautobot_obj.status = "active-status"
+        nautobot_obj.tags.filter.return_value.exists.return_value = False
+
+        self.diff_model.safe_delete(nautobot_obj, "Decommissioning", self.adapter.safe_delete_tag)
+
+        self.assertEqual(nautobot_obj.status, "safe-deleted-status")
+        nautobot_obj.tags.add.assert_called_once_with(self.adapter.safe_delete_tag)
+        mock_tag_object.assert_called_once()
+
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
+    def test_safe_delete_skips_when_tag_already_present_and_status_unchanged(self, mock_status, mock_tag_object):
+        """Tag already on object and status already correct -> no save, no tag_object."""
+        already_status = "safe-deleted-status"
+        mock_status.return_value = already_status
+        nautobot_obj = mock.MagicMock()
+        nautobot_obj.status = already_status  # already matches
+        nautobot_obj.tags.filter.return_value.exists.return_value = True  # tag already present
+
+        self.diff_model.safe_delete(nautobot_obj, "Decommissioning", self.adapter.safe_delete_tag)
+
+        nautobot_obj.tags.add.assert_not_called()
+        mock_tag_object.assert_not_called()
+
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object")
+    def test_safe_delete_no_tag_arg_is_a_noop_for_tagging(self, mock_tag_object):
+        """Defensive guard: when safe_delete_tag is None, tags.add is never called."""
+        nautobot_obj = mock.MagicMock(spec=["tags"])  # has tags but no status attr
+
+        self.diff_model.safe_delete(nautobot_obj, safe_delete_status=None, safe_delete_tag=None)
+
+        nautobot_obj.tags.add.assert_not_called()
+        mock_tag_object.assert_not_called()
+
+
+# ============================================================
+# Location lifecycle
+# ============================================================
+
+
+class TestLocationModel(SimpleTestCase):
+    """Test `Location.create/update/delete` branching logic."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
+        return_value=None,
+    )
+    def test_create_returns_none_when_helper_fails(self, _mock_helper):
+        """If `get_or_create_location_object` returns None, `create` returns None and does not call super()."""
+        with mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super_create:
+            result = Location.create(
+                adapter=self.adapter,
+                ids={"name": "X"},
+                attrs={"site_id": "Y", "status": "Active"},
+            )
+        self.assertIsNone(result)
+        mock_super_create.assert_not_called()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object"
+    )
+    def test_create_calls_super_when_helper_succeeds(self, mock_helper):
+        """Successful helper call leads to super().create() being invoked."""
+        mock_helper.return_value = mock.MagicMock()
+        with mock.patch.object(diffsync_models.DiffSyncModel, "create", return_value="created") as mock_super:
+            result = Location.create(
+                adapter=self.adapter,
+                ids={"name": "X"},
+                attrs={"site_id": "Y", "status": "Active"},
+            )
+        self.assertEqual(result, "created")
+        mock_super.assert_called_once()
+
+    def test_delete_returns_none_when_location_does_not_exist(self):
+        """`DoesNotExist` lookup -> logged and `super().delete()` not invoked."""
+        diff_model = Location(name="missing", site_id=None, status="Active")
+        diff_model.adapter = self.adapter
+
+        with (
+            mock.patch.object(
+                diffsync_models.NautobotLocation.objects,
+                "get",
+                side_effect=diffsync_models.NautobotLocation.DoesNotExist,
+            ),
+            mock.patch.object(diffsync_models.DiffSyncModel, "delete") as mock_super_delete,
+        ):
+            result = diff_model.delete()
+
+        self.assertIsNone(result)
+        mock_super_delete.assert_not_called()
+        self.adapter.job.logger.error.assert_called_once()
+
+
+# ============================================================
+# Device lifecycle
+# ============================================================
+
+
+class TestDeviceModel(SimpleTestCase):
+    """Test `Device.create/update` branching and regression guards."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+        self.adapter.job.debug = False
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
+        return_value=None,
+    )
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object")
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
+    )
+    @mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.DeviceType.objects.filter")
+    def test_create_short_circuits_when_location_missing(self, mock_dt_filter, mock_role, mock_status, _mock_loc):
+        """Any required helper returning None means Device.create returns None without saving."""
+        mock_dt_filter.return_value.first.return_value = mock.MagicMock()
+        mock_role.return_value = mock.MagicMock()
+        mock_status.return_value = mock.MagicMock()
+
+        with mock.patch.object(diffsync_models.NautobotDevice.objects, "get_or_create") as mock_get_or_create:
+            result = Device.create(
+                adapter=self.adapter,
+                ids={"name": "d1"},
+                attrs={"model": "m", "vendor": "v", "location_name": "loc"},
+            )
+
+        self.assertIsNone(result)
+        mock_get_or_create.assert_not_called()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
+    )
+    def test_create_skips_role_cf_save_when_value_already_matches(self, mock_role_helper):
+        """Regression: Role.validated_save() must not run when cf['ipfabric_type'] already matches role_name."""
+        role_obj = mock.MagicMock()
+        role_obj.cf.get.return_value = "DesiredRole"  # already matches
+        mock_role_helper.return_value = role_obj
+
+        # Force the rest of the create() to bail before super() by making location lookup fail
+        with (
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
+                return_value=None,
+            ),
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object"
+            ),
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
+        ):
+            Device.create(
+                adapter=self.adapter,
+                ids={"name": "d1"},
+                attrs={"model": "m", "vendor": "v", "role": "DesiredRole", "location_name": "loc"},
+            )
+
+        role_obj.validated_save.assert_not_called()
+        # cf was never written either
+        role_obj.cf.__setitem__.assert_not_called()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_device_role_object"
+    )
+    def test_create_writes_and_saves_role_cf_when_value_differs(self, mock_role_helper):
+        """When cf['ipfabric_type'] does not match, set it and run validated_save() exactly once."""
+        role_obj = mock.MagicMock()
+        role_obj.cf.get.return_value = "OldRole"  # differs from DesiredRole
+        mock_role_helper.return_value = role_obj
+
+        with (
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_location_object",
+                return_value=None,
+            ),
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_status_object"
+            ),
+            mock.patch.object(diffsync_models.DeviceType.objects, "filter"),
+        ):
+            Device.create(
+                adapter=self.adapter,
+                ids={"name": "d1"},
+                attrs={"model": "m", "vendor": "v", "role": "DesiredRole", "location_name": "loc"},
+            )
+
+        role_obj.cf.__setitem__.assert_called_once_with("ipfabric_type", "DesiredRole")
+        role_obj.validated_save.assert_called_once()
+
+    def test_update_detects_vc_attrs_present_for_non_name_keys(self):
+        """Regression: ``vc_attrs_present`` must be True if any VC-prefixed key is in attrs.
+
+        The previous implementation used ``vc_name or vc_master or vc_position or vc_priority`` and
+        could miss legitimate ``vc_master=False`` or zero-valued updates. Now membership is checked
+        via ``any(k in attrs for k in (...))``.
+        """
+        diff_model = Device(name="d", location_name="loc", vc_name="stack-A")
+        diff_model.adapter = self.adapter
+
+        _device = mock.MagicMock()
+        _device.status.name = "Active"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotDevice.objects, "get", return_value=_device),
+            mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object"),
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_or_create_virtual_chassis_object"
+            ) as mock_get_vc,
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.assign_device_to_virtual_chassis"
+            ) as mock_assign,
+            mock.patch.object(diffsync_models.DiffSyncModel, "update"),
+        ):
+            mock_get_vc.return_value = mock.MagicMock()
+            # vc_position alone in attrs (no vc_name) should still trigger the VC code path
+            diff_model.update({"vc_position": 3})
+
+        mock_get_vc.assert_called_once_with("stack-A", logger=self.adapter.job.logger)
+        mock_assign.assert_called_once()
+
+
+# ============================================================
+# Interface lifecycle
+# ============================================================
+
+
+class TestInterfaceModel(SimpleTestCase):
+    """Test `Interface.create/update/delete` branching and regression guards."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
+        return_value=None,
+    )
+    def test_create_warns_when_tagged_device_not_found(self, _mock_get_device):
+        """Missing parent device -> warning logged, no super().create()."""
+        with mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super:
+            result = Interface.create(
+                adapter=self.adapter,
+                ids={"name": "eth0", "device_name": "nope"},
+                attrs={
+                    "ip_address": None,
+                    "subnet_mask": None,
+                    "status": "Active",
+                },
+            )
+        self.assertIsNone(result)
+        mock_super.assert_not_called()
+        self.adapter.job.logger.warning.assert_called_once()
+
+    def test_create_primary_ipv4_saves_device_only_once(self):
+        """Regression: ip_version dispatch uses ``if/elif`` so device.save() is called exactly once."""
+        device_obj = mock.MagicMock()
+        interface_obj = mock.MagicMock()
+        ip_obj = mock.MagicMock()
+        ip_obj.ip_version = 4
+
+        with (
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
+                return_value=device_obj,
+            ),
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_interface",
+                return_value=interface_obj,
+            ),
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_ip",
+                return_value=ip_obj,
+            ),
+            mock.patch.object(diffsync_models.DiffSyncModel, "create"),
+        ):
+            Interface.create(
+                adapter=self.adapter,
+                ids={"name": "eth0", "device_name": "d1"},
+                attrs={
+                    "ip_address": "10.0.0.1",
+                    "subnet_mask": "255.255.255.0",
+                    "ip_is_primary": True,
+                    "status": "Active",
+                },
+            )
+
+        # IPv4 path sets primary_ip4 and saves once; primary_ip6 should not be touched.
+        self.assertIs(device_obj.primary_ip4, ip_obj)
+        device_obj.save.assert_called_once()
+
+    def test_delete_only_safe_deletes_unshared_ips(self):
+        """Regression: when an IP is also on another interface, the IP must not be safe-deleted."""
+        adapter = self.adapter
+        # Build the interface returned from the prefetch chain.
+        shared_ip = mock.MagicMock(name="shared_ip")
+        shared_ip.interfaces.exclude.return_value.exists.return_value = True  # on another interface
+
+        exclusive_ip = mock.MagicMock(name="exclusive_ip")
+        exclusive_ip.interfaces.exclude.return_value.exists.return_value = False  # only this interface
+
+        interface_obj = mock.MagicMock()
+        interface_obj.id = "iface-uuid"
+        interface_obj.ip_addresses.all.return_value = [shared_ip, exclusive_ip]
+
+        device = mock.MagicMock()
+        device.interfaces.prefetch_related.return_value.get.return_value = interface_obj
+
+        diff_model = Interface(name="eth0", device_name="d1", status="Active")
+        diff_model.adapter = adapter
+
+        with (
+            mock.patch(
+                "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.get_tagged_device",
+                return_value=device,
+            ),
+            mock.patch.object(DiffSyncExtras, "safe_delete") as mock_safe_delete,
+            mock.patch.object(diffsync_models.DiffSyncModel, "delete"),
+        ):
+            diff_model.delete()
+
+        # safe_delete called exactly twice: once for exclusive_ip, once for the interface itself.
+        # NEVER called for shared_ip.
+        safe_delete_targets = [call.args[0] for call in mock_safe_delete.call_args_list]
+        self.assertIn(exclusive_ip, safe_delete_targets)
+        self.assertIn(interface_obj, safe_delete_targets)
+        self.assertNotIn(shared_ip, safe_delete_targets)
+
+
+# ============================================================
+# Vlan lifecycle
+# ============================================================
+
+
+class TestVlanModel(SimpleTestCase):
+    """Test `Vlan.create/update/delete` branching and regression guards."""
+
+    def setUp(self):
+        self.adapter = _make_adapter()
+
+    def test_update_writes_attrs_description_to_vlan(self):
+        """Regression: ``vlan.description = attrs['description']`` (was ``vlan.description = vlan.description``).
+
+        Without this fix, VLAN description changes would silently no-op.
+        """
+        diff_model = Vlan(name="v", vid=10, status="Active", location="loc")
+        diff_model.adapter = self.adapter
+
+        nautobot_vlan = mock.MagicMock()
+        nautobot_vlan.status = "Active"
+        nautobot_vlan.description = "old"
+
+        with (
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=mock.MagicMock()),
+            mock.patch.object(diffsync_models.VLAN.objects, "get", return_value=nautobot_vlan),
+            mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.tag_object"),
+            mock.patch.object(diffsync_models.DiffSyncModel, "update", return_value="ok"),
+        ):
+            result = diff_model.update({"description": "new"})
+
+        self.assertEqual(nautobot_vlan.description, "new")
+        self.assertEqual(result, "ok")
+
+    def test_update_returns_none_when_location_missing(self):
+        """`Location.DoesNotExist` -> error log, no VLAN lookup attempted, no super().update()."""
+        diff_model = Vlan(name="v", vid=10, status="Active", location="ghost")
+        diff_model.adapter = self.adapter
+
+        with (
+            mock.patch.object(
+                diffsync_models.NautobotLocation.objects,
+                "get",
+                side_effect=diffsync_models.NautobotLocation.DoesNotExist,
+            ),
+            mock.patch.object(diffsync_models.VLAN.objects, "get") as mock_vlan_get,
+            mock.patch.object(diffsync_models.DiffSyncModel, "update") as mock_super,
+        ):
+            result = diff_model.update({"description": "new"})
+
+        self.assertIsNone(result)
+        mock_vlan_get.assert_not_called()
+        mock_super.assert_not_called()
+        self.adapter.job.logger.error.assert_called_once()
+
+    @mock.patch(
+        "nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.tonb_nbutils.create_vlan",
+        return_value=None,
+    )
+    def test_create_returns_none_when_helper_fails(self, _mock_create_vlan):
+        """When `create_vlan` returns None, `Vlan.create` short-circuits without calling super()."""
+        with (
+            mock.patch.object(diffsync_models.NautobotLocation.objects, "get", return_value=mock.MagicMock()),
+            mock.patch.object(diffsync_models.DiffSyncModel, "create") as mock_super,
+        ):
+            result = Vlan.create(
+                adapter=self.adapter,
+                ids={"name": "v", "location": "loc"},
+                attrs={"vid": 10, "status": "Active", "description": "d"},
+            )
+
+        self.assertIsNone(result)
+        mock_super.assert_not_called()

--- a/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
@@ -60,9 +60,15 @@ class IPFabricDiffSyncTestCase(TestCase):
             {dev.get_unique_id() for dev in self.ipfabric.get_all("device") if dev.location_name != "stack"},
         )
         self.assertEqual(
-            {f"{vlan['vlanName']}__{vlan['siteName']}" for vlan in VLAN_FIXTURE},
+            {f"{vlan['vlanName']}__{vlan['siteName']}" for vlan in VLAN_FIXTURE if "badvlan" not in vlan["vlanName"]},
             {vlan.get_unique_id() for vlan in self.ipfabric.get_all("vlan")},
         )
+
+        # Assert invalid VLANs were not loaded
+        all_vlans = {vlan.get_unique_id() for vlan in self.ipfabric.get_all("vlan")}
+        self.assertEqual(len(all_vlans), 13)
+        self.assertNotIn("badvlan0001__JCY-SPINE-01.INFRA.NTC.COM_1", all_vlans)
+        self.assertNotIn("badvlan0002__JCY-SPINE-01.INFRA.NTC.COM_1", all_vlans)
 
         # Assert each site has a device tied to it.
         for site in self.ipfabric.get_all("location"):

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -16,6 +16,7 @@ from nautobot.dcim.models import (
     VirtualChassis,
 )
 from nautobot.extras.models import Role, Status, Tag
+from nautobot.ipam.models import IPAddress, Prefix, get_default_namespace
 
 try:
     from nautobot.core.testing.utils import AssertNoRepeatedQueries
@@ -30,7 +31,7 @@ class TestNautobotAdapter(TestCase):
 
     def setUp(self):
         device_ct = ContentType.objects.get_for_model(Device)
-        active_status = Status.objects.get(name="Active")
+        self.active_status = Status.objects.get(name="Active")
         self.ssot_tag, _ = Tag.objects.get_or_create(
             name="SSoT Synced from IPFabric",
             defaults={
@@ -43,9 +44,9 @@ class TestNautobotAdapter(TestCase):
         role.content_types.add(device_ct)
         site_lt, _ = LocationType.objects.get_or_create(name="site")
         site_lt.content_types.add(device_ct)
-        self.site1 = Location.objects.create(name="site1", location_type=site_lt, status=active_status)
-        site2 = Location.objects.create(name="site2", location_type=site_lt, status=active_status)
-        self.stack_site = Location.objects.create(name="stack", location_type=site_lt, status=active_status)
+        self.site1 = Location.objects.create(name="site1", location_type=site_lt, status=self.active_status)
+        site2 = Location.objects.create(name="site2", location_type=site_lt, status=self.active_status)
+        self.stack_site = Location.objects.create(name="stack", location_type=site_lt, status=self.active_status)
         self.stack_site.tags.add(self.ssot_tag)
         man1 = Manufacturer.objects.create(name="man1")
         man2 = Manufacturer.objects.create(name="man2")
@@ -56,7 +57,7 @@ class TestNautobotAdapter(TestCase):
         Device.objects.create(
             name="dev1",
             serial="abc",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=self.site1,
             device_type=dev_type1,
@@ -65,7 +66,7 @@ class TestNautobotAdapter(TestCase):
         Device.objects.create(
             name="dev2",
             serial="def",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=self.site1,
             device_type=dev_type1,
@@ -74,7 +75,7 @@ class TestNautobotAdapter(TestCase):
         Device.objects.create(
             name="dev3",
             serial="xyz",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=site2,
             device_type=dev_type2,
@@ -82,7 +83,7 @@ class TestNautobotAdapter(TestCase):
         stack_master = Device.objects.create(
             name="stack1",
             serial="st123",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=self.stack_site,
             device_type=dev_type2,
@@ -93,11 +94,11 @@ class TestNautobotAdapter(TestCase):
         self.stack.master = stack_master
         self.stack.validated_save()
         for i in range(0, 9):
-            Interface.objects.create(name=f"eth{i}", device=stack_master, type="virtual", status=active_status)
+            Interface.objects.create(name=f"eth{i}", device=stack_master, type="virtual", status=self.active_status)
         Device.objects.create(
             name="stack2",
             serial="st456",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=self.stack_site,
             device_type=dev_type2,
@@ -108,7 +109,7 @@ class TestNautobotAdapter(TestCase):
         Device.objects.create(
             name="stack3",
             serial="st789",
-            status=active_status,
+            status=self.active_status,
             role=role,
             location=self.stack_site,
             device_type=dev_type2,
@@ -223,3 +224,29 @@ class TestNautobotAdapter(TestCase):
             any("is not tagged" in line for line in captured.output),
             f"Expected 'is not tagged' warning, got: {captured.output}",
         )
+
+    def test_load_interfaces_populates_ip_data(self):
+        """`load_interfaces` reads the first prefetched IP and sets ip_address/subnet_mask/ip_is_primary."""
+        stack_master = self.stack.master
+        int_eth0 = stack_master.interfaces.get(name="eth0")
+
+        prefix, _ = Prefix.objects.get_or_create(
+            prefix="10.0.0.0/24", namespace=get_default_namespace(), status=self.active_status
+        )
+        ip_addr, _ = IPAddress.objects.get_or_create(address="10.0.0.5/24", status=self.active_status, parent=prefix)
+        int_eth0.ip_addresses.add(ip_addr)
+        stack_master.primary_ip4 = ip_addr
+        stack_master.validated_save()
+        stack_master.refresh_from_db()
+
+        self.nb_adapter.load_interfaces(device_record=stack_master, diffsync_device=unittest.mock.Mock())
+
+        loaded = {i.name: i for i in self.nb_adapter.get_all("interface")}
+        # eth0 hits the `if ip_addresses:` branch (line 114)
+        self.assertEqual(loaded["eth0"].ip_address, "10.0.0.5")
+        self.assertEqual(loaded["eth0"].subnet_mask, "255.255.255.0")
+        self.assertTrue(loaded["eth0"].ip_is_primary)
+        # eth1..eth8 hit the `else` branch
+        self.assertIsNone(loaded["eth1"].ip_address)
+        self.assertIsNone(loaded["eth1"].subnet_mask)
+        self.assertFalse(loaded["eth1"].ip_is_primary)

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -3,10 +3,12 @@
 import unittest
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.core.choices import ColorChoices
+from nautobot.core.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,
+    Interface,
     Location,
     LocationType,
     Manufacturer,
@@ -15,6 +17,12 @@ from nautobot.dcim.models import (
 )
 from nautobot.extras.models import Role, Status
 
+try:
+    from nautobot.core.testing.utils import AssertNoRepeatedQueries
+except ImportError:
+    AssertNoRepeatedQueries = None
+
+import nautobot_ssot.integrations.ipfabric.utilities.nbutils as tonb_utils
 from nautobot_ssot.integrations.ipfabric.diffsync.adapter_nautobot import NautobotDiffSync
 
 
@@ -22,6 +30,13 @@ class TestNautobotAdapter(TestCase):
     """Test cases for InfoBlox Nautobot adapter."""
 
     def setUp(self):
+        self.ssot_tag = tonb_utils.get_or_create_tag_object(
+            tag_name="SSoT Synced from IPFabric",
+            tag_color=ColorChoices.COLOR_LIGHT_GREEN,
+            description="Object synced at some point from IPFabric to Nautobot",
+            app_label="dcim",
+            model="device",
+        )
         device_ct = ContentType.objects.get_for_model(Device)
         active_status = Status.objects.get(name="Active")
         role = Role.objects.create(name="test")
@@ -31,6 +46,7 @@ class TestNautobotAdapter(TestCase):
         self.site1 = Location.objects.create(name="site1", location_type=site_lt, status=active_status)
         site2 = Location.objects.create(name="site2", location_type=site_lt, status=active_status)
         self.stack_site = Location.objects.create(name="stack", location_type=site_lt, status=active_status)
+        self.stack_site.tags.add(self.ssot_tag)
         man1 = Manufacturer.objects.create(name="man1")
         man2 = Manufacturer.objects.create(name="man2")
         dev_type1 = DeviceType.objects.create(model="dev_type1", manufacturer=man1)
@@ -76,6 +92,8 @@ class TestNautobotAdapter(TestCase):
         )
         self.stack.master = stack_master
         self.stack.validated_save()
+        for i in range(0, 9):
+            Interface.objects.create(name=f"eth{i}", device=stack_master, type="virtual", status=active_status)
         Device.objects.create(
             name="stack2",
             serial="st456",
@@ -146,3 +164,35 @@ class TestNautobotAdapter(TestCase):
             self.assertEqual(device.status, "Active")
             self.assertEqual(device.vc_priority, int(device.name[-1]))
             self.assertEqual(device.vc_position, int(device.name[-1]))
+
+    @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
+    def test_load_data_no_n_plus_one(self):
+        """Full `load_data()` must not produce repeated queries over the number of devices."""
+        with AssertNoRepeatedQueries(self, threshold=3):
+            self.nb_adapter.load_data()
+
+    @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
+    def test_get_initial_location_no_n_plus_one_status(self):
+        """Iterating locations to read `.status.name` must use select_related, not lazy load."""
+        with AssertNoRepeatedQueries(self, threshold=1):
+            locations = self.nb_adapter.get_initial_location(None)
+            for location in locations:
+                _ = location.status.name  # forces the lazy access path
+            self.assertEqual(len(locations), 3, "Should get 3 Locations with no SSoT tag filter.")
+
+    @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
+    def test_get_initial_location_tagged_no_n_plus_one_status(self):
+        """Iterating locations to read `.status.name` must use select_related, not lazy load."""
+        with AssertNoRepeatedQueries(self, threshold=1):
+            self.nb_adapter.sync_ipfabric_tagged_only = True
+            locations = self.nb_adapter.get_initial_location(self.ssot_tag)
+            for location in locations:
+                _ = location.status.name  # forces the lazy access path
+            self.assertEqual(len(locations), 1, "Should get 1 Locations with SSoT tag filter.")
+
+    @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.diffsync.diffsync_models.Location", autospec=True)
+    def test_load_device_no_n_plus_one(self, mock_location):
+        """Device loading with N stack members should not issue per-member or per-interface queries."""
+        with AssertNoRepeatedQueries(self, threshold=1):
+            self.nb_adapter.load_device(Device.objects.filter(location=self.stack_site), mock_location)

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -177,7 +177,7 @@ class TestNautobotAdapter(TestCase):
         with AssertNoRepeatedQueries(self, threshold=1):
             locations = self.nb_adapter.get_initial_location(None)
             for location in locations:
-                _ = location.status.name  # forces the lazy access path
+                _ = location.status.name
             self.assertEqual(len(locations), 3, "Should get 3 Locations with no SSoT tag filter.")
 
     @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
@@ -187,7 +187,7 @@ class TestNautobotAdapter(TestCase):
             self.nb_adapter.sync_ipfabric_tagged_only = True
             locations = self.nb_adapter.get_initial_location(self.ssot_tag)
             for location in locations:
-                _ = location.status.name  # forces the lazy access path
+                _ = location.status.name
             self.assertEqual(len(locations), 1, "Should get 1 Locations with SSoT tag filter.")
 
     @unittest.skipIf(AssertNoRepeatedQueries is None, "Requires Nautobot 3.1+ (AssertNoRepeatedQueries)")
@@ -196,3 +196,30 @@ class TestNautobotAdapter(TestCase):
         """Device loading with N stack members should not issue per-member or per-interface queries."""
         with AssertNoRepeatedQueries(self, threshold=1):
             self.nb_adapter.load_device(Device.objects.filter(location=self.stack_site), mock_location)
+
+    def test_get_initial_location_filter_only(self):
+        """`location_filter` without tagged_only returns the named location."""
+        self.nb_adapter.location_filter = self.site1
+        locations = list(self.nb_adapter.get_initial_location(self.ssot_tag))
+        self.assertEqual(len(locations), 1)
+        self.assertEqual(locations[0].id, self.site1.id)
+
+    def test_get_initial_location_tagged_and_filter_match(self):
+        """`location_filter` with `sync_ipfabric_tagged_only` returns the tagged location."""
+        self.nb_adapter.sync_ipfabric_tagged_only = True
+        self.nb_adapter.location_filter = self.stack_site
+        locations = list(self.nb_adapter.get_initial_location(self.ssot_tag))
+        self.assertEqual(len(locations), 1)
+        self.assertEqual(locations[0].id, self.stack_site.id)
+
+    def test_get_initial_location_tagged_and_filter_no_match_warns(self):
+        """Untagged `location_filter` with `sync_ipfabric_tagged_only` returns empty + warning."""
+        self.nb_adapter.sync_ipfabric_tagged_only = True
+        self.nb_adapter.location_filter = self.site1
+        with self.assertLogs("nautobot.ssot.ipfabric", level="WARNING") as captured:
+            locations = list(self.nb_adapter.get_initial_location(self.ssot_tag))
+        self.assertEqual(len(locations), 0)
+        self.assertTrue(
+            any("is not tagged" in line for line in captured.output),
+            f"Expected 'is not tagged' warning, got: {captured.output}",
+        )

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -15,14 +15,13 @@ from nautobot.dcim.models import (
     Platform,
     VirtualChassis,
 )
-from nautobot.extras.models import Role, Status
+from nautobot.extras.models import Role, Status, Tag
 
 try:
     from nautobot.core.testing.utils import AssertNoRepeatedQueries
 except ImportError:
     AssertNoRepeatedQueries = None
 
-import nautobot_ssot.integrations.ipfabric.utilities.nbutils as tonb_utils
 from nautobot_ssot.integrations.ipfabric.diffsync.adapter_nautobot import NautobotDiffSync
 
 
@@ -30,15 +29,16 @@ class TestNautobotAdapter(TestCase):
     """Test cases for InfoBlox Nautobot adapter."""
 
     def setUp(self):
-        self.ssot_tag = tonb_utils.get_or_create_tag_object(
-            tag_name="SSoT Synced from IPFabric",
-            tag_color=ColorChoices.COLOR_LIGHT_GREEN,
-            description="Object synced at some point from IPFabric to Nautobot",
-            app_label="dcim",
-            model="device",
-        )
         device_ct = ContentType.objects.get_for_model(Device)
         active_status = Status.objects.get(name="Active")
+        self.ssot_tag, _ = Tag.objects.get_or_create(
+            name="SSoT Synced from IPFabric",
+            defaults={
+                "color": ColorChoices.COLOR_LIGHT_GREEN,
+                "description": "Object synced at some point from IPFabric to Nautobot",
+            },
+        )
+        self.ssot_tag.content_types.add(device_ct)
         role = Role.objects.create(name="test")
         role.content_types.add(device_ct)
         site_lt, _ = LocationType.objects.get_or_create(name="site")

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -1493,41 +1493,11 @@ class TestNautobotUtils(TestCase):
         self.assertEqual(result.name, "TagV-VLAN")
         self.assertTrue(logger.warning.called)
 
-    # ===== create_interface error/tag/status paths =====
+    # ===== create_interface error/tag paths =====
 
-    @unittest.mock.patch(
-        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
-    )
     @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_interface_status_multiple_returned(self, mock_logger, mock_status):
-        """Test `create_interface` Status.MultipleObjectsReturned path."""
-        mock_status.return_value.get.side_effect = [Status.MultipleObjectsReturned]
-        logger = mock_logger("nb_job")
-        result = create_interface(self.device, {"name": "StatMulti-Iface"}, logger=logger)
-        self.assertIsNone(result)
-        self.assertTrue(logger.error.called)
-        self.assertIn("Multiple Statuses returned with name Active", logger.error.call_args[0][0])
-
-    @unittest.mock.patch(
-        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
-    )
-    @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_interface_status_does_not_exist(self, mock_logger, mock_status):
-        """Test `create_interface` Status.DoesNotExist path."""
-        mock_status.return_value.get.side_effect = [Status.DoesNotExist]
-        logger = mock_logger("nb_job")
-        result = create_interface(self.device, {"name": "StatDNE-Iface"}, logger=logger)
-        self.assertIsNone(result)
-        self.assertTrue(logger.error.called)
-        self.assertIn("Unable to find a Status with the name Active", logger.error.call_args[0][0])
-
-    @unittest.mock.patch(
-        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
-    )
-    @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_interface_multiple_returned(self, mock_logger, mock_status):
+    def test_create_interface_multiple_returned(self, mock_logger):
         """Test `create_interface` Interface.MultipleObjectsReturned path."""
-        mock_status.return_value.get.return_value = "mock_status"
         logger = mock_logger("nb_job")
         mock_device = mock.MagicMock()
         mock_device.name = "Mock-Device"
@@ -1538,13 +1508,9 @@ class TestNautobotUtils(TestCase):
             "Multiple Interfaces returned with name Multi-Iface on Device named Mock-Device"
         )
 
-    @unittest.mock.patch(
-        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
-    )
     @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_interface_db_error(self, mock_logger, mock_status):
+    def test_create_interface_db_error(self, mock_logger):
         """Test `create_interface` DjangoBaseDBError on get_or_create path."""
-        mock_status.return_value.get.return_value = "mock_status"
         logger = mock_logger("nb_job")
         mock_device = mock.MagicMock()
         mock_device.name = "Mock-Device"
@@ -1553,13 +1519,9 @@ class TestNautobotUtils(TestCase):
         self.assertIsNone(result)
         logger.error.assert_called_with("Unable to create a new Interface named DB-Iface on Device named Mock-Device")
 
-    @unittest.mock.patch(
-        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
-    )
     @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_interface_validation_error(self, mock_logger, mock_status):
+    def test_create_interface_validation_error(self, mock_logger):
         """Test `create_interface` ValidationError on get_or_create path."""
-        mock_status.return_value.get.return_value = "mock_status"
         logger = mock_logger("nb_job")
         mock_device = mock.MagicMock()
         mock_device.name = "Mock-Device"

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -1211,6 +1211,18 @@ class TestNautobotUtils(TestCase):
         self.assertIsNone(result)
         self.assertTrue(logger.error.called)
 
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Tag.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_tag_object_multiple_returned(self, mock_logger, mock_tag):
+        """Test `get_or_create_tag_object` MultipleObjectsReturned path (nbutils.py lines 373-376)."""
+        mock_tag.side_effect = [Tag.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = get_or_create_tag_object(tag_name="Multi-Tag", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple Tags returned with the name Multi-Tag")
+
     # ===== get_or_create_virtual_chassis_object =====
 
     def test_get_or_create_virtual_chassis_object_existing(self):

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -1542,6 +1542,23 @@ class TestNautobotUtils(TestCase):
         self.assertIsNone(result)
         logger.error.assert_called_with("Unable to create a new Interface named V-Iface on Device named Mock-Device")
 
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.get_or_create_status_object",
+        return_value=None,
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_status_helper_returns_none(self, mock_logger, _mock_status_helper):
+        """Test `create_interface` returns None and logs when status helper returns None (nbutils.py line 545)."""
+        logger = mock_logger("nb_job")
+        mock_device = mock.MagicMock()
+        mock_device.name = "Mock-Device"
+        result = create_interface(mock_device, {"name": "NoStat-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        mock_device.interfaces.get_or_create.assert_not_called()
+        logger.error.assert_called_with(
+            "Unable to set Status of Active for Interface named NoStat-Iface on Device named Mock-Device"
+        )
+
     @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
     @unittest.mock.patch("logging.Logger", autospec=True)
     def test_create_interface_tag_db_error(self, mock_logger, mock_tag):

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -1,20 +1,24 @@
+# pylint: disable=too-many-lines
 """Test Nautobot Utilities."""
 
 import ipaddress
 import unittest
+from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import Error as DjangoBaseDBError
 from django.test import TestCase
 from nautobot.core.choices import ColorChoices
-from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer, Platform
+from nautobot.dcim.models import DeviceType, Interface, Location, LocationType, Manufacturer, Platform, VirtualChassis
 from nautobot.dcim.models.devices import Device
-from nautobot.extras.models import Role
+from nautobot.extras.models import Role, Tag
 from nautobot.extras.models.statuses import Status
 from nautobot.ipam.models import VLAN, IPAddress, Prefix, get_default_namespace
 
+from nautobot_ssot.integrations.ipfabric.constants import LAST_SYNCHRONIZED_CF_NAME
 from nautobot_ssot.integrations.ipfabric.utilities import (
+    assign_device_to_virtual_chassis,
     create_interface,
     create_ip,
     create_vlan,
@@ -24,7 +28,11 @@ from nautobot_ssot.integrations.ipfabric.utilities import (
     get_or_create_manufacturer_object,
     get_or_create_platform_object,
     get_or_create_status_object,
+    get_or_create_tag_object,
+    get_or_create_virtual_chassis_object,
+    get_tagged_device,
 )
+from nautobot_ssot.integrations.ipfabric.utilities.nbutils import tag_object
 from nautobot_ssot.integrations.ipfabric.utilities.utils import job_scoped_cache
 
 
@@ -36,7 +44,11 @@ class TestNautobotUtils(TestCase):
         """Setup."""
         job_scoped_cache.clear_all()
         site_location_type = LocationType.objects.update_or_create(name="Site")[0]
-        site_location_type.content_types.set([ContentType.objects.get_for_model(VLAN)])
+        locaiton_cts = [
+            ContentType.objects.get_for_model(VLAN),
+            ContentType.objects.get_for_model(Device),
+        ]
+        site_location_type.content_types.set(locaiton_cts)
         self.location = Location.objects.create(
             name="Test-Location",
             status=Status.objects.get(name="Active"),
@@ -923,3 +935,618 @@ class TestNautobotUtils(TestCase):
         test_interface = create_interface(self.device, interface_details)
         self.assertEqual(test_interface.id, self.device.interfaces.get(name="Test-Interface-New").id)
         self.assertEqual(test_interface.mtu, 1500)
+
+    # ===== get_or_create_manufacturer_object error/tag paths =====
+
+    def test_get_or_create_manufacturer_object_new(self):
+        """Test creating a new Manufacturer."""
+        self.assertFalse(Manufacturer.objects.filter(name="New-Manufacturer").exists())
+        result = get_or_create_manufacturer_object(vendor_name="New-Manufacturer")
+        self.assertEqual(result.name, "New-Manufacturer")
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Manufacturer.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_manufacturer_object_multiple_returned(self, mock_logger, mock_mfg):
+        """Test `get_or_create_manufacturer_object` MultipleObjectsReturned path."""
+        mock_mfg.side_effect = [Manufacturer.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = get_or_create_manufacturer_object(vendor_name="X-Mfg", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple Manufacturers returned with name X-Mfg")
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Manufacturer.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_manufacturer_object_db_error(self, mock_logger, mock_mfg):
+        """Test `get_or_create_manufacturer_object` DjangoBaseDBError path."""
+        mock_mfg.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_manufacturer_object(vendor_name="X-Mfg", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Manufacturer named X-Mfg")
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Manufacturer.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_manufacturer_object_validation_error(self, mock_logger, mock_mfg):
+        """Test `get_or_create_manufacturer_object` ValidationError path."""
+        mock_mfg.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_manufacturer_object(vendor_name="X-Mfg", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Manufacturer named X-Mfg")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_manufacturer_object_tag_db_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_manufacturer_object` tag_object DjangoBaseDBError path."""
+        mock_tag.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_manufacturer_object(vendor_name="Tag-DB-Mfg", logger=logger)
+        self.assertEqual(result.name, "Tag-DB-Mfg")
+        logger.warning.assert_called_with(
+            f"Unable to perform a validated_save() on Manufacturer Tag-DB-Mfg with an ID of {result.id}"
+        )
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_manufacturer_object_tag_validation_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_manufacturer_object` tag_object ValidationError path."""
+        mock_tag.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_manufacturer_object(vendor_name="Tag-V-Mfg", logger=logger)
+        self.assertEqual(result.name, "Tag-V-Mfg")
+        logger.warning.assert_called_with(
+            f"Unable to perform a validated_save() on Manufacturer Tag-V-Mfg with an ID of {result.id}"
+        )
+
+    # ===== get_or_create_device_role_object error/tag paths =====
+
+    def test_get_or_create_device_role_object_new(self):
+        """Test creating a new Role with cf and content_type."""
+        self.assertFalse(Role.objects.filter(name="New-Role").exists())
+        result = get_or_create_device_role_object(role_name="New-Role", role_color=ColorChoices.COLOR_BLUE)
+        self.assertEqual(result.name, "New-Role")
+        self.assertEqual(result.cf.get("ipfabric_type"), "New-Role")
+        self.assertIn(self.content_type, result.content_types.all())
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Role.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_device_role_object_db_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_device_role_object` DjangoBaseDBError on create path."""
+        mock_create.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_device_role_object(role_name="DB-Role", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Role named DB-Role")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Role.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_device_role_object_validation_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_device_role_object` ValidationError on create path."""
+        mock_create.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_device_role_object(role_name="V-Role", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Role named V-Role")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Role.objects.get", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_device_role_object_multiple_returned(self, mock_logger, mock_get):
+        """Test `get_or_create_device_role_object` MultipleObjectsReturned path."""
+        mock_get.side_effect = [Role.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = get_or_create_device_role_object(role_name="Multi-Role", logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple Roles returned with the name Multi-Role")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_device_role_object_tag_db_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_device_role_object` tag_object DjangoBaseDBError path."""
+        mock_tag.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_device_role_object(role_name="TagDB-Role", logger=logger)
+        self.assertEqual(result.name, "TagDB-Role")
+        logger.warning.assert_called_with(
+            f"Unable to perform validated_save() on Role TagDB-Role with an ID of {result.id}"
+        )
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_device_role_object_tag_validation_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_device_role_object` tag_object ValidationError path."""
+        mock_tag.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_device_role_object(role_name="TagV-Role", logger=logger)
+        self.assertEqual(result.name, "TagV-Role")
+        logger.warning.assert_called_with(
+            f"Unable to perform validated_save() on Role TagV-Role with an ID of {result.id}"
+        )
+
+    # ===== get_or_create_status_object error paths =====
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_status_object_db_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_status_object` DjangoBaseDBError on create path."""
+        mock_create.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_status_object(
+            status_name="DB-Status", status_color=ColorChoices.COLOR_AMBER, logger=logger
+        )
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Status named DB-Status")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_status_object_validation_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_status_object` ValidationError on create path."""
+        mock_create.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_status_object(
+            status_name="V-Status", status_color=ColorChoices.COLOR_AMBER, logger=logger
+        )
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Status named V-Status")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_status_object_multiple_returned(self, mock_logger, mock_get):
+        """Test `get_or_create_status_object` MultipleObjectsReturned path."""
+        mock_get.side_effect = [Status.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = get_or_create_status_object(
+            status_name="Multi-Status", status_color=ColorChoices.COLOR_AMBER, logger=logger
+        )
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple Statuses returned with the name Multi-Status")
+
+    # ===== get_or_create_platform_object error paths =====
+
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_no_manufacturer(self, mock_logger):
+        """Test `get_or_create_platform_object` returns None when manufacturer is None."""
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(platform="ios", manufacturer_obj=None, logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create Platform ios because Manufacturer is None")
+
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_manufacturer_mismatch(self, mock_logger):
+        """Test `get_or_create_platform_object` returns None when Platform belongs to a different Manufacturer."""
+        other_mfg = Manufacturer.objects.create(name="Other-Mfg")
+        Platform.objects.create(name="shared-platform", manufacturer=self.manufacturer)
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(platform="shared-platform", manufacturer_obj=other_mfg, logger=logger)
+        self.assertIsNone(result)
+        logger.warning.assert_called_with(
+            f"Platform shared-platform already exists but belongs to Manufacturer {self.manufacturer}, "
+            f"not {other_mfg}. Skipping assignment to avoid validation errors."
+        )
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Platform.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_db_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_platform_object` DjangoBaseDBError on create path."""
+        mock_create.side_effect = [DjangoBaseDBError("err")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(platform="db-fail", manufacturer_obj=self.manufacturer, logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+        self.assertIn("Unable to create a new Platform named db-fail", logger.error.call_args[0][0])
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Platform.objects.create", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_validation_error_on_create(self, mock_logger, mock_create):
+        """Test `get_or_create_platform_object` ValidationError on create path."""
+        mock_create.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(platform="v-fail", manufacturer_obj=self.manufacturer, logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Platform.objects.get", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_multiple_returned(self, mock_logger, mock_get):
+        """Test `get_or_create_platform_object` MultipleObjectsReturned path."""
+        mock_get.side_effect = [Platform.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(platform="multi", manufacturer_obj=self.manufacturer, logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple Platforms returned with the name multi")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Platform.objects.get", autospec=True)
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_platform_object_db_error_on_get(self, mock_logger, mock_get):
+        """Test `get_or_create_platform_object` DjangoBaseDBError on get path."""
+        mock_get.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_platform_object(
+            platform="get-db-fail", manufacturer_obj=self.manufacturer, logger=logger
+        )
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to retrieve Platform named get-db-fail")
+
+    # ===== get_or_create_tag_object =====
+
+    def test_get_or_create_tag_object_existing(self):
+        """Test `get_or_create_tag_object` returns existing Tag."""
+        existing, _ = Tag.objects.get_or_create(name="Existing-Tag", defaults={"color": ColorChoices.COLOR_GREY})
+        result = get_or_create_tag_object(tag_name="Existing-Tag")
+        self.assertEqual(result.id, existing.id)
+
+    def test_get_or_create_tag_object_new(self):
+        """Test `get_or_create_tag_object` creates new Tag and adds default content_type."""
+        self.assertFalse(Tag.objects.filter(name="New-Tag").exists())
+        result = get_or_create_tag_object(tag_name="New-Tag", tag_color=ColorChoices.COLOR_BLUE)
+        self.assertEqual(result.name, "New-Tag")
+        self.assertIn(self.content_type, result.content_types.all())
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Tag.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_tag_object_db_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_tag_object` DjangoBaseDBError path."""
+        mock_tag.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = get_or_create_tag_object(tag_name="DB-Tag", logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Tag.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_tag_object_validation_error(self, mock_logger, mock_tag):
+        """Test `get_or_create_tag_object` ValidationError path."""
+        mock_tag.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_tag_object(tag_name="V-Tag", logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    # ===== get_or_create_virtual_chassis_object =====
+
+    def test_get_or_create_virtual_chassis_object_existing(self):
+        """Test `get_or_create_virtual_chassis_object` returns existing VC."""
+        existing = VirtualChassis.objects.create(name="Stack-1")
+        result = get_or_create_virtual_chassis_object(name="Stack-1")
+        self.assertEqual(result.id, existing.id)
+
+    def test_get_or_create_virtual_chassis_object_new(self):
+        """Test `get_or_create_virtual_chassis_object` creates new VC."""
+        self.assertFalse(VirtualChassis.objects.filter(name="Stack-New").exists())
+        result = get_or_create_virtual_chassis_object(name="Stack-New")
+        self.assertEqual(result.name, "Stack-New")
+        self.assertTrue(VirtualChassis.objects.filter(name="Stack-New").exists())
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.VirtualChassis.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_virtual_chassis_object_db_error(self, mock_logger, mock_vc):
+        """Test `get_or_create_virtual_chassis_object` DjangoBaseDBError path."""
+        mock_vc.side_effect = [DjangoBaseDBError("err-msg")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_virtual_chassis_object(name="Stack-Err", logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+        self.assertIn(
+            "Unable to get or create VirtualChassis named Stack-Err",
+            logger.error.call_args[0][0],
+        )
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.VirtualChassis.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_get_or_create_virtual_chassis_object_validation_error(self, mock_logger, mock_vc):
+        """Test `get_or_create_virtual_chassis_object` ValidationError path."""
+        mock_vc.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = get_or_create_virtual_chassis_object(name="Stack-VErr", logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    # ===== assign_device_to_virtual_chassis =====
+
+    def _make_vc_test_device(self, name):
+        """Create a fresh device for VirtualChassis tests."""
+        return Device.objects.create(
+            name=name,
+            location=self.location,
+            device_type=self.device_type,
+            role=self.device_role,
+            status=Status.objects.get(name="Active"),
+        )
+
+    def test_assign_device_to_virtual_chassis_initial(self):
+        """Test initial assignment with VC, position, and priority."""
+        vc = VirtualChassis.objects.create(name="Stack-Init")
+        device = self._make_vc_test_device("VC-Initial")
+        result = assign_device_to_virtual_chassis(device, vc, position=1, priority=10)
+        device.refresh_from_db()
+        self.assertEqual(result.id, vc.id)
+        self.assertEqual(device.virtual_chassis_id, vc.id)
+        self.assertEqual(device.vc_position, 1)
+        self.assertEqual(device.vc_priority, 10)
+
+    def test_assign_device_to_virtual_chassis_idempotent(self):
+        """Test that calling twice with same args is a no-op on the second call."""
+        vc = VirtualChassis.objects.create(name="Stack-Idem")
+        device = self._make_vc_test_device("VC-Idem")
+        assign_device_to_virtual_chassis(device, vc, position=1, priority=10)
+        device.refresh_from_db()
+        with mock.patch.object(Device, "validated_save") as save_mock:
+            assign_device_to_virtual_chassis(device, vc, position=1, priority=10)
+            save_mock.assert_not_called()
+
+    def test_assign_device_to_virtual_chassis_position_only(self):
+        """Test setting position without priority."""
+        vc = VirtualChassis.objects.create(name="Stack-Pos")
+        device = self._make_vc_test_device("VC-Pos")
+        assign_device_to_virtual_chassis(device, vc, position=2)
+        device.refresh_from_db()
+        self.assertEqual(device.vc_position, 2)
+        self.assertIsNone(device.vc_priority)
+
+    def test_assign_device_to_virtual_chassis_master_set(self):
+        """Test setting master saves VC with the new master."""
+        vc = VirtualChassis.objects.create(name="Stack-Master")
+        device = self._make_vc_test_device("VC-Master")
+        assign_device_to_virtual_chassis(device, vc, position=1, master=True)
+        vc.refresh_from_db()
+        self.assertEqual(vc.master_id, device.id)
+
+    def test_assign_device_to_virtual_chassis_master_idempotent(self):
+        """Test that re-assigning the same master is a no-op on the VC save."""
+        vc = VirtualChassis.objects.create(name="Stack-MasterIdem")
+        device = self._make_vc_test_device("VC-MasterIdem")
+        assign_device_to_virtual_chassis(device, vc, position=1, master=True)
+        with mock.patch.object(VirtualChassis, "validated_save") as save_mock:
+            assign_device_to_virtual_chassis(device, vc, position=1, master=True)
+            save_mock.assert_not_called()
+
+    # ===== get_tagged_device =====
+
+    def test_get_tagged_device_match(self):
+        """Test returns the device when name and SSoT tag match."""
+        ssot_tag, _ = Tag.objects.get_or_create(
+            name="SSoT Synced from IPFabric", defaults={"color": ColorChoices.COLOR_LIGHT_GREEN}
+        )
+        ssot_tag.content_types.add(self.content_type)
+        self.device.tags.add(ssot_tag)
+        result = get_tagged_device(self.device.name)
+        self.assertEqual(result.id, self.device.id)
+
+    def test_get_tagged_device_no_match(self):
+        """Test returns None when device has no SSoT tag."""
+        result = get_tagged_device("Test-Device")
+        self.assertIsNone(result)
+
+    def test_get_tagged_device_cache_reuse(self):
+        """Test second call hits the cache and skips DB."""
+        ssot_tag, _ = Tag.objects.get_or_create(
+            name="SSoT Synced from IPFabric", defaults={"color": ColorChoices.COLOR_LIGHT_GREEN}
+        )
+        ssot_tag.content_types.add(self.content_type)
+        self.device.tags.add(ssot_tag)
+        first = get_tagged_device(self.device.name)
+        with mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.Device.objects.filter") as mock_filter:
+            second = get_tagged_device(self.device.name)
+            mock_filter.assert_not_called()
+        self.assertIs(first, second)
+
+    # ===== tag_object (direct) =====
+
+    def test_tag_object_adds_tag_and_cf(self):
+        """Test `tag_object` adds tag and writes cf values."""
+        tag_object(nautobot_object=self.device, custom_field=LAST_SYNCHRONIZED_CF_NAME)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.cf.get("system_of_record"), "IPFabric")
+        self.assertIn("SSoT Synced from IPFabric", [t.name for t in self.device.tags.all()])
+
+    def test_tag_object_alternate_tag_name(self):
+        """Test `tag_object` with an alternate tag_name."""
+        Tag.objects.get_or_create(name="Custom-Tag", defaults={"color": ColorChoices.COLOR_GREY})
+        tag_object(
+            nautobot_object=self.device,
+            custom_field=LAST_SYNCHRONIZED_CF_NAME,
+            tag_name="Custom-Tag",
+        )
+        self.device.refresh_from_db()
+        self.assertIn("Custom-Tag", [t.name for t in self.device.tags.all()])
+
+    # ===== create_vlan error/tag paths =====
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.VLAN.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_vlan_multiple_returned(self, mock_logger, mock_vlan):
+        """Test `create_vlan` MultipleObjectsReturned path."""
+        mock_vlan.side_effect = [VLAN.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = create_vlan(
+            vlan_name="Multi-VLAN",
+            vlan_id=200,
+            vlan_status="Active",
+            location_obj=self.location,
+            description="t",
+            logger=logger,
+        )
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Multiple VLANs returned with name Multi-VLAN and ID 200")
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.VLAN.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_vlan_db_error(self, mock_logger, mock_vlan):
+        """Test `create_vlan` DjangoBaseDBError path."""
+        mock_vlan.side_effect = [DjangoBaseDBError("oops")]
+        logger = mock_logger("nb_job")
+        result = create_vlan(
+            vlan_name="DB-VLAN",
+            vlan_id=201,
+            vlan_status="Active",
+            location_obj=self.location,
+            description="t",
+            logger=logger,
+        )
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.VLAN.objects.get_or_create", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_vlan_validation_error(self, mock_logger, mock_vlan):
+        """Test `create_vlan` ValidationError path."""
+        mock_vlan.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = create_vlan(
+            vlan_name="V-VLAN",
+            vlan_id=202,
+            vlan_status="Active",
+            location_obj=self.location,
+            description="t",
+            logger=logger,
+        )
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_vlan_tag_db_error(self, mock_logger, mock_tag):
+        """Test `create_vlan` tag_object DjangoBaseDBError path."""
+        mock_tag.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = create_vlan(
+            vlan_name="TagDB-VLAN",
+            vlan_id=203,
+            vlan_status="Active",
+            location_obj=self.location,
+            description="t",
+            logger=logger,
+        )
+        self.assertEqual(result.name, "TagDB-VLAN")
+        self.assertTrue(logger.warning.called)
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_vlan_tag_validation_error(self, mock_logger, mock_tag):
+        """Test `create_vlan` tag_object ValidationError path."""
+        mock_tag.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = create_vlan(
+            vlan_name="TagV-VLAN",
+            vlan_id=204,
+            vlan_status="Active",
+            location_obj=self.location,
+            description="t",
+            logger=logger,
+        )
+        self.assertEqual(result.name, "TagV-VLAN")
+        self.assertTrue(logger.warning.called)
+
+    # ===== create_interface error/tag/status paths =====
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_status_multiple_returned(self, mock_logger, mock_status):
+        """Test `create_interface` Status.MultipleObjectsReturned path."""
+        mock_status.return_value.get.side_effect = [Status.MultipleObjectsReturned]
+        logger = mock_logger("nb_job")
+        result = create_interface(self.device, {"name": "StatMulti-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+        self.assertIn("Multiple Statuses returned with name Active", logger.error.call_args[0][0])
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_status_does_not_exist(self, mock_logger, mock_status):
+        """Test `create_interface` Status.DoesNotExist path."""
+        mock_status.return_value.get.side_effect = [Status.DoesNotExist]
+        logger = mock_logger("nb_job")
+        result = create_interface(self.device, {"name": "StatDNE-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        self.assertTrue(logger.error.called)
+        self.assertIn("Unable to find a Status with the name Active", logger.error.call_args[0][0])
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_multiple_returned(self, mock_logger, mock_status):
+        """Test `create_interface` Interface.MultipleObjectsReturned path."""
+        mock_status.return_value.get.return_value = "mock_status"
+        logger = mock_logger("nb_job")
+        mock_device = mock.MagicMock()
+        mock_device.name = "Mock-Device"
+        mock_device.interfaces.get_or_create.side_effect = Interface.MultipleObjectsReturned
+        result = create_interface(mock_device, {"name": "Multi-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with(
+            "Multiple Interfaces returned with name Multi-Iface on Device named Mock-Device"
+        )
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_db_error(self, mock_logger, mock_status):
+        """Test `create_interface` DjangoBaseDBError on get_or_create path."""
+        mock_status.return_value.get.return_value = "mock_status"
+        logger = mock_logger("nb_job")
+        mock_device = mock.MagicMock()
+        mock_device.name = "Mock-Device"
+        mock_device.interfaces.get_or_create.side_effect = DjangoBaseDBError
+        result = create_interface(mock_device, {"name": "DB-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Interface named DB-Iface on Device named Mock-Device")
+
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.Status.objects.get_for_model", autospec=True
+    )
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_validation_error(self, mock_logger, mock_status):
+        """Test `create_interface` ValidationError on get_or_create path."""
+        mock_status.return_value.get.return_value = "mock_status"
+        logger = mock_logger("nb_job")
+        mock_device = mock.MagicMock()
+        mock_device.name = "Mock-Device"
+        mock_device.interfaces.get_or_create.side_effect = ValidationError("failure")
+        result = create_interface(mock_device, {"name": "V-Iface"}, logger=logger)
+        self.assertIsNone(result)
+        logger.error.assert_called_with("Unable to create a new Interface named V-Iface on Device named Mock-Device")
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_tag_db_error(self, mock_logger, mock_tag):
+        """Test `create_interface` tag_object DjangoBaseDBError path."""
+        mock_tag.side_effect = [DjangoBaseDBError]
+        logger = mock_logger("nb_job")
+        result = create_interface(self.device, {"name": "TagDB-Iface"}, logger=logger)
+        self.assertEqual(result.name, "TagDB-Iface")
+        self.assertTrue(logger.warning.called)
+
+    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.tag_object")
+    @unittest.mock.patch("logging.Logger", autospec=True)
+    def test_create_interface_tag_validation_error(self, mock_logger, mock_tag):
+        """Test `create_interface` tag_object ValidationError path."""
+        mock_tag.side_effect = [ValidationError("failure")]
+        logger = mock_logger("nb_job")
+        result = create_interface(self.device, {"name": "TagV-Iface"}, logger=logger)
+        self.assertEqual(result.name, "TagV-Iface")
+        self.assertTrue(logger.warning.called)

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -15,16 +15,17 @@ from nautobot.extras.models.statuses import Status
 from nautobot.ipam.models import VLAN, IPAddress, Prefix, get_default_namespace
 
 from nautobot_ssot.integrations.ipfabric.utilities import (
-    create_device_type_object,
     create_interface,
     create_ip,
-    create_location,
-    create_manufacturer,
-    create_platform_object,
-    create_status,
     create_vlan,
     get_or_create_device_role_object,
+    get_or_create_device_type_object,
+    get_or_create_location_object,
+    get_or_create_manufacturer_object,
+    get_or_create_platform_object,
+    get_or_create_status_object,
 )
+from nautobot_ssot.integrations.ipfabric.utilities.utils import job_scoped_cache
 
 
 # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-public-methods
@@ -33,6 +34,7 @@ class TestNautobotUtils(TestCase):
 
     def setUp(self):
         """Setup."""
+        job_scoped_cache.clear_all()
         site_location_type = LocationType.objects.update_or_create(name="Site")[0]
         site_location_type.content_types.set([ContentType.objects.get_for_model(VLAN)])
         self.location = Location.objects.create(
@@ -91,25 +93,27 @@ class TestNautobotUtils(TestCase):
 
     def test_create_location_existing_location_no_location_id(self):
         """Test `create_location` Utility."""
-        test_location = create_location(location_name="Test-Location")
+        test_location = get_or_create_location_object(location_name="Test-Location")
         self.assertEqual(test_location.id, self.location.id)
 
     def test_create_location_existing_location_with_location_id(self):
         """Test `create_location` Utility."""
         self.assertFalse(self.location.cf.get("ipfabric_site_id"))
-        test_location = create_location(location_name="Test-Location", location_id="Test-Location")
+        test_location = get_or_create_location_object(location_name="Test-Location", location_id="Test-Location")
         self.assertEqual(test_location.id, self.location.id)
         self.assertEqual(test_location.cf["ipfabric_site_id"], "Test-Location")
 
     def test_create_location_no_location_id(self):
         """Test `create_location` Utility."""
-        test_location = create_location(location_name="Test-Location-new")
+        test_location = get_or_create_location_object(location_name="Test-Location-new")
         self.assertEqual(test_location.name, "Test-Location-new")
 
     def test_create_location_with_location_id(self):
         """Test `create_location` Utility."""
         self.assertFalse(Location.objects.filter(name="Test-Location-new"))
-        test_location = create_location(location_name="Test-Location-new", location_id="Test-Location-new")
+        test_location = get_or_create_location_object(
+            location_name="Test-Location-new", location_id="Test-Location-new"
+        )
         self.assertEqual(test_location.name, "Test-Location-new")
         self.assertEqual(test_location.cf["ipfabric_site_id"], "Test-Location-new")
 
@@ -122,7 +126,9 @@ class TestNautobotUtils(TestCase):
         """Test `create_location` Utility."""
         mock_location.side_effect = [Location.MultipleObjectsReturned]
         logger = mock_logger("nb_job")
-        test_location = create_location(location_name="Test-Location", location_id="Test-Location", logger=logger)
+        test_location = get_or_create_location_object(
+            location_name="Test-Location", location_id="Test-Location", logger=logger
+        )
         self.assertEqual(test_location, None)
         logger.error.assert_called_with("Multiple Locations returned with name Test-Location")
         mock_tag_object.assert_not_called()
@@ -136,7 +142,9 @@ class TestNautobotUtils(TestCase):
         """Test `create_location` Utility."""
         mock_location.side_effect = [DjangoBaseDBError]
         logger = mock_logger("nb_job")
-        test_location = create_location(location_name="Test-Location", location_id="Test-Location", logger=logger)
+        test_location = get_or_create_location_object(
+            location_name="Test-Location", location_id="Test-Location", logger=logger
+        )
         self.assertEqual(test_location, None)
         logger.error.assert_called_with("Unable to create a new Location named Test-Location with LocationType Site")
         mock_tag_object.assert_not_called()
@@ -150,7 +158,9 @@ class TestNautobotUtils(TestCase):
         """Test `create_location` Utility."""
         mock_location.side_effect = [ValidationError("failure")]
         logger = mock_logger("nb_job")
-        test_location = create_location(location_name="Test-Location", location_id="Test-Location", logger=logger)
+        test_location = get_or_create_location_object(
+            location_name="Test-Location", location_id="Test-Location", logger=logger
+        )
         self.assertEqual(test_location, None)
         logger.error.assert_called_with("Unable to create a new Location named Test-Location with LocationType Site")
         mock_tag_object.assert_not_called()
@@ -161,7 +171,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_location` Utility."""
         mock_tag_object.side_effect = [DjangoBaseDBError]
         logger = mock_logger("nb_job")
-        test_location = create_location(location_name="Test-Location-new", logger=logger)
+        test_location = get_or_create_location_object(location_name="Test-Location-new", logger=logger)
         self.assertEqual(test_location.name, "Test-Location-new")
         logger.warning.assert_called_with(
             f"Unable to perform a validated_save() on Location {test_location.name} with an ID of {test_location.id}"
@@ -173,32 +183,40 @@ class TestNautobotUtils(TestCase):
         """Test `create_location` Utility."""
         mock_tag_object.side_effect = [ValidationError("failure")]
         logger = mock_logger("nb_job")
-        test_location = create_location(location_name="Test-Location-new", logger=logger)
+        test_location = get_or_create_location_object(location_name="Test-Location-new", logger=logger)
         self.assertEqual(test_location.name, "Test-Location-new")
         logger.warning.assert_called_with(
             f"Unable to perform a validated_save() on Location {test_location.name} with an ID of {test_location.id}"
         )
 
-    def test_create_device_type_object(self):
+    def test_get_or_create_device_type_object(self):
         """Test `create_device_type_object` Utility."""
-        test_device_type = create_device_type_object(device_type="Test-DeviceType-New", vendor_name="Test-Manufacturer")
+        test_device_type = get_or_create_device_type_object(
+            device_type="Test-DeviceType-New", vendor_name="Test-Manufacturer"
+        )
         self.assertEqual(test_device_type.model, "Test-DeviceType-New")
 
     def test_create_device_type_object_existing_device_type(self):
         """Test `create_device_type_object` Utility."""
-        test_device_type = create_device_type_object(device_type="Test-DeviceType", vendor_name="Test-Manufacturer")
+        test_device_type = get_or_create_device_type_object(
+            device_type="Test-DeviceType", vendor_name="Test-Manufacturer"
+        )
         self.assertEqual(test_device_type.id, self.device_type.id)
 
-    @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.create_manufacturer", autospec=True)
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.ipfabric.utilities.nbutils.get_or_create_manufacturer_object", autospec=True
+    )
     @unittest.mock.patch(
         "nautobot_ssot.integrations.ipfabric.utilities.nbutils.DeviceType.objects.get_or_create", autospec=True
     )
     @unittest.mock.patch("logging.Logger", autospec=True)
-    def test_create_device_type_fail_to_get_manufacturer(self, mock_logger, mock_device_type, mock_create_manufacturer):
+    def test_create_device_type_fail_to_get_manufacturer(
+        self, mock_logger, mock_device_type, mock_get_or_create_manufacturer_object
+    ):
         """Test `create_device_type_object` Utility."""
-        mock_create_manufacturer.return_value = None
+        mock_get_or_create_manufacturer_object.return_value = None
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType", vendor_name="Test-Manufacturer", logger=logger
         )
         mock_device_type.assert_not_called()
@@ -215,7 +233,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_device_type_object` Utility."""
         mock_device_type.side_effect = [DeviceType.MultipleObjectsReturned]
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType", vendor_name="Test-Manufacturer", logger=logger
         )
         logger.error.assert_called_with(
@@ -231,7 +249,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_device_type_object` Utility."""
         mock_device_type.side_effect = [DjangoBaseDBError]
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType", vendor_name="Test-Manufacturer", logger=logger
         )
         logger.error.assert_called_with(
@@ -247,7 +265,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_device_type_object` Utility."""
         mock_device_type.side_effect = [ValidationError("failure")]
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType", vendor_name="Test-Manufacturer", logger=logger
         )
         logger.error.assert_called_with(
@@ -261,7 +279,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_device_type_object` Utility."""
         mock_tag_object.side_effect = [None, DjangoBaseDBError]
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType-new", vendor_name="Test-Manufacturer", logger=logger
         )
         self.assertEqual(test_device_type.model, "Test-DeviceType-new")
@@ -275,7 +293,7 @@ class TestNautobotUtils(TestCase):
         """Test `create_device_type_object` Utility."""
         mock_tag_object.side_effect = [None, ValidationError("failure")]
         logger = mock_logger("nb_job")
-        test_device_type = create_device_type_object(
+        test_device_type = get_or_create_device_type_object(
             device_type="Test-DeviceType-new", vendor_name="Test-Manufacturer", logger=logger
         )
         self.assertEqual(test_device_type.model, "Test-DeviceType-new")
@@ -283,47 +301,47 @@ class TestNautobotUtils(TestCase):
             f"Unable to perform a validated_save() on DeviceType Test-DeviceType-new with an ID of {test_device_type.id}"
         )
 
-    def test_create_manufacturer(self):
-        """Test `create_manufacturer` Utility."""
-        test_manufacturer = create_manufacturer(vendor_name="Test-Manufacturer")
+    def test_get_or_create_manufacturer_object(self):
+        """Test `get_or_create_manufacturer_object` Utility."""
+        test_manufacturer = get_or_create_manufacturer_object(vendor_name="Test-Manufacturer")
         self.assertEqual(test_manufacturer.id, self.manufacturer.id)
 
-    def test_create_platform_object_platform_created_no_napalm_driver(self):
-        """Test `create_platform_object` Utility."""
+    def test_get_or_create_platform_object_platform_created_no_napalm_driver(self):
+        """Test `get_or_create_platform_object_object` Utility."""
         platform = "does_not_exist"
         self.assertEqual(Platform.objects.filter(name=platform).count(), 0)
-        platform_obj = create_platform_object(platform, self.manufacturer)
+        platform_obj = get_or_create_platform_object(platform, self.manufacturer)
         self.assertEqual(self.manufacturer.id, platform_obj.manufacturer.id)
         self.assertEqual(platform_obj.name, platform)
         expected_network_driver = f"{self.manufacturer.name.lower()}_{platform}"
         self.assertEqual(platform_obj.network_driver, expected_network_driver)
         self.assertEqual(platform_obj.napalm_driver, "")
 
-    def test_create_platform_object_platform_created_with_napalm_driver(self):
-        """Test `create_platform_object` Utility."""
+    def test_get_or_create_platform_object_platform_created_with_napalm_driver(self):
+        """Test `get_or_create_platform_object` Utility."""
         manufacturer_obj, _ = Manufacturer.objects.get_or_create(name="Cisco")
         platform = "ios"
         self.assertEqual(Platform.objects.filter(name=platform).count(), 0)
-        platform_obj = create_platform_object(platform, manufacturer_obj)
+        platform_obj = get_or_create_platform_object(platform, manufacturer_obj)
         self.assertEqual(manufacturer_obj.id, platform_obj.manufacturer.id)
         self.assertEqual(platform_obj.name, platform)
         self.assertEqual(platform_obj.network_driver, "cisco_ios")
         self.assertEqual(platform_obj.napalm_driver, "cisco_ios")
 
-    def test_create_platform_object_platform_created_iosxe(self):
+    def test_get_or_create_platform_object_platform_created_iosxe(self):
         """Test `create_platform_object` Utility."""
         platform = "ios-xe"
         self.assertEqual(Platform.objects.filter(name=platform).count(), 0)
-        platform_obj = create_platform_object(platform, self.manufacturer)
+        platform_obj = get_or_create_platform_object(platform, self.manufacturer)
         self.assertEqual(platform_obj.network_driver, "cisco_ios")
         self.assertEqual(platform_obj.napalm_driver, "cisco_ios")
 
-    def test_create_platform_object_existing_platform_returned(self):
-        """Test `create_platform_object` Utility."""
+    def test_get_or_create_platform_object_existing_platform_returned(self):
+        """Test `get_or_create_platform_object` Utility."""
         manufacturer_obj, _ = Manufacturer.objects.get_or_create(name="Cisco")
         platform = "ios"
         platform_obj = Platform.objects.create(name=platform, manufacturer=manufacturer_obj)
-        existing_platform_obj = create_platform_object(platform, manufacturer_obj)
+        existing_platform_obj = get_or_create_platform_object(platform, manufacturer_obj)
         self.assertEqual(platform_obj.id, existing_platform_obj.id)
         self.assertEqual(platform_obj.network_driver, "")
         self.assertEqual(platform_obj.napalm_driver, "")
@@ -333,14 +351,14 @@ class TestNautobotUtils(TestCase):
         test_device_role = get_or_create_device_role_object("Test-Role", role_color=ColorChoices.COLOR_RED)
         self.assertEqual(test_device_role.id, self.device_role.id)
 
-    def test_create_status(self):
-        """Test `create_status` Utility."""
-        test_status = create_status(status_name="Test-Status", status_color=ColorChoices.COLOR_AMBER)
+    def test_get_or_create_status_object(self):
+        """Test `get_or_create_status_object` Utility."""
+        test_status = get_or_create_status_object(status_name="Test-Status", status_color=ColorChoices.COLOR_AMBER)
         self.assertEqual(test_status.id, self.status.id)
 
-    def test_create_status_doesnt_exist(self):
-        """Test `create_status` Utility."""
-        test_status = create_status(status_name="Test-Status-100", status_color=ColorChoices.COLOR_AMBER)
+    def test_get_or_create_status_object_doesnt_exist(self):
+        """Test `get_or_create_status_object` Utility."""
+        test_status = get_or_create_status_object(status_name="Test-Status-100", status_color=ColorChoices.COLOR_AMBER)
         self.assertEqual(test_status.id, Status.objects.get(name="Test-Status-100").id)
 
     @unittest.mock.patch("nautobot_ssot.integrations.ipfabric.utilities.nbutils.IPAddressToInterface")

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -1313,6 +1313,43 @@ class TestNautobotUtils(TestCase):
             assign_device_to_virtual_chassis(device, vc, position=1, master=True)
             save_mock.assert_not_called()
 
+    def test_assign_device_to_virtual_chassis_priority_update(self):
+        """Calling again with a new priority updates priority and persists."""
+        vc = VirtualChassis.objects.create(name="Stack-PriUpdate")
+        device = self._make_vc_test_device("VC-PriUpdate")
+        assign_device_to_virtual_chassis(device, vc, position=1, priority=10)
+        device.refresh_from_db()
+        self.assertEqual(device.vc_priority, 10)
+
+        assign_device_to_virtual_chassis(device, vc, position=1, priority=20)
+        device.refresh_from_db()
+        self.assertEqual(device.vc_priority, 20)
+
+    def test_assign_device_to_virtual_chassis_position_change(self):
+        """Calling again with a different position updates position and persists."""
+        vc = VirtualChassis.objects.create(name="Stack-PosChange")
+        device = self._make_vc_test_device("VC-PosChange")
+        assign_device_to_virtual_chassis(device, vc, position=1)
+        device.refresh_from_db()
+        self.assertEqual(device.vc_position, 1)
+
+        assign_device_to_virtual_chassis(device, vc, position=3)
+        device.refresh_from_db()
+        self.assertEqual(device.vc_position, 3)
+
+    def test_assign_device_to_virtual_chassis_master_swap(self):
+        """Setting master=True for a different device flips the VC master."""
+        vc = VirtualChassis.objects.create(name="Stack-MasterSwap")
+        first = self._make_vc_test_device("VC-MasterSwap-1")
+        second = self._make_vc_test_device("VC-MasterSwap-2")
+        assign_device_to_virtual_chassis(first, vc, position=1, master=True)
+        vc.refresh_from_db()
+        self.assertEqual(vc.master_id, first.id)
+
+        assign_device_to_virtual_chassis(second, vc, position=2, master=True)
+        vc.refresh_from_db()
+        self.assertEqual(vc.master_id, second.id)
+
     # ===== get_tagged_device =====
 
     def test_get_tagged_device_match(self):

--- a/nautobot_ssot/tests/ipfabric/test_utils.py
+++ b/nautobot_ssot/tests/ipfabric/test_utils.py
@@ -1,9 +1,12 @@
 """Tests for IPFabric utilities.utils."""
 
+import threading
+
 from django.test import SimpleTestCase
 
 from nautobot_ssot.integrations.ipfabric.constants import DEFAULT_INTERFACE_TYPE
 from nautobot_ssot.integrations.ipfabric.utilities import utils
+from nautobot_ssot.integrations.ipfabric.utilities.utils import job_scoped_cache
 
 
 class TestUtils(SimpleTestCase):  # pylint: disable=too-many-public-methods
@@ -152,3 +155,133 @@ class TestUtils(SimpleTestCase):  # pylint: disable=too-many-public-methods
 
     def test_interface_name_twohundredgigethernet(self):
         self.assertEqual("200gbase-x-qsfp56", utils.convert_media_type("", "TwoHundredGigabitEthernet1"))
+
+
+class TestJobScopedCache(SimpleTestCase):
+    """Test the `job_scoped_cache` decorator class."""
+
+    def setUp(self):
+        """Ensure no leaked state from other tests."""
+        job_scoped_cache.clear_all()
+
+    def test_cache_hit_returns_same_object(self):
+        """Second call with same args returns the cached result (no second invocation)."""
+        call_count = {"n": 0}
+
+        @job_scoped_cache
+        def make_obj(x):
+            call_count["n"] += 1
+            return [x]
+
+        first = make_obj(1)
+        second = make_obj(1)
+        self.assertIs(first, second)
+        self.assertEqual(call_count["n"], 1)
+
+    def test_cache_miss_for_different_args(self):
+        """Different args produce different cached entries; no false hits."""
+
+        @job_scoped_cache
+        def make_obj(x):
+            return [x]
+
+        a = make_obj(1)
+        b = make_obj(2)
+        self.assertIsNot(a, b)
+        self.assertEqual(a, [1])
+        self.assertEqual(b, [2])
+
+    def test_cache_clear_resets_instance(self):
+        """`cache_clear()` on one instance forces the next call to re-invoke the function."""
+        call_count = {"n": 0}
+
+        @job_scoped_cache
+        def make_obj(x):
+            call_count["n"] += 1
+            return [x]
+
+        first = make_obj(1)
+        make_obj.cache_clear()
+        second = make_obj(1)
+        self.assertIsNot(first, second)
+        self.assertEqual(call_count["n"], 2)
+
+    def test_cache_info_reports_hits_misses_and_size(self):
+        """`cache_info()` accurately reports hits, misses, and current size."""
+
+        @job_scoped_cache
+        def make_obj(x):
+            return [x]
+
+        make_obj(1)  # miss
+        make_obj(1)  # hit
+        make_obj(2)  # miss
+        info = make_obj.cache_info()
+        self.assertEqual(info.hits, 1)
+        self.assertEqual(info.misses, 2)
+        self.assertEqual(info.currsize, 2)
+        self.assertIsNone(info.maxsize)
+
+    def test_clear_all_resets_every_instance(self):
+        """`clear_all()` resets caches on every registered instance."""
+
+        @job_scoped_cache
+        def first(x):
+            return [x]
+
+        @job_scoped_cache
+        def second(x):
+            return {x}
+
+        first(1)
+        second(2)
+        self.assertEqual(first.cache_info().currsize, 1)
+        self.assertEqual(second.cache_info().currsize, 1)
+
+        job_scoped_cache.clear_all()
+
+        self.assertEqual(first.cache_info().currsize, 0)
+        self.assertEqual(second.cache_info().currsize, 0)
+
+    def test_clear_group_only_clears_named_group(self):
+        """`clear_group()` clears the named group's caches and leaves others intact."""
+
+        @job_scoped_cache(group="alpha")
+        def in_group(x):
+            return [x]
+
+        @job_scoped_cache
+        def ungrouped(x):
+            return [x]
+
+        in_group(1)
+        ungrouped(1)
+        self.assertEqual(in_group.cache_info().currsize, 1)
+        self.assertEqual(ungrouped.cache_info().currsize, 1)
+
+        job_scoped_cache.clear_group("alpha")
+
+        self.assertEqual(in_group.cache_info().currsize, 0, "group-cleared cache should be empty")
+        self.assertEqual(ungrouped.cache_info().currsize, 1, "ungrouped cache must remain intact")
+
+    def test_thread_local_isolation(self):
+        """Each thread gets its own cache store; entries do not leak across threads."""
+
+        @job_scoped_cache
+        def make_obj(x):
+            return [x]
+
+        main_result = make_obj(1)
+        other_thread_result = []
+
+        def in_thread():
+            other_thread_result.append(make_obj(1))
+
+        worker = threading.Thread(target=in_thread)
+        worker.start()
+        worker.join()
+
+        self.assertEqual(len(other_thread_result), 1)
+        # Different threads -> separate cache stores -> separate fresh objects with equal values.
+        self.assertIsNot(main_result, other_thread_result[0])
+        self.assertEqual(main_result, other_thread_result[0])


### PR DESCRIPTION
## What's Changed

- DB queries per sync: ~5–10× reduction at typical environment sizes
- Per-record N+1s eliminated in the loader (devices/interfaces/VLANs)
- Inline tag/status/device lookups eliminated in the diff-application path
- 9+ real correctness bugs found and fixed along the way
- N+1 regression guards now in place so this doesn't quietly slip backward

## To Do

- [ ] Explanation of Change(s)
- [X] Added change log fragment(s)
- [X] Unit, Integration Tests
