### PR TITLE
Fix Infoblox SSoT sync bug - blanking out Infoblox `comment` field when any field of nautobot Prefix object gets updated

### DIFF
--- a/changes/1211.fixed
+++ b/changes/1211.fixed
@@ -1,0 +1,1 @@
+Fixed Infoblox SSoT sync bug - blanking out Infoblox `comment` field when any field of nautobot Prefix object gets updated

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/infoblox.py
@@ -68,19 +68,20 @@ class InfobloxNetwork(Network):
             network_view_to_namespace_map=self.adapter.config.infoblox_network_view_to_namespace_map,
             direction="ns_to_nv",
         )
-        network_type = attrs.get("network_type", self.network_type)
-        if network_type != "container":
-            self.adapter.conn.update_network(
-                prefix=self.get_identifiers()["network"],
-                network_view=network_view,
-                comment=attrs.get("description", ""),
-            )
-        else:
-            self.adapter.conn.update_network_container(
-                prefix=self.get_identifiers()["network"],
-                network_view=network_view,
-                comment=attrs.get("description", ""),
-            )
+        if "description" in attrs:
+            network_type = attrs.get("network_type", self.network_type)
+            if network_type != "container":
+                self.adapter.conn.update_network(
+                    prefix=self.get_identifiers()["network"],
+                    network_view=network_view,
+                    comment=attrs.get("description", ""),
+                )
+            else:
+                self.adapter.conn.update_network_container(
+                    prefix=self.get_identifiers()["network"],
+                    network_view=network_view,
+                    comment=attrs.get("description", ""),
+                )
         if attrs.get("ranges"):
             self.adapter.job.logger.warning(
                 f"Prefix, {self.network}-{self.namespace}, has a change of Ranges in Nautobot, but"

--- a/nautobot_ssot/tests/infoblox/test_infoblox_models.py
+++ b/nautobot_ssot/tests/infoblox/test_infoblox_models.py
@@ -196,6 +196,49 @@ class TestModelInfobloxNetwork(TestCase):
             )
             mock_tag_involved_objects.assert_called_once()
 
+    @unittest.mock.patch(
+        "nautobot_ssot.integrations.infoblox.diffsync.adapters.nautobot.NautobotMixin.tag_involved_objects",
+        autospec=True,
+    )
+    def test_network_update_does_not_blank_comment_when_only_ext_attrs_change(self, mock_tag_involved_objects):
+        """Regression: when only ext_attrs differ, comment must not be blanked in Infoblox.
+
+        Reproduces the bug where `attrs.get("description", "")` in nautobot_ssot/integrations/infoblox/diffsync/models/infoblox.py
+        InfobloxNetwork.update() method returns an empty string when "description" is absent from `attrs`, clearing the Infoblox
+        comment on every sync that updates only extensible attributes or any other field other than `description`.
+        """
+        nb_network_atrs = {
+            "description": "SameDescription",
+            "ext_attrs": {"Site": "DC2"},
+        }
+        nb_ds_network = self.nb_adapter.prefix(**_get_network_dict(nb_network_atrs))
+        self.nb_adapter.add(nb_ds_network)
+        self.nb_adapter.load()
+        with unittest.mock.patch(
+            "nautobot_ssot.integrations.infoblox.utils.client.InfobloxApi", autospec=True
+        ) as mock_client:
+            infoblox_adapter = InfobloxAdapter(conn=mock_client, config=self.config)
+            inf_ds_namespace = infoblox_adapter.namespace(
+                name="Global",
+                ext_attrs={},
+            )
+            infoblox_adapter.add(inf_ds_namespace)
+            inf_network_atrs = {
+                "description": "SameDescription",
+                "ext_attrs": {"Site": "DC1"},
+            }
+            inf_ds_network = infoblox_adapter.prefix(**_get_network_dict(inf_network_atrs))
+            infoblox_adapter.add(inf_ds_network)
+            infoblox_adapter.job = Mock()
+            self.nb_adapter.sync_to(infoblox_adapter)
+            for call in infoblox_adapter.conn.update_network.call_args_list:
+                self.assertNotEqual(
+                    call.kwargs.get("comment"),
+                    "",
+                    f"update_network was called with comment='' which would blank the Infoblox comment: {call}",
+                )
+            mock_tag_involved_objects.assert_called_once()
+
 
 class TestModelInfobloxIPAddress(TestCase):
     """Tests Fixed Address record operations."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1221

## What's Changed

This should fix an annoying bug when nautobot `prefix` objects get ssot synced against Infoblox.

Any prefix field who get changed and later synced against Infoblox renders the `comment` field blank (with the exception of the Prefix `description` field).

The fix is very easy. We just check if the key `description` is inside the `attrs` dict which is passed to InfobloxNetwork.update() method. If so, we do the update, else we don't. 

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
