### PR TITLE
Resolve Version parsing on Citrix devices

### DIFF
--- a/changes/1239.fixed
+++ b/changes/1239.fixed
@@ -1,0 +1,1 @@
+Resolve version parsing on newer Citrix devices.

--- a/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
@@ -112,9 +112,7 @@ class CitrixNitroClient:
             _result = _result.json()
             if _result.get("errorcode") == 0:
                 return _result
-            self.job.logger.warning(f"Failure with request to {url}: {_result['message']}, data: {data}")
-        else:
-            self.job.logger.warning(f"HTTP {_result.status_code} from {url}: {_result.text}, data: {data}")
+            self.job.logger.warning(f"Failure with request: {_result['message']}")
         return {}
 
     def get_sites(self):

--- a/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
@@ -112,7 +112,9 @@ class CitrixNitroClient:
             _result = _result.json()
             if _result.get("errorcode") == 0:
                 return _result
-            self.job.logger.warning(f"Failure with request: {_result['message']}")
+            self.job.logger.warning(f"Failure with request to {url}: {_result['message']}, data: {data}")
+        else:
+            self.job.logger.warning(f"HTTP {_result.status_code} from {url}: {_result.text[:300]}, data: {data}")
         return {}
 
     def get_sites(self):
@@ -197,7 +199,7 @@ def parse_version(version: str):
         version (str): Version string from device API query.
     """
     result = ""
-    match_pattern = r"NetScaler\s(?P<version>NS\d+\.\d+: Build\s\d+\.\d+\.\w+)"
+    match_pattern = r"(?:NetScaler\s)?(?P<version>(?:NS)?\d+\.\d+: Build\s\d+\.\d+(?:\.\w+)?)"
     match = re.match(pattern=match_pattern, string=version)
     if match:
         result = match.group("version")

--- a/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
+++ b/nautobot_ssot/integrations/citrix_adm/utils/citrix_adm.py
@@ -114,7 +114,7 @@ class CitrixNitroClient:
                 return _result
             self.job.logger.warning(f"Failure with request to {url}: {_result['message']}, data: {data}")
         else:
-            self.job.logger.warning(f"HTTP {_result.status_code} from {url}: {_result.text[:300]}, data: {data}")
+            self.job.logger.warning(f"HTTP {_result.status_code} from {url}: {_result.text}, data: {data}")
         return {}
 
     def get_sites(self):

--- a/nautobot_ssot/tests/citrix_adm/test_utils_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_utils_citrix_adm.py
@@ -229,6 +229,18 @@ class TestCitrixAdmClient(TestCase):
         actual = parse_version(version=version)
         self.assertEqual(actual, expected)
 
+    def test_parse_version_optional_segments(self):
+        """Validate parse_version handles optional NetScaler/NS prefixes and trailing build qualifier."""
+        cases = [
+            ("NetScaler NS13.1: Build 37.38, Date: Nov 23 2022, 04:42:36   (64-bit)", "NS13.1: Build 37.38"),
+            ("NetScaler 13.1: Build 37.38.nc, Date: Nov 23 2022, 04:42:36   (64-bit)", "13.1: Build 37.38.nc"),
+            ("NS13.1: Build 37.38.nc, Date: Nov 23 2022, 04:42:36   (64-bit)", "NS13.1: Build 37.38.nc"),
+            ("13.1: Build 37.38, Date: Nov 23 2022, 04:42:36   (64-bit)", "13.1: Build 37.38"),
+        ]
+        for version, expected in cases:
+            with self.subTest(version=version):
+                self.assertEqual(parse_version(version=version), expected)
+
     def test_parse_vlan_bindings(self):
         """Validate functionality of the parse_vlan_bindings function."""
         vlan_bindings = VLAN_FIXTURE_RECV[0]


### PR DESCRIPTION
# Closes: #1239 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
It appears that newer Citrix versions have dropped the Netscaler NS prefix. Updated the regex to allow for this and still parse correctly. Does not change existing parsing behavior, the existing test will still pass, and new tests have been created on the newer version strings received from Citrix.

Also added some extra logging if hitting a Citrix URL is failing.