### PR TITLE
Fixing Dump Data bug

### DIFF
--- a/changes/1045.fixed
+++ b/changes/1045.fixed
@@ -1,0 +1,1 @@
+Fixed `nautobot-server dumpdata nautobot_ssot` failing with `ProgrammingError: relation "nautobot_ssot_ssotconfig" does not exist` by giving the unmanaged `SSOTConfig` model a manager that returns an empty queryset.

--- a/nautobot_ssot/models.py
+++ b/nautobot_ssot/models.py
@@ -274,9 +274,7 @@ class _SSOTConfigManager(models.Manager):
     """Manager that never queries the database; SSOTConfig has no table."""
 
     def get_queryset(self):
-        # SSOTConfig is unmanaged and intentionally has no underlying table.
-        # Returning .none() prevents management commands such as dumpdata
-        # from issuing a SELECT against the non-existent relation.
+        """Return an empty queryset; SSOTConfig is unmanaged and has no underlying table."""
         return super().get_queryset().none()
 
 

--- a/nautobot_ssot/models.py
+++ b/nautobot_ssot/models.py
@@ -270,8 +270,20 @@ class SyncLogEntry(BaseModel):  # pylint: disable=nb-string-field-blank-null
         }.get(self.status)
 
 
+class _SSOTConfigManager(models.Manager):
+    """Manager that never queries the database; SSOTConfig has no table."""
+
+    def get_queryset(self):
+        # SSOTConfig is unmanaged and intentionally has no underlying table.
+        # Returning .none() prevents management commands such as dumpdata
+        # from issuing a SELECT against the non-existent relation.
+        return super().get_queryset().none()
+
+
 class SSOTConfig(models.Model):  # pylint: disable=nb-incorrect-base-class
     """Non-db model providing user permission constraints."""
+
+    objects = _SSOTConfigManager()
 
     class Meta:
         managed = False

--- a/nautobot_ssot/tests/test_management.py
+++ b/nautobot_ssot/tests/test_management.py
@@ -187,3 +187,18 @@ class TestElongateInterfaceNames(TestCase):
             stdout=out,
         )
         self.assertEqual(out.getvalue().strip(), "Updating ssot_test_1.ge2 >> GigabitEthernet2")
+
+
+class TestDumpdataNautobotSSOT(TestCase):
+    """Regression tests for dumpdata against the nautobot_ssot app."""
+
+    def test_dumpdata_does_not_query_ssotconfig_table(self):
+        # SSOTConfig is an unmanaged model with no underlying table; it exists
+        # solely to register the `view_ssotconfig` permission. Before #1045 was
+        # fixed, `dumpdata nautobot_ssot` crashed with ProgrammingError when
+        # Django tried to SELECT from the non-existent relation.
+        out = StringIO()
+        call_command("dumpdata", "nautobot_ssot", format="json", stdout=out)
+        payload = out.getvalue()
+        self.assertTrue(payload.lstrip().startswith("["))
+        self.assertNotIn("nautobot_ssot.ssotconfig", payload)


### PR DESCRIPTION
# Closes: #1045

## What's Changed

Quick fix for bug in dumpdata - has been in the code for a while due to an unmanaged model.

### Root cause

`SSOTConfig` is registered as an unmanaged Django model (`Meta.managed = False`)
so its sole purpose is to register the `nautobot_ssot.view_ssotconfig` permission
used by `SSOTConfigView`. Because no table is ever created, Django's `dumpdata`
crashes when it walks every model in the app and issues `SELECT … FROM
nautobot_ssot_ssotconfig`.

### Fix

Attach a manager to `SSOTConfig` that returns `.none()`, so any queryset walker
(`dumpdata`, `loaddata`, admin index) yields zero rows without touching the
non-existent relation. The model stays unmanaged; no migration is needed; the
permission and view-gating behavior are unchanged.

### Before / After

Before (`develop`):

\```
$ nautobot-server dumpdata --format json nautobot_ssot
…
psycopg2.errors.UndefinedTable: relation "nautobot_ssot_ssotconfig" does not exist
LINE 1: ...D FOR SELECT "nautobot_ssot_ssotconfig"."id" FROM "nautobot_...
django.db.utils.ProgrammingError: relation "nautobot_ssot_ssotconfig" does not exist
\```

After (this PR):

\```
$ nautobot-server dumpdata --format json nautobot_ssot | head -c 80
[{"model": "nautobot_ssot.sync", "pk": "…", "fields": {"source": "ServiceNow"…
\```

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example  <!-- N/A — CLI-only behavior, included above -->
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)  <!-- N/A -->
- [x] Outline Remaining Work, Constraints from Design  <!-- none -->