### PR TITLE
Fixed vSphere crashes

### DIFF
--- a/changes/+vsphere.fixed
+++ b/changes/+vsphere.fixed
@@ -1,0 +1,2 @@
+Fixed vSphere SSoT `sync_complete` raising `IPAddress.DoesNotExist` when a primary IP was not present in Nautobot.
+Fixed vSphere SSoT `VirtualMachineModel.update` omitting `cluster__name` from the lookup used in `sync_complete`.

--- a/changes/1236.fixed
+++ b/changes/1236.fixed
@@ -1,0 +1,1 @@
+Fixed vSphere SSoT source load crashing when vSphere contains duplicate VM names within a cluster.

--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_nautobot.py
@@ -56,7 +56,10 @@ class NBAdapter(NautobotAdapter):
                 continue
             for ip in ["primary_ip4", "primary_ip6"]:
                 if info[ip]:
-                    setattr(vm, ip, IPAddress.objects.get(host=info[ip]))
+                    try:
+                        setattr(vm, ip, IPAddress.objects.get(host=info[ip]))
+                    except IPAddress.DoesNotExist:
+                        self.job.logger.warning(f"IPAddress {info[ip]} not found for {vm}, skipping {ip} assignment.")
             try:
                 vm.validated_save()
             except ValidationError as err:

--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_vsphere.py
@@ -122,7 +122,7 @@ class VsphereDiffSync(Adapter):
             diffsync_cluster (ClusterModel): Current DiffSync Cluster object.
             cluster_name (str): Name of the cluster to which the VM belongs.
         """
-        diffsync_virtualmachine, _ = self.get_or_instantiate(
+        diffsync_virtualmachine, created = self.get_or_instantiate(
             self.virtual_machine,
             {"name": virtual_machine.get("name"), "cluster__name": cluster_name},
             {
@@ -135,6 +135,13 @@ class VsphereDiffSync(Adapter):
                 "tags": tags,
             },
         )
+        # vSphere allows duplicate VM names within a cluster, but Nautobot has a uniqueness constraint on cluster,
+        # tenant (not applicable here), and name. If it wasn't created via get_or_instantiate, we can assume it's a duplicate.
+        if not created:
+            self.job.logger.warning(
+                f"Duplicate Virtual Machine name '{virtual_machine.get('name')}' found in cluster '{cluster_name}'. Skipping duplicate VM."
+            )
+            return
         self.load_vm_interfaces(
             vsphere_virtual_machine_details=virtual_machine_details,
             vm_id=virtual_machine["vm"],

--- a/nautobot_ssot/integrations/vsphere/diffsync/models/vsphere.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/models/vsphere.py
@@ -275,7 +275,7 @@ class VirtualMachineModel(vSphereModelDiffSync):
         if attrs.get("primary_ip4__host") or attrs.get("primary_ip6__host"):
             self.adapter._primary_ips.append(
                 {
-                    "device": {"name": self.name},
+                    "device": {"name": self.name, "cluster__name": self.cluster__name},
                     "primary_ip4": attrs.pop("primary_ip4__host", None),
                     "primary_ip6": attrs.pop("primary_ip6__host", None),
                 }

--- a/nautobot_ssot/tests/vsphere/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/vsphere/test_nautobot_adapter.py
@@ -205,6 +205,28 @@ class TestNautobotAdapter(TestCase):  # pylint: disable=too-many-instance-attrib
             f"VirtualMachine not found for {missing_device}, skipping primary IP assignment."
         )
 
+    def test_sync_complete_ipaddress_not_found_logs_warning(self):
+        """sync_complete logs a warning and skips when the primary IP does not exist in Nautobot."""
+        adapter = self._make_adapter()
+        adapter._primary_ips = [
+            {
+                "device": {"name": "Test VM", "cluster__name": "Test Cluster"},
+                "primary_ip4": "203.0.113.1",
+                "primary_ip6": None,
+            }
+        ]
+
+        adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+
+        self.test_virtualmachine.refresh_from_db()
+        self.assertIsNone(self.test_virtualmachine.primary_ip4)
+        warning_calls = [
+            call_args
+            for call_args in adapter.job.logger.warning.call_args_list
+            if "IPAddress 203.0.113.1 not found" in call_args.args[0]
+        ]
+        self.assertEqual(len(warning_calls), 1)
+
     def test_sync_complete_empty_primary_ips(self):
         """sync_complete does nothing and logs no warnings when _primary_ips is empty."""
         adapter = self._make_adapter()

--- a/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
@@ -166,7 +166,6 @@ class TestVsphereAdapter(unittest.TestCase):
             if "Duplicate Virtual Machine name 'DuplicateNamedVM'" in call_args.args[0]
         ]
         self.assertEqual(len(warning_calls), 1)
-        self.assertIn("vm-200", warning_calls[0].args[0])
 
     def test_load_vm_interfaces(self):
         vm_detail_json = json_fixture(f"{FIXTURES}/vm_details_nautobot.json")["value"]

--- a/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_adapter.py
@@ -121,6 +121,53 @@ class TestVsphereAdapter(unittest.TestCase):
         self.assertEqual(len(vm2.tags), 1)
         self.assertIn("SSoT Synced from vSphere", [tag["name"] for tag in vm2.tags])
 
+    def test_load_virtualmachines_skips_duplicate_name(self):
+        """Duplicate VM names within a cluster are warned and skipped instead of crashing.
+
+        Regression test #1236. vSphere allows multiple VMs with the same name in a cluster,
+        but Nautobot's VirtualMachine is unique on (cluster, tenant, name). Before
+        this guard, the second same-named VM resolved to the existing diffsync VM and
+        load_vm_interfaces raised ObjectAlreadyExists on add_child.
+        """
+        self.vsphere_adapter.client.get_vms_from_cluster.return_value = self.resp_with_json(
+            f"{FIXTURES}/get_vms_from_cluster_duplicate.json"
+        )
+
+        mock_response_vm_details = unittest.mock.MagicMock()
+        mock_response_vm_details.json.side_effect = [
+            json_fixture(f"{FIXTURES}/vm_details_nautobot.json"),
+            json_fixture(f"{FIXTURES}/vm_details_nautobot.json"),
+        ]
+        self.vsphere_adapter.client.get_vm_details.return_value = mock_response_vm_details
+
+        mock_response_get_vm_interfaces = unittest.mock.MagicMock()
+        mock_response_get_vm_interfaces.json.side_effect = [
+            json_fixture(f"{FIXTURES}/get_vm_interfaces.json"),
+        ]
+        self.vsphere_adapter.client.get_vm_interfaces.return_value = mock_response_get_vm_interfaces
+
+        cluster_json_info = {"cluster": "domain-c123", "name": "HeshLawCluster"}
+        diffsync_cluster, _ = self.vsphere_adapter.get_or_instantiate(
+            self.vsphere_adapter.cluster,
+            {"name": "HeshLawCluster", "cluster_type__name": "VMWare vSphere"},
+        )
+
+        self.vsphere_adapter.load_virtualmachines(cluster_json_info, diffsync_cluster)
+
+        vms = [
+            vm
+            for vm in self.vsphere_adapter.get_all("virtual_machine")
+            if vm.name == "DuplicateNamedVM" and vm.cluster__name == "HeshLawCluster"
+        ]
+        self.assertEqual(len(vms), 1)
+        warning_calls = [
+            call_args
+            for call_args in self.vsphere_adapter.job.logger.warning.call_args_list
+            if "Duplicate Virtual Machine name 'DuplicateNamedVM'" in call_args.args[0]
+        ]
+        self.assertEqual(len(warning_calls), 1)
+        self.assertIn("vm-200", warning_calls[0].args[0])
+
     def test_load_vm_interfaces(self):
         vm_detail_json = json_fixture(f"{FIXTURES}/vm_details_nautobot.json")["value"]
         diffsync_vm, _ = self.vsphere_adapter.get_or_instantiate(

--- a/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_update.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_update.py
@@ -489,6 +489,47 @@ class TestVSphereDiffSyncModelsUpdate(TestCase):
         self.assertEqual(nb_vm.name, "TestVM")
         self.assertEqual(nb_vm.primary_ip.host, "2001:db8:abcd:42::abcd")
 
+    def test_vm_update_primary_ips_dict_includes_cluster(self):
+        """VirtualMachineModel.update appends a _primary_ips entry whose device dict includes cluster__name.
+
+        Without cluster__name, sync_complete's VirtualMachine.objects.get(**info["device"])
+        can raise MultipleObjectsReturned (or update the wrong VM) when vSphere contains
+        duplicate VM names. The dict must mirror what create() builds from ids.
+        """
+        nb_clustergroup, _ = ClusterGroup.objects.get_or_create(name="TestClusterGroup")
+        nb_clustertype, _ = ClusterType.objects.get_or_create(name="VMWare vSphere")
+        nb_cluster = Cluster.objects.create(
+            name="TestCluster",
+            cluster_group=nb_clustergroup,
+            cluster_type=nb_clustertype,
+        )
+        nb_vm = VirtualMachine.objects.create(
+            name="TestVM",
+            status=self.active_status,
+            vcpus=1,
+            memory=1,
+            disk=1,
+            cluster=nb_cluster,
+        )
+        nb_vm.tags.set([self.ssot_tag])
+
+        nb_adapter = NBAdapter(config=self.config, cluster_filters=None)
+        nb_adapter.job = MagicMock()
+        nb_adapter.load()
+
+        diffsync_vm = nb_adapter.get(
+            self.vsphere_adapter.virtual_machine,
+            {"name": "TestVM", "cluster__name": "TestCluster"},
+        )
+
+        diffsync_vm.update({"primary_ip4__host": "192.168.1.1", "primary_ip6__host": None})
+
+        self.assertEqual(len(nb_adapter._primary_ips), 1)  # pylint: disable=protected-access
+        self.assertEqual(
+            nb_adapter._primary_ips[0]["device"],  # pylint: disable=protected-access
+            {"name": "TestVM", "cluster__name": "TestCluster"},
+        )
+
     def test_tag_update(self):
         tag, _ = Tag.objects.get_or_create(name="Owner__EEE", description="")
         tag.content_types.set([ContentType.objects.get_for_model(VirtualMachine)])

--- a/nautobot_ssot/tests/vsphere/vsphere_fixtures/get_vms_from_cluster_duplicate.json
+++ b/nautobot_ssot/tests/vsphere/vsphere_fixtures/get_vms_from_cluster_duplicate.json
@@ -1,0 +1,18 @@
+{
+   "value":[
+      {
+         "memory_size_MiB":4096,
+         "vm":"vm-100",
+         "name":"DuplicateNamedVM",
+         "power_state":"POWERED_ON",
+         "cpu_count":2
+      },
+      {
+         "memory_size_MiB":4096,
+         "vm":"vm-200",
+         "name":"DuplicateNamedVM",
+         "power_state":"POWERED_ON",
+         "cpu_count":2
+      }
+   ]
+}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1236

## What's Changed

This PR fixes the following items:
- Duplicate VMs with the same name are now logged and skipped
- Added a try/except in `sync_complete` method to guard against missing IP Addresses
- Added the cluster name to the update method to guard against duplicate VMs in separate clusters

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5574