### PR TITLE
Resolve KeyError with LibreNMS IP's

### DIFF
--- a/changes/1238.fixed
+++ b/changes/1238.fixed
@@ -1,0 +1,1 @@
+Resolve KeyError in LibreNMS if IP is missing.

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
@@ -934,7 +934,6 @@ class BootstrapAdapter(Adapter, LabelMixin):
         """Load ScheduledJob objects from Bootstrap into DiffSync Models."""
         if self.job.debug:
             self.job.logger.debug(f"Loading Bootstrap ScheduledJob {scheduled_job}")
-        print(f"\n\n\nHUHUHWHAT: {scheduled_job=}")
         scheduled_job = self.load_branch_values(item_type="scheduled_job", original_item=scheduled_job)
         try:
             self.get(self.scheduled_job, scheduled_job["name"])

--- a/nautobot_ssot/integrations/librenms/utils/librenms.py
+++ b/nautobot_ssot/integrations/librenms/utils/librenms.py
@@ -172,7 +172,7 @@ class LibreNMSApi(ApiEndpoint):  # pylint: disable=too-few-public-methods
             ipaddress_ip_interface = ipaddress.ip_address(ip_address)
             if isinstance(ipaddress_ip_interface, ipaddress.IPv4Address):
                 for ipv4_address in device_ips["addresses"]:
-                    if ipv4_address["ipv4_address"] == ip_address:
+                    if ipv4_address.get("ipv4_address") == ip_address:
                         ip_network_info = ipaddress.ip_interface(f"{ip_address}/24")
                         ip_address_info = ipaddress.ip_interface(f"{ip_address}/{ipv4_address['ipv4_prefixlen']}")
                         return {
@@ -181,7 +181,7 @@ class LibreNMSApi(ApiEndpoint):  # pylint: disable=too-few-public-methods
                         }
             elif isinstance(ipaddress_ip_interface, ipaddress.IPv6Address):
                 for ipv6_address in device_ips["addresses"]:
-                    if ipv6_address["ipv6_address"] == ip_address:
+                    if ipv6_address.get("ipv6_address") == ip_address:
                         ip_network_info = ipaddress.ip_interface(f"{ip_address}/64")
                         ip_address_info = ipaddress.ip_interface(f"{ip_address}/{ipv6_address['ipv6_prefixlen']}")
                         return {

--- a/nautobot_ssot/tests/librenms/test_librenms_validators.py
+++ b/nautobot_ssot/tests/librenms/test_librenms_validators.py
@@ -15,6 +15,7 @@ from nautobot_ssot.integrations.librenms.utils import (
     normalize_gps_coordinates,
     normalize_setting,
 )
+from nautobot_ssot.integrations.librenms.utils.librenms import LibreNMSApi
 
 
 class TestNormalizeGPSCoordinates(TestCase):
@@ -419,3 +420,47 @@ class TestIsRunningTests(TestCase):
 
         result = is_running_tests()
         self.assertTrue(result)
+
+
+class TestGetLibreNMSIPInfoForDeviceIP(TestCase):
+    """Test getting IP info for a device IP."""
+
+    def setUp(self):
+        """Set up test case."""
+        self.api = LibreNMSApi(url="https://librenms.example.com", token="token")
+
+    @parameterized.expand(
+        [
+            (
+                "ipv4_skips_entry_missing_key",
+                "10.0.0.1",
+                [
+                    {"ipv6_address": "2001:db8::1", "ipv6_prefixlen": "64"},  # no ipv4_address key
+                    {"ipv4_address": "10.0.0.1", "ipv4_prefixlen": "24"},
+                ],
+                {"network": "10.0.0.0/24", "address": "10.0.0.1/24"},
+            ),
+            (
+                "ipv6_skips_entry_missing_key",
+                "2001:db8::1",
+                [
+                    {"ipv4_address": "10.0.0.1", "ipv4_prefixlen": "24"},  # no ipv6_address key
+                    {"ipv6_address": "2001:db8::1", "ipv6_prefixlen": "64"},
+                ],
+                {"network": "2001:db8::/64", "address": "2001:db8::1/64"},
+            ),
+            (
+                "no_match_returns_none",
+                "10.0.0.1",
+                [{"ipv6_address": "2001:db8::1", "ipv6_prefixlen": "64"}],  # no ipv4_address key
+                None,
+            ),
+        ]
+    )
+    @patch.object(LibreNMSApi, "get_librenms_ips_for_device")
+    def test_get_librenms_ipinfo_for_device_ip(self, _test_name, ip_address, addresses, expected_result, mock_get_ips):
+        """Test that an address entry missing the IP key is skipped instead of raising KeyError."""
+        mock_get_ips.return_value = {"status": "ok", "count": len(addresses), "addresses": addresses}
+
+        result = self.api.get_librenms_ipinfo_for_device_ip(1, ip_address)
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
LibreNMS would crash if searching for the wrong type of IP address, this resolves that crash. Also removed a stray print/debug statement left in code previously.

