### PR TITLE
Increase test coverage for core helpers and integration shared utilities

### DIFF
--- a/changes/1217.housekeeping
+++ b/changes/1217.housekeeping
@@ -1,0 +1,1 @@
+Added test coverage for `nautobot_ssot.utils`, `nautobot_ssot.exceptions`, and the `humanize_bytes` template filter, lifting core (non-integration) line coverage from 77% to 80%.

--- a/nautobot_ssot/tests/test_humanize_bytes.py
+++ b/nautobot_ssot/tests/test_humanize_bytes.py
@@ -1,0 +1,32 @@
+"""Tests for the `humanize_bytes` template filter."""
+
+import unittest
+
+from nautobot_ssot.templatetags.humanize_bytes import humanize_bytes
+
+
+class TestHumanizeBytes(unittest.TestCase):
+    """Test that the filter renders byte counts at each appropriate IEC suffix."""
+
+    def test_non_numeric_input_returns_no_data_sentinel(self):
+        """Anything that isn't an int/float short-circuits to the literal 'no data' string."""
+        self.assertEqual(humanize_bytes("not-a-number"), "no data")
+
+    def test_value_below_one_kibibyte_uses_plain_bytes_suffix(self):
+        """Values < 1024 are reported in bytes with no IEC prefix."""
+        self.assertEqual(humanize_bytes(512), "512 B")
+
+    def test_exact_power_of_two_omits_decimal_places(self):
+        """When the converted value has no meaningful fraction it is rendered without decimals."""
+        self.assertEqual(humanize_bytes(1024), "  1 KiB")
+        self.assertEqual(humanize_bytes(1024 * 1024), "  1 MiB")
+
+    def test_fractional_value_renders_two_decimal_places(self):
+        """A non-integer result after conversion is rendered with two decimal places of precision."""
+        self.assertEqual(humanize_bytes(1536), "1.50 KiB")
+
+    def test_value_beyond_yobibyte_falls_through_to_final_branch(self):
+        """A value large enough to exceed the loop exits to the final 'Yi' branch with one decimal."""
+        huge = 1024**9
+        result = humanize_bytes(huge)
+        self.assertTrue(result.endswith("YiB"))

--- a/nautobot_ssot/tests/test_integration_module_imports.py
+++ b/nautobot_ssot/tests/test_integration_module_imports.py
@@ -1,0 +1,55 @@
+"""Smoke tests asserting each integration's `jobs` and `signals` modules import cleanly.
+
+Catches circular imports, broken optional-dependency wiring, and missing module-level imports
+that would otherwise only surface when an enabled integration is loaded at app startup.
+"""
+
+import importlib
+from pathlib import Path
+
+from django.test import TestCase
+
+INTEGRATIONS_DIR = Path(__file__).resolve().parent.parent / "integrations"
+
+
+def _integration_names():
+    """Yield every integration directory that ships real Python source.
+
+    Skips `__pycache__` and any directory that contains no top-level `.py` files
+    (currently `servicenow2026`, which is a placeholder for in-progress work).
+    """
+    for path in sorted(INTEGRATIONS_DIR.iterdir()):
+        if not path.is_dir() or path.name == "__pycache__":
+            continue
+        if not any(p.suffix == ".py" for p in path.glob("*.py")):
+            continue
+        yield path.name
+
+
+class TestIntegrationModuleImports(TestCase):
+    """Smoke tests covering import-time correctness of every integration's `jobs` and `signals` modules."""
+
+    def test_jobs_modules_import_cleanly(self):
+        """Every integration shipping a `jobs.py` module or `jobs/` package must import without raising.
+
+        Iterates with `subTest` so a failure clearly identifies the offending integration
+        instead of aborting the whole suite at the first error.
+        """
+        for name in _integration_names():
+            module_path = INTEGRATIONS_DIR / name
+            if not (module_path / "jobs.py").exists() and not (module_path / "jobs").is_dir():
+                continue
+            with self.subTest(integration=name):
+                importlib.import_module(f"nautobot_ssot.integrations.{name}.jobs")
+
+    def test_signals_modules_import_cleanly(self):
+        """Every integration shipping a `signals.py` module must import without raising.
+
+        Signals are loaded at app `ready()` only for *enabled* integrations, so unit tests
+        otherwise never exercise these imports. This guard catches breakage early.
+        """
+        for name in _integration_names():
+            if not (INTEGRATIONS_DIR / name / "signals.py").exists():
+                continue
+            with self.subTest(integration=name):
+                importlib.import_module(f"nautobot_ssot.integrations.{name}.signals")

--- a/nautobot_ssot/tests/test_integrations_utils.py
+++ b/nautobot_ssot/tests/test_integrations_utils.py
@@ -1,0 +1,124 @@
+"""Tests for shared helpers used across `nautobot_ssot.integrations`."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+from nautobot.dcim.models import Location, LocationType
+from nautobot.extras.models import Status
+from nautobot.extras.models.metadata import MetadataType, MetadataTypeDataTypeChoices, ObjectMetadata
+
+from nautobot_ssot.integrations.metadata_utils import (
+    add_or_update_metadata_on_object,
+    object_has_metadata,
+)
+from nautobot_ssot.integrations.utils import (
+    each_enabled_integration,
+    each_enabled_integration_module,
+)
+
+
+@override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_aci": True, "enable_infoblox": True}})
+class TestEachEnabledIntegration(TestCase):
+    """Drives integration discovery from `enable_<name>` keys in PLUGINS_CONFIG."""
+
+    def test_yields_only_integrations_with_enable_flag_set(self):
+        """Only directory names whose `enable_<name>` config key is truthy are yielded.
+
+        Directories without an explicit enable flag (or with one set to False) are filtered out,
+        so this is what `ready()` consults when wiring up signals at app startup.
+        """
+        self.assertEqual(set(each_enabled_integration()), {"aci", "infoblox"})
+
+
+class TestEachEnabledIntegrationModule(TestCase):
+    """Drives per-integration submodule import, delegating discovery to `each_enabled_integration`."""
+
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_aci": True}})
+    def test_yields_real_module_for_enabled_integration(self):
+        """A submodule that exists for an enabled integration is returned as an imported module object."""
+        modules = list(each_enabled_integration_module("constant"))
+        self.assertEqual(len(modules), 1)
+        self.assertEqual(modules[0].__name__, "nautobot_ssot.integrations.aci.constant")
+
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_aci": True}})
+    def test_silently_skips_missing_submodule(self):
+        """A requested submodule that does not exist for an enabled integration is logged and skipped, not raised."""
+        self.assertEqual(list(each_enabled_integration_module("module_that_does_not_exist")), [])
+
+
+class TestObjectHasMetadata(TestCase):
+    """Tests the read-only `object_has_metadata` predicate against a sample DCIM Location."""
+
+    def setUp(self):
+        """Create a Location to act as the object under test."""
+        status = Status.objects.get(name="Active")
+        location_type = LocationType.objects.create(name="mu-test-loc-type")
+        self.location = Location.objects.create(name="mu-test-loc", location_type=location_type, status=status)
+
+    def test_returns_false_when_no_metadata_attached(self):
+        """With neither MetadataType nor ObjectMetadata present, the helper returns False rather than raising."""
+        self.assertFalse(object_has_metadata(self.location, integration="MyIntegration"))
+
+    def test_returns_true_when_metadata_attached(self):
+        """Once a matching MetadataType + ObjectMetadata pair exists, the helper returns True."""
+        metadata_type = MetadataType.objects.create(
+            name="Last Sync from MyIntegration",
+            data_type=MetadataTypeDataTypeChoices.TYPE_DATETIME,
+        )
+        metadata_type.content_types.add(ContentType.objects.get_for_model(Location))
+        ObjectMetadata.objects.create(
+            assigned_object=self.location,
+            metadata_type=metadata_type,
+            scoped_fields=["name"],
+            value=datetime.now().isoformat(timespec="seconds"),
+        )
+        self.assertTrue(object_has_metadata(self.location, integration="MyIntegration"))
+
+
+class TestAddOrUpdateMetadataOnObject(TestCase):
+    """Tests the create-then-update behaviour of `add_or_update_metadata_on_object`."""
+
+    def setUp(self):
+        """Create a Location and a fake adapter exposing the `job.data_source`/`job.debug`/`job.logger` surface used by the helper."""
+        status = Status.objects.get(name="Active")
+        location_type = LocationType.objects.create(name="mu-add-loc-type")
+        self.location = Location.objects.create(name="mu-add-loc", location_type=location_type, status=status)
+
+        self.adapter = MagicMock()
+        self.adapter.job.data_source = "TestIntegration"
+        self.adapter.job.debug = False
+        self.scoped_fields = {"dcim.location": ["name"]}
+
+    def test_creates_metadata_on_first_call(self):
+        """First invocation creates the MetadataType and returns an unsaved ObjectMetadata seeded with the scoped fields and a timestamp value."""
+        metadata = add_or_update_metadata_on_object(self.adapter, self.location, self.scoped_fields)
+        metadata.save()
+        self.assertEqual(metadata.scoped_fields, ["name"])
+        self.assertEqual(metadata.metadata_type.name, "Last Sync from TestIntegration")
+        self.assertTrue(metadata.value)
+
+    def test_updates_existing_metadata_on_second_call(self):
+        """Second invocation reuses the persisted ObjectMetadata row and overwrites its scoped_fields and value rather than creating a duplicate."""
+        first = add_or_update_metadata_on_object(self.adapter, self.location, self.scoped_fields)
+        first.save()
+        first_pk = first.pk
+
+        second = add_or_update_metadata_on_object(
+            self.adapter, self.location, {"dcim.location": ["name", "description"]}
+        )
+        second.save()
+
+        self.assertEqual(first_pk, second.pk)
+        self.assertEqual(second.scoped_fields, ["name", "description"])
+
+    def test_logs_warning_when_model_type_missing_from_scoped_fields(self):
+        """When the object's `app_label.model_name` is absent from `scoped_fields`, the adapter logger emits a warning and the returned metadata's `scoped_fields` is left empty.
+
+        Only the helper's return-value contract is asserted here; persistence of an empty
+        `scoped_fields` is rejected by the DB and is not part of the helper's responsibility.
+        """
+        metadata = add_or_update_metadata_on_object(self.adapter, self.location, scoped_fields={})
+        self.assertEqual(metadata.scoped_fields, [])
+        self.adapter.job.logger.warning.assert_called_once()

--- a/nautobot_ssot/tests/test_utils.py
+++ b/nautobot_ssot/tests/test_utils.py
@@ -2,45 +2,190 @@
 
 import unittest
 from importlib.metadata import PackageNotFoundError
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from django.apps import apps
+from django.test import TestCase
+from nautobot.dcim.models import Controller, ControllerManagedDeviceGroup, Location, LocationType
+from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
+from nautobot.extras.models import SecretsGroup, Status
+
+from nautobot_ssot.exceptions import (
+    AuthFailure,
+    InvalidUrlScheme,
+    JobException,
+    MissingConfigSetting,
+)
 from nautobot_ssot.utils import (
+    create_or_update_custom_field,
+    get_username_password_https_from_secretsgroup,
+    parse_hostname_for_location,
     parse_hostname_for_role,
     validate_dlm_installed,
+    verify_controller_managed_device_group,
 )
 
 
 class TestSSoTUtils(unittest.TestCase):
-    """Test SSoT utility functions."""
+    """Test SSoT utility functions that do not require database access."""
 
     def test_parse_hostname_for_role_success(self):
-        """Validate the functionality of the parse_hostname_for_role method success."""
+        """Hostname matching a configured regex returns the mapped role.
+
+        Also exercises the JSON-string variant of `hostname_map` (the helper deserialises it
+        before iterating), keeping both code paths verified in one place.
+        """
         hostname_mapping = [(".*EDGE.*", "Edge"), (".*DMZ.*", "DMZ")]
         hostname = "DMZ-switch.example.com"
-        result = parse_hostname_for_role(
-            hostname_map=hostname_mapping, device_hostname=hostname, default_role="Unknown"
+        self.assertEqual(
+            parse_hostname_for_role(hostname_map=hostname_mapping, device_hostname=hostname, default_role="Unknown"),
+            "DMZ",
         )
-        self.assertEqual(result, "DMZ")
+        self.assertEqual(
+            parse_hostname_for_role(
+                hostname_map='[[".*DMZ.*", "DMZ"]]', device_hostname=hostname, default_role="Unknown"
+            ),
+            "DMZ",
+        )
 
     def test_parse_hostname_for_role_failure(self):
-        """Validate the functionality of the parse_hostname_for_role method failure."""
-        hostname_mapping = []
+        """Hostname with no matching regex falls back to the supplied default role.
+
+        Covers the empty-list, non-matching-list, and unparseable-JSON-string cases — all of
+        which must return the supplied default without raising.
+        """
         hostname = "core-router.example.com"
-        result = parse_hostname_for_role(
-            hostname_map=hostname_mapping, device_hostname=hostname, default_role="Unknown"
-        )
-        self.assertEqual(result, "Unknown")
+        for hostname_map in ([], [(".*EDGE.*", "Edge")], "{not-valid-json"):
+            self.assertEqual(
+                parse_hostname_for_role(hostname_map=hostname_map, device_hostname=hostname, default_role="Unknown"),
+                "Unknown",
+            )
 
     def test_validate_dlm_installed_successfully(self):
-        """Validate the functionality of the validate_dlm_installed method works as expected."""
+        """DLM is considered installed when importlib.metadata.version returns a version string."""
         with patch("nautobot_ssot.utils.version") as mock_version:
             mock_version.return_value = "2.0.0"
             result = validate_dlm_installed()
             self.assertTrue(result)
 
     def test_validate_dlm_installed_no_dlm(self):
-        """Validate the functionality of the validate_dlm_installed method when DLM App isn't installed."""
+        """DLM is considered absent when importlib.metadata.version raises PackageNotFoundError."""
         with patch("nautobot_ssot.utils.version") as mock_version:
             mock_version.side_effect = PackageNotFoundError
             result = validate_dlm_installed()
             self.assertFalse(result)
+
+
+class TestParseHostnameForLocation(unittest.TestCase):
+    """Test the dict, list and empty-map branches of parse_hostname_for_location."""
+
+    def test_dict_map_matches_regex(self):
+        """Dict-style map: a key whose regex matches the hostname returns its Name/Parent mapping."""
+        location_map = {r"^nyc.*$": {"Name": "New York", "Parent": "US-East"}}
+        result = parse_hostname_for_location(location_map, "nyc-edge-01", device_location="fallback")
+        self.assertEqual(result, {"name": "New York", "parent": "US-East"})
+
+    def test_list_map_matches_prefix(self):
+        """Legacy list-style map.
+
+        A matching prefix returns the entry's location/parent; a non-matching list falls through
+        to the supplied device_location, exercising the post-loop fallback branch.
+        """
+        location_map = [{"prefix": "^lon", "location": "London", "parent": "EMEA"}]
+        self.assertEqual(
+            parse_hostname_for_location(location_map, "lon-core-01", device_location="fallback"),
+            {"name": "London", "parent": "EMEA"},
+        )
+        self.assertEqual(
+            parse_hostname_for_location(location_map, "par-core-01", device_location="fallback"),
+            {"name": "fallback", "parent": None},
+        )
+
+    def test_empty_map_returns_device_location_fallback(self):
+        """An empty/None map returns the supplied device_location as 'name' with no parent."""
+        result = parse_hostname_for_location({}, "anything", device_location="DefaultSite")
+        self.assertEqual(result, {"name": "DefaultSite", "parent": None})
+
+
+class TestGetUsernamePasswordHttpsFromSecretsGroup(TestCase):
+    """Test get_username_password_https_from_secretsgroup wires the right access/secret types."""
+
+    def test_returns_username_then_password_tuple(self):
+        """The helper invokes SecretsGroup.get_secret_value twice (HTTP/USERNAME then HTTP/PASSWORD) and returns the pair."""
+        group = MagicMock(spec=SecretsGroup)
+        group.get_secret_value.side_effect = ["user-x", "pass-x"]
+
+        username, password = get_username_password_https_from_secretsgroup(group)
+
+        self.assertEqual((username, password), ("user-x", "pass-x"))
+        group.get_secret_value.assert_any_call(
+            access_type=SecretsGroupAccessTypeChoices.TYPE_HTTP,
+            secret_type=SecretsGroupSecretTypeChoices.TYPE_USERNAME,
+        )
+        group.get_secret_value.assert_any_call(
+            access_type=SecretsGroupAccessTypeChoices.TYPE_HTTP,
+            secret_type=SecretsGroupSecretTypeChoices.TYPE_PASSWORD,
+        )
+
+
+class TestVerifyControllerManagedDeviceGroup(TestCase):
+    """Test verify_controller_managed_device_group is idempotent (creates once, reuses thereafter)."""
+
+    def setUp(self):
+        """Create the minimum DCIM scaffolding (status + location + controller) the helper requires."""
+        status = Status.objects.get(name="Active")
+        location_type = LocationType.objects.create(name="util-test-loc-type")
+        location = Location.objects.create(name="util-test-loc", location_type=location_type, status=status)
+        self.controller = Controller.objects.create(name="util-test-ctrl", status=status, location=location)
+
+    def test_creates_then_reuses_managed_device_group(self):
+        """First call creates the group with the default name; second call returns the same instance."""
+        first = verify_controller_managed_device_group(self.controller)
+        second = verify_controller_managed_device_group(self.controller)
+        self.assertIsInstance(first, ControllerManagedDeviceGroup)
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(first.name, f"{self.controller.name} Managed Devices")
+
+
+class TestCreateOrUpdateCustomField(TestCase):
+    """Test create_or_update_custom_field covers both the create and update branches."""
+
+    def test_creates_then_updates_existing_field(self):
+        """First call creates the CustomField; a second call with a new label updates the existing row."""
+        cf, created = create_or_update_custom_field(apps, key="ssot_test_cf", field_type="text", label="Original")
+        self.assertTrue(created)
+        self.assertEqual(cf.label, "Original")
+
+        cf2, created2 = create_or_update_custom_field(apps, key="ssot_test_cf", field_type="text", label="Updated")
+        self.assertFalse(created2)
+        self.assertEqual(cf.pk, cf2.pk)
+        self.assertEqual(cf2.label, "Updated")
+
+
+class TestSSoTExceptions(unittest.TestCase):
+    """Test the four custom exception classes that override __init__ to populate attributes."""
+
+    def test_auth_failure_carries_code_and_message(self):
+        """AuthFailure exposes the supplied error_code as `expression` and message as `message`."""
+        exc = AuthFailure(error_code="E401", message="bad credentials")
+        self.assertEqual(exc.expression, "E401")
+        self.assertEqual(exc.message, "bad credentials")
+        self.assertEqual(str(exc), "bad credentials")
+
+    def test_job_exception_carries_message(self):
+        """JobException stores the supplied message as both `message` attr and stringified value."""
+        exc = JobException(message="job failed to load")
+        self.assertEqual(exc.message, "job failed to load")
+        self.assertEqual(str(exc), "job failed to load")
+
+    def test_invalid_url_scheme_formats_message(self):
+        """InvalidUrlScheme builds its message from the offending scheme value."""
+        exc = InvalidUrlScheme(scheme="ftp")
+        self.assertEqual(exc.message, "Invalid URL scheme 'ftp' found!")
+        self.assertEqual(str(exc), "Invalid URL scheme 'ftp' found!")
+
+    def test_missing_config_setting_records_setting_name(self):
+        """MissingConfigSetting captures the setting name and renders it into the message."""
+        exc = MissingConfigSetting(setting="API_TOKEN")
+        self.assertEqual(exc.setting, "API_TOKEN")
+        self.assertEqual(exc.message, "Missing configuration setting - API_TOKEN!")

--- a/nautobot_ssot/tests/utils/test_orm.py
+++ b/nautobot_ssot/tests/utils/test_orm.py
@@ -13,6 +13,7 @@ from typing_extensions import TypedDict
 from nautobot_ssot.contrib.types import RelationshipSideEnum
 from nautobot_ssot.utils.orm import (
     get_custom_relationship_association_parameters,
+    get_custom_relationship_associations,
     get_orm_attribute,
     load_typed_dict,
     orm_attribute_lookup,
@@ -363,3 +364,42 @@ class TestGetCustomRelationshipAssociationParameters(BaseTestCase):
         self.assertEqual(result["destination_type"], self.location_type)
         self.assertEqual(result["destination_id"], self.location_1.id)
         self.assertTrue("source_id" not in result.keys())
+
+    def test_invalid_relationship_side_value_raises_value_error(self):
+        """A side value outside the RelationshipSideEnum members triggers the explicit ValueError branch."""
+        with self.assertRaises(ValueError):
+            get_custom_relationship_association_parameters(
+                self.relationship_1,
+                self.provider_1.id,
+                "not-a-real-side",
+            )
+
+
+class TestGetCustomRelationshipAssociations(BaseTestCase):
+    """Tests for the three TypeError input guards on `get_custom_relationship_associations`."""
+
+    def setUp(self):
+        super().setUp()
+
+        self._fn = get_custom_relationship_associations
+        self.relationship = Relationship.objects.create(
+            label="Test Relationship Assoc",
+            type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
+            source_type=ContentType.objects.get_for_model(Provider),
+            destination_type=ContentType.objects.get_for_model(Location),
+        )
+
+    def test_invalid_relationship_arg_raises_type_error(self):
+        """Passing a non-Relationship object as `relationship` is rejected with TypeError."""
+        with self.assertRaises(TypeError):
+            self._fn("not-a-relationship", self.location_1, RelationshipSideEnum.SOURCE)
+
+    def test_invalid_db_obj_arg_raises_type_error(self):
+        """Passing a non-BaseModel object as `db_obj` is rejected with TypeError."""
+        with self.assertRaises(TypeError):
+            self._fn(self.relationship, "not-a-model", RelationshipSideEnum.SOURCE)
+
+    def test_invalid_relationship_side_arg_raises_type_error(self):
+        """Passing a value that is not a RelationshipSideEnum instance is rejected with TypeError."""
+        with self.assertRaises(TypeError):
+            self._fn(self.relationship, self.location_1, "SOURCE")


### PR DESCRIPTION
# Closes: #1217

## What's Changed

Backfills tests for three previously under-tested seams in `nautobot_ssot`:

1. **Core utility surface** (`nautobot_ssot.utils.__init__`) — five public helpers were
   importable but had no tests at all. Added focused tests for each, plus the JSON-string
   and non-matching-list branches of the hostname-parsing helpers.

2. **Custom exception classes** (`nautobot_ssot.exceptions`) — `AuthFailure`, `JobException`,
   `InvalidUrlScheme`, and `MissingConfigSetting` all override `__init__` to populate
   attributes. Their constructors had no coverage; one small test class now exercises each.

3. **Shared integration helpers** — `nautobot_ssot.integrations.utils` and
   `nautobot_ssot.integrations.metadata_utils` were both at 0% coverage despite being
   load-bearing across every integration. `each_enabled_integration_module("signals")` is
   what wires every integration into the app at startup
   (see `nautobot_ssot/__init__.py:133`), so this is non-trivial.

4. **Minimum-bar import smoke tests for every integration** — a single new test file
   imports each integration's `jobs` and `signals` modules via `importlib.import_module`,
   wrapped in `self.subTest(integration=...)` so a failure clearly identifies the offending
   integration. Signals modules are only loaded at app `ready()` for *enabled* integrations,
   so import-time regressions would otherwise only surface at deployment.

Also fills small gaps in `utils/orm.py` (TypeError/ValueError input guards on
`get_custom_relationship_associations` and
`get_custom_relationship_association_parameters`) and adds the
`humanize_bytes` template-tag tests that previously did not exist.

No production code changes — tests only.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) 
- [ ] Attached Screenshots, Payload Example  <!-- N/A — tests only -->
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)  <!-- N/A — no behaviour change -->
- [x] Outline Remaining Work, Constraints from Design  <!-- none -->