### PR TITLE
Add skip_component_autocreation opt-in (Phases 1-3 of SSoT feature)

### DIFF
--- a/changes/1226.added
+++ b/changes/1226.added
@@ -1,0 +1,1 @@
+Added `skip_component_autocreation` opt-in for SSoT jobs, suppressing Nautobot's automatic Device/Module component instantiation during sync.

--- a/changes/1229.housekeeping
+++ b/changes/1229.housekeeping
@@ -1,0 +1,1 @@
+Added unit tests for the `skip_component_autocreation` mechanism, end-to-end Device/Module suppression, and the `DataSyncBaseJob` job-level integration.

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from nautobot.core.settings_funcs import is_truthy
 from nautobot.extras.plugins import NautobotAppConfig
 
+from nautobot_ssot.contrib.component_autocreation import install_patches
 from nautobot_ssot.integrations.utils import each_enabled_integration_module
 
 logger = logging.getLogger("nautobot.ssot")
@@ -150,8 +151,6 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
         # the PLUGINS_CONFIG setting of the same name). See
         # nautobot_ssot/contrib/component_autocreation.py for details.
         try:
-            from nautobot_ssot.contrib.component_autocreation import install_patches
-
             install_patches()
         except Exception:  # pylint: disable=broad-except
             # Failure to install the suppression patches must never block app startup.

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -122,6 +122,7 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
         "servicenow_password": "",
         "servicenow_username": "",
         "enable_global_search": True,
+        "skip_component_autocreation": False,
     }
     config_view_name = "plugins:nautobot_ssot:config"
     docs_view_name = "plugins:nautobot_ssot:docs"
@@ -142,6 +143,19 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
                 "Sync",
                 "SyncLogEntry",
             ]
+
+        # Install the opt-in Device/Module create_components() suppression patches.
+        # The patches are inert by default and only take effect inside a
+        # skip_component_autocreation() context (driven by the job class attribute or
+        # the PLUGINS_CONFIG setting of the same name). See
+        # nautobot_ssot/contrib/component_autocreation.py for details.
+        try:
+            from nautobot_ssot.contrib.component_autocreation import install_patches
+
+            install_patches()
+        except Exception:  # pylint: disable=broad-except
+            # Failure to install the suppression patches must never block app startup.
+            logger.exception("Failed to install Device/Module component_autocreation patches.")
 
 
 config = NautobotSSOTAppConfig  # pylint:disable=invalid-name

--- a/nautobot_ssot/contrib/__init__.py
+++ b/nautobot_ssot/contrib/__init__.py
@@ -1,6 +1,10 @@
 """SSoT Contrib."""
 
 from nautobot_ssot.contrib.adapter import NautobotAdapter
+from nautobot_ssot.contrib.component_autocreation import (
+    is_suppression_active,
+    skip_component_autocreation,
+)
 from nautobot_ssot.contrib.model import NautobotModel
 from nautobot_ssot.contrib.types import (
     CustomFieldAnnotation,
@@ -14,4 +18,6 @@ __all__ = (
     "NautobotAdapter",
     "NautobotModel",
     "RelationshipSideEnum",
+    "is_suppression_active",
+    "skip_component_autocreation",
 )

--- a/nautobot_ssot/contrib/__init__.py
+++ b/nautobot_ssot/contrib/__init__.py
@@ -4,8 +4,18 @@ Keep imports in this module safe during Django startup by avoiding eager imports
 of modules that touch ORM models at import time.
 """
 
+from typing import TYPE_CHECKING
+
 from nautobot_ssot.contrib.component_autocreation import is_suppression_active, skip_component_autocreation
 from nautobot_ssot.contrib.types import CustomFieldAnnotation, CustomRelationshipAnnotation, RelationshipSideEnum
+
+if TYPE_CHECKING:
+    # Imported for static analysis only (type checkers, and mkdocstrings/griffe doc
+    # collection). These are NOT imported at runtime -- TYPE_CHECKING is False then --
+    # so Django app startup still avoids eagerly importing ORM-backed modules. At
+    # runtime the names below resolve lazily via __getattr__.
+    from nautobot_ssot.contrib.adapter import NautobotAdapter
+    from nautobot_ssot.contrib.model import NautobotModel
 
 
 def __getattr__(name):

--- a/nautobot_ssot/contrib/__init__.py
+++ b/nautobot_ssot/contrib/__init__.py
@@ -1,16 +1,25 @@
-"""SSoT Contrib."""
+"""Public exports for SSoT contrib helpers.
 
-from nautobot_ssot.contrib.adapter import NautobotAdapter
-from nautobot_ssot.contrib.component_autocreation import (
-    is_suppression_active,
-    skip_component_autocreation,
-)
-from nautobot_ssot.contrib.model import NautobotModel
-from nautobot_ssot.contrib.types import (
-    CustomFieldAnnotation,
-    CustomRelationshipAnnotation,
-    RelationshipSideEnum,
-)
+Keep imports in this module safe during Django startup by avoiding eager imports
+of modules that touch ORM models at import time.
+"""
+
+from nautobot_ssot.contrib.component_autocreation import is_suppression_active, skip_component_autocreation
+from nautobot_ssot.contrib.types import CustomFieldAnnotation, CustomRelationshipAnnotation, RelationshipSideEnum
+
+
+def __getattr__(name):
+    """Lazily load Django/ORM-dependent exports."""
+    if name == "NautobotAdapter":
+        from nautobot_ssot.contrib.adapter import NautobotAdapter  # pylint: disable=import-outside-toplevel
+
+        return NautobotAdapter
+    if name == "NautobotModel":
+        from nautobot_ssot.contrib.model import NautobotModel  # pylint: disable=import-outside-toplevel
+
+        return NautobotModel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = (
     "CustomFieldAnnotation",

--- a/nautobot_ssot/contrib/component_autocreation.py
+++ b/nautobot_ssot/contrib/component_autocreation.py
@@ -1,0 +1,180 @@
+"""Opt-in suppression of Nautobot's automatic Device/Module component instantiation.
+
+When a new ``Device`` or ``Module`` is saved, Nautobot calls
+``create_components()`` from within ``save()``, instantiating one component per
+template defined on the related ``DeviceType``/``ModuleType``. For Single
+Source of Truth (SSoT) sync jobs this is almost always undesirable: the source
+of truth owns the component inventory, and the auto-created components either
+collide with or pollute what the sync is about to write.
+
+This module exposes three opt-in mechanisms (in order of granularity):
+
+1. ``skip_component_autocreation`` -- a context manager that suppresses
+   autocreation for any code that runs inside it.
+2. A ``skip_component_autocreation = True`` class attribute on
+   :class:`nautobot_ssot.jobs.base.DataSyncBaseJob` subclasses (wired up in
+   ``jobs/base.py``).
+3. A global ``skip_component_autocreation`` flag in
+   ``PLUGINS_CONFIG["nautobot_ssot"]`` (also wired in ``jobs/base.py``).
+
+The underlying mechanism is a process-wide monkey-patch installed once at app
+startup via :func:`install_patches`. The patch wraps
+``Device.create_components`` and ``Module.create_components`` with a thin
+shim that consults a :class:`contextvars.ContextVar`. When the flag is unset
+(the default), behaviour is unchanged; when set, the wrapped method becomes a
+no-op and returns an empty list.
+
+The patch is idempotent so it is safe under Django autoreload, and stores a
+reference to the original method on the wrapper so :func:`uninstall_patches`
+can restore the unmodified behaviour (primarily useful for tests).
+"""
+
+import contextvars
+import functools
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+_skip_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "nautobot_ssot_skip_component_autocreation",
+    default=False,
+)
+
+
+class skip_component_autocreation:  # noqa: N801 — intentional lowercase, matches stdlib (suppress, nullcontext)
+    """Context manager that suppresses Device/Module component autocreation.
+
+    Inside the ``with`` block, ``Device.create_components()`` and
+    ``Module.create_components()`` become no-ops. The original behaviour is
+    restored automatically on exit, including when the block raises.
+
+    Nested usage is supported; each context manager instance saves and
+    restores its own token, so an outer ``with`` block continues to suppress
+    after an inner block exits.
+
+    Implementation uses :mod:`contextvars`, so the flag is correctly scoped
+    per asyncio task / Celery worker invocation and does not leak across
+    threads.
+
+    Example:
+        >>> from nautobot_ssot.contrib import skip_component_autocreation
+        >>> from nautobot.dcim.models import Device
+        >>> with skip_component_autocreation():
+        ...     device = Device.objects.create(...)  # no auto-components
+    """
+
+    def __init__(self):
+        """Initialize without entering the context yet."""
+        self._token: contextvars.Token | None = None
+
+    def __enter__(self):
+        """Activate suppression for the calling context."""
+        self._token = _skip_flag.set(True)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Restore the previous suppression state."""
+        if self._token is not None:
+            _skip_flag.reset(self._token)
+            self._token = None
+        # Do not suppress exceptions raised inside the with block.
+        return False
+
+
+def is_suppression_active() -> bool:
+    """Return whether component autocreation is currently suppressed.
+
+    Intended for tests and adapter code that wants to make decisions based on
+    whether it is running inside a :class:`skip_component_autocreation`
+    block. Production code should normally use the context manager directly.
+    """
+    return _skip_flag.get()
+
+
+def _build_wrapper(original):
+    """Build a wrapper around an ``alters_data`` model method.
+
+    The wrapper delegates to ``original`` unless the suppression flag is
+    active, in which case it returns an empty list and logs at DEBUG level.
+
+    Args:
+        original: The bound-method-like callable being wrapped (typically
+            ``Device.create_components`` or ``Module.create_components``).
+
+    Returns:
+        A new callable suitable for assigning back to the model class. The
+        wrapper exposes ``_ssot_wrapped = True`` and ``_ssot_original`` for
+        introspection and cleanup.
+    """
+
+    @functools.wraps(original)
+    def wrapper(self):
+        if _skip_flag.get():
+            logger.debug(
+                "SSoT suppressed create_components() for %s pk=%s",
+                type(self).__name__,
+                self.pk,
+            )
+            return []
+        return original(self)
+
+    # Django checks ``alters_data`` on methods to refuse calling them from
+    # templates. Preserve it on the wrapper so behaviour is unchanged.
+    wrapper.alters_data = True
+    wrapper._ssot_wrapped = True
+    wrapper._ssot_original = original
+    return wrapper
+
+
+def install_patches() -> None:
+    """Install the ``create_components`` wrappers on ``Device`` and ``Module``.
+
+    Called once from ``NautobotSSOTAppConfig.ready()``. Safe to call multiple
+    times -- already-wrapped methods are detected via the ``_ssot_wrapped``
+    sentinel and left alone, so Django's autoreload behaviour does not stack
+    wrappers.
+
+    Failures (e.g. Nautobot internals changed in a way the patch does not
+    understand) are logged but not raised, so app startup is never blocked by
+    this opt-in feature.
+    """
+    try:
+        # Import lazily so this module remains importable for doc generation
+        # and unit tests that do not boot a full Nautobot environment.
+        from nautobot.dcim.models import Device, Module
+    except ImportError:
+        logger.exception(
+            "Could not import nautobot.dcim.models.{Device,Module}; skip_component_autocreation will be unavailable."
+        )
+        return
+
+    for model in (Device, Module):
+        original = model.create_components
+        if getattr(original, "_ssot_wrapped", False):
+            logger.debug(
+                "%s.create_components already wrapped by SSoT; skipping.",
+                model.__name__,
+            )
+            continue
+        model.create_components = _build_wrapper(original)
+        logger.debug("Wrapped %s.create_components with SSoT suppression shim.", model.__name__)
+
+
+def uninstall_patches() -> None:
+    """Restore the original ``create_components`` methods.
+
+    Primarily intended for test teardown. Idempotent: if a method is not
+    currently wrapped by this app, it is left alone.
+    """
+    try:
+        from nautobot.dcim.models import Device, Module
+    except ImportError:
+        return
+
+    for model in (Device, Module):
+        current = model.create_components
+        original = getattr(current, "_ssot_original", None)
+        if original is not None:
+            model.create_components = original
+            logger.debug("Restored original %s.create_components.", model.__name__)

--- a/nautobot_ssot/contrib/component_autocreation.py
+++ b/nautobot_ssot/contrib/component_autocreation.py
@@ -42,7 +42,7 @@ _skip_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
 )
 
 
-class skip_component_autocreation:  # noqa: N801 — intentional lowercase, matches stdlib (suppress, nullcontext)
+class skip_component_autocreation:  # noqa: N801 — intentional lowercase, matches stdlib (suppress, nullcontext)  # pylint: disable=C0103
     """Context manager that suppresses Device/Module component autocreation.
 
     Inside the ``with`` block, ``Device.create_components()`` and
@@ -122,8 +122,8 @@ def _build_wrapper(original):
     # Django checks ``alters_data`` on methods to refuse calling them from
     # templates. Preserve it on the wrapper so behaviour is unchanged.
     wrapper.alters_data = True
-    wrapper._ssot_wrapped = True
-    wrapper._ssot_original = original
+    wrapper._ssot_wrapped = True  # pylint: disable=protected-access
+    wrapper._ssot_original = original  # pylint: disable=protected-access
     return wrapper
 
 
@@ -142,7 +142,7 @@ def install_patches() -> None:
     try:
         # Import lazily so this module remains importable for doc generation
         # and unit tests that do not boot a full Nautobot environment.
-        from nautobot.dcim.models import Device, Module
+        from nautobot.dcim.models import Device, Module  # pylint: disable=import-outside-toplevel
     except ImportError:
         logger.exception(
             "Could not import nautobot.dcim.models.{Device,Module}; skip_component_autocreation will be unavailable."
@@ -168,7 +168,7 @@ def uninstall_patches() -> None:
     currently wrapped by this app, it is left alone.
     """
     try:
-        from nautobot.dcim.models import Device, Module
+        from nautobot.dcim.models import Device, Module  # pylint: disable=import-outside-toplevel
     except ImportError:
         return
 

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -1,6 +1,7 @@
 # pylint: disable=protected-access
 """Base Job classes for sync workers."""
 
+import functools
 import logging
 import threading
 import traceback
@@ -28,7 +29,38 @@ from nautobot.extras.models import JobLogEntry, JobResult
 
 from nautobot_ssot.choices import SyncLogEntryActionChoices
 from nautobot_ssot.contrib.adapter import NautobotAdapter
+from nautobot_ssot.contrib.component_autocreation import skip_component_autocreation
 from nautobot_ssot.models import BaseModel, Sync, SyncLogEntry
+
+
+def _maybe_suppress_component_autocreation(func):
+    """Wrap a ``sync_data``-style method to honour the ``skip_component_autocreation`` opt-in.
+
+    The wrapped method runs inside a :class:`skip_component_autocreation` context when either:
+
+    * the instance's ``skip_component_autocreation`` class attribute is True, or
+    * ``PLUGINS_CONFIG["nautobot_ssot"]["skip_component_autocreation"]`` is True.
+
+    Either source set to True opts in (OR semantics). When neither is set the wrapped method
+    runs unchanged, preserving historical behaviour.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        suppress = bool(getattr(self, "skip_component_autocreation", False)) or settings.PLUGINS_CONFIG.get(
+            "nautobot_ssot", {}
+        ).get("skip_component_autocreation", False)
+        if suppress:
+            self.logger.info(
+                "skip_component_autocreation=True: Nautobot Device/Module automatic component "
+                "instantiation will be suppressed for the duration of this sync."
+            )
+            with skip_component_autocreation():
+                return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
 
 DataMapping = namedtuple("DataMapping", ["source_name", "source_url", "target_name", "target_url"])
 """Entry in the list returned by a job's data_mappings() API.
@@ -111,7 +143,16 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
       - `dryrun_default` - defaults to True if unspecified
       - `data_source` and `data_target` as labels (by default, will use the `name` and/or "Nautobot" as appropriate)
       - `data_source_icon` and `data_target_icon`
+      - `skip_component_autocreation` - if True, Nautobot's automatic Device/Module component
+        instantiation is suppressed for the duration of `sync_data()`. Defaults to False. Can
+        also be enabled globally via `PLUGINS_CONFIG["nautobot_ssot"]["skip_component_autocreation"]`;
+        either source set to True opts in. See `nautobot_ssot.contrib.component_autocreation`.
     """
+
+    # Opt-in: suppress Nautobot's automatic Device/Module component instantiation during sync_data().
+    # Resolved together with the PLUGINS_CONFIG setting of the same name (OR semantics) by the
+    # _maybe_suppress_component_autocreation decorator applied to sync_data().
+    skip_component_autocreation: bool = False
 
     dryrun = DryRunVar(
         description="Perform a dry-run, making no actual changes to Nautobot data.",
@@ -335,6 +376,7 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
 
         return source_adapter, target_adapter, source_duration, target_duration
 
+    @_maybe_suppress_component_autocreation
     def sync_data(self, memory_profiling):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
         """Method to load data from adapters, calculate diffs and sync (if not dry-run).
 

--- a/nautobot_ssot/jobs/examples.py
+++ b/nautobot_ssot/jobs/examples.py
@@ -25,7 +25,7 @@ from nautobot.extras.secrets.exceptions import SecretError
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
 
-from nautobot_ssot.contrib import NautobotAdapter, NautobotModel
+from nautobot_ssot.contrib import NautobotAdapter, NautobotModel  # pylint: disable=no-name-in-module
 from nautobot_ssot.contrib.typeddicts import TagDict
 from nautobot_ssot.exceptions import MissingSecretsGroupException
 from nautobot_ssot.jobs.base import DataMapping, DataSource, DataTarget

--- a/nautobot_ssot/tests/test_component_autocreation.py
+++ b/nautobot_ssot/tests/test_component_autocreation.py
@@ -1,0 +1,283 @@
+"""Tests for the skip_component_autocreation opt-in (Phases 1 & 2).
+
+Covers three layers:
+
+* The underlying mechanism (`nautobot_ssot.contrib.component_autocreation`): patch
+  installation, idempotency, context-manager semantics, and ContextVar isolation.
+* End-to-end suppression of Nautobot Device/Module component instantiation.
+* Job-level integration via `DataSyncBaseJob` (class attribute + PLUGINS_CONFIG setting).
+"""
+
+import os.path
+import threading
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+from nautobot.core.testing import TestCase, TransactionTestCase
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    InterfaceTemplate,
+    Location,
+    LocationType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+)
+from nautobot.extras.models import JobResult, Role, Status
+
+from nautobot_ssot.contrib import is_suppression_active, skip_component_autocreation
+from nautobot_ssot.contrib.component_autocreation import install_patches, uninstall_patches
+from nautobot_ssot.tests.jobs import DataSyncBaseJob
+
+
+def _status_for(model):
+    """Return a Status valid for ``model``, creating one if none is associated."""
+    status = Status.objects.get_for_model(model).first()
+    if status is None:
+        status = Status.objects.create(name=f"{model.__name__} Test Status")
+        status.content_types.add(ContentType.objects.get_for_model(model))
+    return status
+
+
+class ComponentAutocreationMechanismTestCase(TestCase):
+    """Unit tests for the patch installer and the context manager."""
+
+    def test_patches_installed_on_models(self):
+        """install_patches() (run at app ready) wraps both Device and Module."""
+        self.assertTrue(getattr(Device.create_components, "_ssot_wrapped", False))
+        self.assertTrue(getattr(Module.create_components, "_ssot_wrapped", False))
+
+    def test_patches_idempotent(self):
+        """Re-running install_patches() does not stack wrappers."""
+        before_device = Device.create_components
+        before_module = Module.create_components
+        install_patches()
+        self.assertIs(Device.create_components, before_device)
+        self.assertIs(Module.create_components, before_module)
+
+    def test_wrapper_preserves_alters_data(self):
+        """The wrapper keeps Django's template-safety ``alters_data`` flag."""
+        self.assertTrue(getattr(Device.create_components, "alters_data", False))
+        self.assertTrue(getattr(Module.create_components, "alters_data", False))
+
+    def test_wrapper_exposes_original(self):
+        """The wrapper stores the original callable for rollback/introspection."""
+        self.assertTrue(callable(getattr(Device.create_components, "_ssot_original", None)))
+        self.assertTrue(callable(getattr(Module.create_components, "_ssot_original", None)))
+
+    def test_uninstall_then_reinstall_restores_wrapper(self):
+        """uninstall_patches() restores originals; install_patches() re-wraps."""
+        original = Device.create_components._ssot_original
+        try:
+            uninstall_patches()
+            self.assertIs(Device.create_components, original)
+            self.assertFalse(getattr(Device.create_components, "_ssot_wrapped", False))
+        finally:
+            # Always leave the patches installed so we don't affect other tests.
+            install_patches()
+        self.assertTrue(getattr(Device.create_components, "_ssot_wrapped", False))
+
+    def test_context_manager_inactive_by_default(self):
+        """Suppression is off unless explicitly entered."""
+        self.assertFalse(is_suppression_active())
+
+    def test_context_manager_activates_and_restores(self):
+        """The flag is set inside the block and cleared on exit."""
+        with skip_component_autocreation():
+            self.assertTrue(is_suppression_active())
+        self.assertFalse(is_suppression_active())
+
+    def test_context_manager_nested(self):
+        """An outer block keeps suppressing after an inner block exits."""
+        with skip_component_autocreation():
+            with skip_component_autocreation():
+                self.assertTrue(is_suppression_active())
+            self.assertTrue(is_suppression_active())
+        self.assertFalse(is_suppression_active())
+
+    def test_context_manager_exception_safe(self):
+        """An exception inside the block still restores the previous state."""
+        with self.assertRaises(RuntimeError):
+            with skip_component_autocreation():
+                self.assertTrue(is_suppression_active())
+                raise RuntimeError("boom")
+        self.assertFalse(is_suppression_active())
+
+    def test_contextvar_isolated_across_threads(self):
+        """Suppression in one thread does not leak into a separately spawned thread."""
+        captured = {}
+
+        def worker():
+            captured["value"] = is_suppression_active()
+
+        with skip_component_autocreation():
+            self.assertTrue(is_suppression_active())
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+
+        # A freshly spawned thread starts with its own (default) context.
+        self.assertFalse(captured["value"])
+
+
+class ComponentAutocreationModelTestCase(TestCase):
+    """End-to-end tests that real Device/Module component creation is suppressed."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Build a DeviceType and ModuleType that each define interface templates."""
+        cls.manufacturer = Manufacturer.objects.create(name="SSoT Test Manufacturer")
+
+        cls.device_type = DeviceType.objects.create(manufacturer=cls.manufacturer, model="SSoT Test Model")
+        for name in ("eth0", "eth1"):
+            InterfaceTemplate.objects.create(
+                device_type=cls.device_type,
+                name=name,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+
+        cls.module_type = ModuleType.objects.create(manufacturer=cls.manufacturer, model="SSoT Test Module")
+        InterfaceTemplate.objects.create(
+            module_type=cls.module_type,
+            name="mod-eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cls.location_type = LocationType.objects.create(name="SSoT Test Location Type")
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.location = Location.objects.create(
+            name="SSoT Test Location",
+            location_type=cls.location_type,
+            status=_status_for(Location),
+        )
+
+        cls.device_role = Role.objects.create(name="SSoT Test Role")
+        cls.device_role.content_types.add(ContentType.objects.get_for_model(Device))
+
+        cls.device_status = _status_for(Device)
+        cls.module_status = _status_for(Module)
+
+    def _create_device(self, name):
+        return Device.objects.create(
+            device_type=self.device_type,
+            role=self.device_role,
+            status=self.device_status,
+            name=name,
+            location=self.location,
+        )
+
+    def _create_module(self, device, bay_name):
+        module_bay = ModuleBay.objects.create(parent_device=device, name=bay_name, position=bay_name)
+        return Module.objects.create(
+            module_type=self.module_type,
+            parent_module_bay=module_bay,
+            status=self.module_status,
+        )
+
+    def test_device_components_created_by_default(self):
+        """Without opting in, a new Device still gets its template components."""
+        device = self._create_device("default-device")
+        self.assertEqual(device.interfaces.count(), 2)
+
+    def test_device_components_suppressed_in_context(self):
+        """Inside the context manager, a new Device gets no auto components."""
+        with skip_component_autocreation():
+            device = self._create_device("suppressed-device")
+        self.assertEqual(device.interfaces.count(), 0)
+
+    def test_module_components_created_by_default(self):
+        """Without opting in, a new Module still gets its template components."""
+        device = self._create_device("module-parent-default")
+        module = self._create_module(device, "bay-default")
+        self.assertEqual(module.interfaces.count(), 1)
+
+    def test_module_components_suppressed_in_context(self):
+        """Inside the context manager, a new Module gets no auto components."""
+        device = self._create_device("module-parent-suppressed")
+        with skip_component_autocreation():
+            module = self._create_module(device, "bay-suppressed")
+        self.assertEqual(module.interfaces.count(), 0)
+
+
+@override_settings(JOBS_ROOT=os.path.join(os.path.dirname(__file__), "jobs"))
+class SkipComponentAutocreationJobTestCase(TransactionTestCase):
+    """Tests for the DataSyncBaseJob.sync_data() integration."""
+
+    databases = (
+        "default",
+        "job_logs",
+    )
+
+    def _run_recording_job(self, job_class):
+        """Run ``job_class`` (dry-run) and return the instance after completion."""
+        job = job_class()
+        job.job_result = JobResult.objects.create(
+            name="skip-component-autocreation-test",
+            task_name="skip-component-autocreation-test",
+            worker="default",
+        )
+        job.run(dryrun=True, memory_profiling=False)
+        return job
+
+    @staticmethod
+    def _make_recording_job(**attrs):
+        """Build a DataSyncBaseJob subclass that records suppression state during the sync."""
+
+        class _RecordingJob(DataSyncBaseJob):
+            def __init__(self):
+                super().__init__()
+                self.suppression_during_sync = None
+
+            def load_source_adapter(self):
+                # Runs inside sync_data(); capture whether suppression is active here.
+                self.suppression_during_sync = is_suppression_active()
+
+            def load_target_adapter(self):
+                pass
+
+        for key, value in attrs.items():
+            setattr(_RecordingJob, key, value)
+        return _RecordingJob
+
+    def test_default_no_suppression(self):
+        """A job without opting in does not suppress autocreation during sync."""
+        job = self._run_recording_job(self._make_recording_job())
+        self.assertFalse(job.suppression_during_sync)
+        self.assertFalse(is_suppression_active())
+
+    def test_class_attribute_opt_in(self):
+        """`skip_component_autocreation = True` on the job suppresses during sync."""
+        job = self._run_recording_job(self._make_recording_job(skip_component_autocreation=True))
+        self.assertTrue(job.suppression_during_sync)
+        self.assertFalse(is_suppression_active())
+
+    def test_settings_opt_in(self):
+        """The PLUGINS_CONFIG flag suppresses even without the class attribute."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_component_autocreation": True}):
+            job = self._run_recording_job(self._make_recording_job())
+        self.assertTrue(job.suppression_during_sync)
+        self.assertFalse(is_suppression_active())
+
+    def test_or_semantics_attribute_true_setting_false(self):
+        """Class attribute True with the setting False still suppresses (OR semantics)."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_component_autocreation": False}):
+            job = self._run_recording_job(self._make_recording_job(skip_component_autocreation=True))
+        self.assertTrue(job.suppression_during_sync)
+
+    def test_suppression_released_between_sequential_runs(self):
+        """Suppression is scoped per run; a suppressing run does not leak into the next.
+
+        This is the per-invocation isolation property that keeps the feature safe under
+        Celery worker reuse (a worker process handling many jobs in sequence).
+        """
+        suppressing = self._run_recording_job(self._make_recording_job(skip_component_autocreation=True))
+        self.assertTrue(suppressing.suppression_during_sync)
+        self.assertFalse(is_suppression_active())
+
+        following = self._run_recording_job(self._make_recording_job())
+        self.assertFalse(following.suppression_during_sync)


### PR DESCRIPTION
# Closes: #1227, #1228, #1229 (parent: #1226)

## What's Changed

Implements **Phases 1–3** of the `skip_component_autocreation` feature (see #1226 for the full feature request and phase breakdown). SSoT jobs can now opt in to suppressing Nautobot's automatic `Device.create_components()` / `Module.create_components()` calls during a sync.

When a `Device` or `Module` is created in Nautobot, `save()` unconditionally instantiates one component per template defined on the related `DeviceType`/`ModuleType`. For SSoT this is almost always undesirable — the source of truth owns the component inventory, and the auto-created components either collide with or pollute what the sync is about to write.

### Phase 1 — Core mechanism (#1227)

- **`nautobot_ssot/contrib/component_autocreation.py`** *(new)* — exposes:
  - `skip_component_autocreation` — class-based context manager (reentrant, exception-safe, `contextvars`-backed).
  - `is_suppression_active()` — helper for tests and adapter code.
  - `install_patches()` / `uninstall_patches()` — idempotent monkey-patch installers that wrap `Device.create_components` and `Module.create_components` with a delegating shim. Preserves `alters_data = True`, stores `_ssot_wrapped` / `_ssot_original` sentinels for introspection and rollback.
- **`nautobot_ssot/__init__.py`** — adds `skip_component_autocreation: False` to `default_settings` and calls `install_patches()` from `AppConfig.ready()` inside a broad try/except so a patch failure never blocks app startup.
- **`nautobot_ssot/contrib/__init__.py`** — re-exports the new public API; lazy-loads the ORM-dependent `NautobotAdapter` / `NautobotModel` via module `__getattr__` so importing the contrib namespace during Django startup does not eagerly import ORM models.

### Phase 2 — Job-level integration (#1228)

- **`nautobot_ssot/jobs/base.py`**:
  - Adds `skip_component_autocreation: bool = False` class attribute on `DataSyncBaseJob` (documented in the class docstring).
  - Adds the `_maybe_suppress_component_autocreation` decorator and applies it to `sync_data()`. The decorator resolves the effective flag as the class attribute **OR** `PLUGINS_CONFIG["nautobot_ssot"]["skip_component_autocreation"]` (either source set to `True` opts in) and, when set, runs the entire `sync_data()` body inside the `skip_component_autocreation()` context manager. Decorating rather than re-indenting keeps the `sync_data()` body unchanged for review.
- **`nautobot_ssot/jobs/examples.py`** — silences pylint `no-name-in-module` for the now lazily-exported contrib names.

### Why a monkey-patch?

`create_components()` is called unconditionally inside `Device.save()` / `Module.save()` in Nautobot core, with no signal, setting, or hook gating it. `bulk_create()` is used internally so `post_save` listeners on components can't intercept it either. The monkey-patch is the only reachable extension point today. Phase 6 (#1232) tracks proposing a proper upstream hook in `nautobot/nautobot`, after which this app will feature-detect and deprecate the patch path.

### Opt-in API (three levels)

```python
# 1. Context manager — arbitrary code
from nautobot_ssot.contrib import skip_component_autocreation
from nautobot.dcim.models import Device

with skip_component_autocreation():
    Device.objects.create(...)   # no auto-instantiated components

# 2. Job class attribute — recommended
from nautobot_ssot.jobs import DataTarget

class MyDataTarget(DataTarget):
    skip_component_autocreation = True

# 3. Global setting — operator-wide
# PLUGINS_CONFIG["nautobot_ssot"]["skip_component_autocreation"] = True
```

### Verified locally

- `ruff check` / `ruff format --check` clean on all changed files.
- AST parse of all changed Python files.
- Standalone smoke test of the Phase 1 module via `importlib`: context-manager default off, nested correctly, exception-safe, wrapper delegates when off and returns `[]` when on, `alters_data`/`_ssot_wrapped`/`_ssot_original` set on wrapper, `install_patches()` logs and returns gracefully when `nautobot.dcim` is unimportable.
- Standalone test of the Phase 2 decorator's OR-semantics truth table (4/4 cases), suppression released after `sync_data()` returns, and INFO-log gating matched to suppression.
- Full suite run against the SSoT dev stack: 19 new tests pass; existing `test_jobs.py` (75 tests) unaffected.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1226.added`)
- [ ] Attached Screenshots, Payload Example — N/A (no UI/API surface)
- [x] Unit, Integration Tests — **Phase 3** (#1229): `nautobot_ssot/tests/test_component_autocreation.py` (19 tests) covers the mechanism, end-to-end Device/Module suppression, and the job-level integration. Existing `test_jobs.py` (75 tests) still passes.
- [ ] Documentation Updates — **Phase 4** (#1230, separate PR).
- [ ] Phase 5 — release prep (#1231).
- [ ] Phase 6 — upstream Nautobot core hook (#1232).

## Reviewer Notes

- Default behaviour is unchanged: with neither the class attribute nor the setting enabled, `sync_data()` runs exactly as before, and the patched `create_components` delegates to the original.
- `_maybe_suppress_component_autocreation` is applied to the base `sync_data()`. Subclasses that fully override `sync_data()` without calling `super()` should use the `skip_component_autocreation()` context manager directly — documented in Phase 4.
- `install_patches()` is idempotent and tolerant of import failures, so it is safe under Django autoreload and minimal/headless test environments.
- `ContextVar` (not `threading.local`) is deliberate — it isolates correctly under asyncio tasks and Celery workers, including under `CELERY_TASK_ALWAYS_EAGER=True`.




## Upstream coordination

An upstream feature request for a public extension point has been filed in Nautobot core: nautobot/nautobot#9026. The core team has asked for the core integration to land first, with SSoT then implementing consumer-side support that feature-detects the upstream symbol. The disposition of this PR (hold as draft, close in favour of a fresh consumer-side PR after #9026 lands, or merge as-is with a deprecation path) is to be confirmed by the maintainers.
