### PR TITLE
Fix AttributeError on custom field lookups through related objects

### DIFF
--- a/changes/753.fixed
+++ b/changes/753.fixed
@@ -1,0 +1,1 @@
+Fixed `AttributeError: 'dict' object has no attribute '<key>'` when a diffsync model attribute traverses a Nautobot JSON field such as `_custom_field_data`, including through a foreign key (for example `vlan___custom_field_data__my_key`).

--- a/nautobot_ssot/tests/utils/test_orm.py
+++ b/nautobot_ssot/tests/utils/test_orm.py
@@ -202,6 +202,51 @@ class TestORMAttributeLookup(BaseTestCase):
         self.assertEqual(result, "")
 
 
+class TestORMAttributeLookupCustomFields(TestCase):
+    """Regression tests for issue #753 — accessing custom field values through FK chains."""
+
+    def setUp(self):
+        """Create a CustomField, attach it to LocationType, and populate it on two related Locations."""
+        status = Status.objects.get(name="Active")
+
+        from nautobot.extras.models import CustomField  # local import keeps top imports unchanged
+
+        self.cf_label = "netvs_gpk"
+        cf_content_type = ContentType.objects.get_for_model(Location)
+        self.custom_field = CustomField.objects.create(label=self.cf_label, key=self.cf_label, type="text")
+        self.custom_field.content_types.add(cf_content_type)
+
+        self.location_type = LocationType.objects.create(name="Loc Type 753")
+        self.parent_location = Location.objects.create(
+            name="Parent Location 753",
+            location_type=self.location_type,
+            status=status,
+            _custom_field_data={self.cf_label: "parent-value"},
+        )
+        self.child_location = Location.objects.create(
+            name="Child Location 753",
+            location_type=self.location_type,
+            parent=self.parent_location,
+            status=status,
+            _custom_field_data={self.cf_label: "child-value"},
+        )
+
+    def test_direct_custom_field_lookup(self):
+        """`_custom_field_data__<key>` on the root object resolves to the stored value."""
+        result = orm_attribute_lookup(self.child_location, f"_custom_field_data__{self.cf_label}")
+        self.assertEqual(result, "child-value")
+
+    def test_foreign_custom_field_lookup(self):
+        """`<fk>___custom_field_data__<key>` resolves the custom field on the related object (#753)."""
+        result = orm_attribute_lookup(self.child_location, f"parent___custom_field_data__{self.cf_label}")
+        self.assertEqual(result, "parent-value")
+
+    def test_foreign_custom_field_lookup_missing_key(self):
+        """Missing custom field key returns None rather than raising."""
+        result = orm_attribute_lookup(self.child_location, "parent___custom_field_data__does_not_exist")
+        self.assertIsNone(result)
+
+
 class TestLoadTypedDict(BaseTestCase):
     """Unittests for `load_typed_dict` function."""
 

--- a/nautobot_ssot/tests/utils/test_orm.py
+++ b/nautobot_ssot/tests/utils/test_orm.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from nautobot.circuits.models import Provider
 from nautobot.dcim.models import Location, LocationType
 from nautobot.extras.choices import RelationshipTypeChoices
-from nautobot.extras.models import Relationship, RelationshipAssociation, Status
+from nautobot.extras.models import CustomField, Relationship, RelationshipAssociation, Status
 from typing_extensions import TypedDict
 
 from nautobot_ssot.contrib.types import RelationshipSideEnum
@@ -208,8 +208,6 @@ class TestORMAttributeLookupCustomFields(TestCase):
     def setUp(self):
         """Create a CustomField, attach it to LocationType, and populate it on two related Locations."""
         status = Status.objects.get(name="Active")
-
-        from nautobot.extras.models import CustomField  # local import keeps top imports unchanged
 
         self.cf_label = "netvs_gpk"
         cf_content_type = ContentType.objects.get_for_model(Location)

--- a/nautobot_ssot/utils/orm.py
+++ b/nautobot_ssot/utils/orm.py
@@ -52,7 +52,10 @@ def orm_attribute_lookup(db_obj: Model, attr_name: str) -> Any:
     lookups = attr_name.split("__")
     if related_object := getattr(db_obj, lookups.pop(0)):
         for lookup in lookups:
-            related_object = get_orm_attribute(related_object, lookup)
+            if isinstance(related_object, dict):
+                related_object = related_object.get(lookup)
+            else:
+                related_object = get_orm_attribute(related_object, lookup)
             if not related_object:
                 break
     return related_object


### PR DESCRIPTION
# Closes: #753

## What's Changed

`orm_attribute_lookup` walks an attribute path like `vlan___custom_field_data__netvs_gpk`
by splitting on `__` and following each component with `getattr`. That works for
foreign keys, but `_custom_field_data` is a Django `JSONField` whose value is a
plain `dict`, so the next iteration tries `getattr(dict, "netvs_gpk")` and raises:

\```
AttributeError: 'dict' object has no attribute 'netvs_gpk'
\```

The same failure affects the direct (root-object) form `_custom_field_data__<key>`
as well — the bug is not specific to traversal through a related object, just
more visible there.

### Fix

Inside the walk loop, check `isinstance(related_object, dict)` and use
`dict.get(lookup)` instead of `get_orm_attribute` when the previous step
yielded a dict. The check runs every iteration, so nested cases
(`fk__fk__\_custom_field_data__key`) also resolve correctly. `dict.get`
returning `None` is treated the same as a missing FK — the existing
`if not related_object: break` short-circuits the rest of the path.

### Why not change `get_orm_attribute`

`get_orm_attribute` is documented as taking a `Model` and has a test
asserting it raises for dict input. Loosening that contract would ripple
into the custom-relationship path that also calls it. Branching at the
walker level keeps the blast radius to the single loop where the dict
can actually appear.

### Before / After

Before (on develop):

\```
$ invoke unittest --label nautobot_ssot.tests.utils.test_orm.TestORMAttributeLookupCustomFields
…
ERROR: test_foreign_custom_field_lookup
…
  File "/source/nautobot_ssot/utils/orm.py", line 27, in get_orm_attribute
    raise AttributeError(err)
AttributeError: 'dict' object has no attribute 'netvs_gpk'

Ran 3 tests in 0.019s
FAILED (errors=3)
\```

After (this PR):

\```
$ invoke unittest --label nautobot_ssot.tests.utils.test_orm
Ran 37 tests in 0.195s
OK
\```


## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example  <!-- N/A — library-internal traversal, repro shown above -->
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)  <!-- N/A — no contract change -->
- [x] Outline Remaining Work, Constraints from Design  <!-- none -->