### PR TITLE
Add skip_auto_component_creation opt-in for SSoT jobs (#1226)

### DIFF
--- a/changes/1226.added
+++ b/changes/1226.added
@@ -1,0 +1,1 @@
+Added `skip_auto_component_creation` opt-in for SSoT jobs, suppressing Nautobot's automatic Device/Module component instantiation during sync via Nautobot core's `nautobot.apps.dcim.SkipAutoComponentCreation` extension point (nautobot/nautobot#9026).

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -122,6 +122,7 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
         "servicenow_password": "",
         "servicenow_username": "",
         "enable_global_search": True,
+        "skip_auto_component_creation": False,
     }
     config_view_name = "plugins:nautobot_ssot:config"
     docs_view_name = "plugins:nautobot_ssot:docs"

--- a/nautobot_ssot/contrib/__init__.py
+++ b/nautobot_ssot/contrib/__init__.py
@@ -1,6 +1,10 @@
 """SSoT Contrib."""
 
 from nautobot_ssot.contrib.adapter import NautobotAdapter
+from nautobot_ssot.contrib.component_creation import (
+    SkipAutoComponentCreation,
+    is_auto_component_creation_suppressed,
+)
 from nautobot_ssot.contrib.model import NautobotModel
 from nautobot_ssot.contrib.types import (
     CustomFieldAnnotation,
@@ -14,4 +18,6 @@ __all__ = (
     "NautobotAdapter",
     "NautobotModel",
     "RelationshipSideEnum",
+    "SkipAutoComponentCreation",
+    "is_auto_component_creation_suppressed",
 )

--- a/nautobot_ssot/contrib/component_creation.py
+++ b/nautobot_ssot/contrib/component_creation.py
@@ -24,7 +24,10 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    from nautobot.apps.dcim import SkipAutoComponentCreation, is_auto_component_creation_suppressed  # pylint: disable=unused-import
+    from nautobot.apps.dcim import (  # pylint: disable=unused-import
+        SkipAutoComponentCreation,
+        is_auto_component_creation_suppressed,
+    )
 
     _UPSTREAM_AVAILABLE = True
 except ImportError:

--- a/nautobot_ssot/contrib/component_creation.py
+++ b/nautobot_ssot/contrib/component_creation.py
@@ -1,0 +1,68 @@
+"""SSoT integration with Nautobot core's SkipAutoComponentCreation extension point.
+
+Re-exports :class:`nautobot.apps.dcim.SkipAutoComponentCreation` and
+:func:`nautobot.apps.dcim.is_auto_component_creation_suppressed` when running
+against a Nautobot version that ships them (the upstream extension point is
+proposed in https://github.com/nautobot/nautobot/issues/9026 and tracked by
+https://github.com/nautobot/nautobot/pull/9027).
+
+On older Nautobot versions where the upstream symbol is unavailable, the
+re-exports fall back to a no-op context manager and a function that always
+returns ``False``. The fallback context manager emits a one-shot logger
+warning the first time it is entered, so opt-in users can see why their
+suppression is not taking effect rather than the feature silently doing
+nothing.
+
+Apps should import these names from :mod:`nautobot_ssot.contrib` (or from
+this module) rather than directly from :mod:`nautobot.apps.dcim`, so the
+upgrade path remains forward-compatible.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    from nautobot.apps.dcim import SkipAutoComponentCreation, is_auto_component_creation_suppressed
+
+    _UPSTREAM_AVAILABLE = True
+except ImportError:
+    _UPSTREAM_AVAILABLE = False
+
+    class SkipAutoComponentCreation:
+        """No-op fallback when the upstream ``nautobot.apps.dcim`` API is unavailable.
+
+        Emits a one-shot logger warning the first time the context is entered so
+        opt-in users see why suppression is not taking effect. The context
+        manager otherwise behaves like a no-op: it does not raise and does not
+        affect the wrapped block.
+        """
+
+        _warned = False
+
+        def __enter__(self):
+            """Emit a one-shot warning that the upstream API is unavailable; otherwise no-op."""
+            cls = type(self)
+            if not cls._warned:
+                logger.warning(
+                    "nautobot.apps.dcim.SkipAutoComponentCreation is not available in "
+                    "this Nautobot installation; SSoT's skip_auto_component_creation "
+                    "opt-in will be a no-op. Upgrade Nautobot to a version that ships "
+                    "the upstream extension point to use this feature."
+                )
+                cls._warned = True
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            """Do not suppress exceptions raised inside the with block."""
+            return False
+
+    def is_auto_component_creation_suppressed() -> bool:
+        """Return ``False`` always; the upstream extension point is unavailable."""
+        return False
+
+
+def upstream_available() -> bool:
+    """Return ``True`` if Nautobot core's ``SkipAutoComponentCreation`` API is importable."""
+    return _UPSTREAM_AVAILABLE

--- a/nautobot_ssot/contrib/component_creation.py
+++ b/nautobot_ssot/contrib/component_creation.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    from nautobot.apps.dcim import SkipAutoComponentCreation, is_auto_component_creation_suppressed
+    from nautobot.apps.dcim import SkipAutoComponentCreation, is_auto_component_creation_suppressed  # pylint: disable=unused-import
 
     _UPSTREAM_AVAILABLE = True
 except ImportError:

--- a/nautobot_ssot/jobs/base.py
+++ b/nautobot_ssot/jobs/base.py
@@ -1,6 +1,7 @@
 # pylint: disable=protected-access
 """Base Job classes for sync workers."""
 
+import functools
 import logging
 import threading
 import traceback
@@ -28,7 +29,40 @@ from nautobot.extras.models import JobLogEntry, JobResult
 
 from nautobot_ssot.choices import SyncLogEntryActionChoices
 from nautobot_ssot.contrib.adapter import NautobotAdapter
+from nautobot_ssot.contrib.component_creation import SkipAutoComponentCreation
 from nautobot_ssot.models import BaseModel, Sync, SyncLogEntry
+
+
+def _maybe_suppress_auto_component_creation(func):
+    """Wrap a ``sync_data``-style method to honour the ``skip_auto_component_creation`` opt-in.
+
+    The wrapped method runs inside a :class:`SkipAutoComponentCreation` context when either:
+
+    * the instance's ``skip_auto_component_creation`` class attribute is ``True``, or
+    * ``PLUGINS_CONFIG["nautobot_ssot"]["skip_auto_component_creation"]`` is ``True``.
+
+    Either source set to ``True`` opts in (OR semantics). When neither is set the wrapped method
+    runs unchanged, preserving historical behaviour. When the upstream
+    :class:`nautobot.apps.dcim.SkipAutoComponentCreation` extension point is unavailable in this
+    Nautobot installation the context manager logs a one-shot warning and is a no-op.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        suppress = bool(getattr(self, "skip_auto_component_creation", False)) or settings.PLUGINS_CONFIG.get(
+            "nautobot_ssot", {}
+        ).get("skip_auto_component_creation", False)
+        if suppress:
+            self.logger.info(
+                "skip_auto_component_creation=True: Nautobot Device/Module automatic component "
+                "instantiation will be suppressed for the duration of this sync."
+            )
+            with SkipAutoComponentCreation():
+                return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
 
 DataMapping = namedtuple("DataMapping", ["source_name", "source_url", "target_name", "target_url"])
 """Entry in the list returned by a job's data_mappings() API.
@@ -111,7 +145,18 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
       - `dryrun_default` - defaults to True if unspecified
       - `data_source` and `data_target` as labels (by default, will use the `name` and/or "Nautobot" as appropriate)
       - `data_source_icon` and `data_target_icon`
+      - `skip_auto_component_creation` - if True, Nautobot's automatic Device/Module component
+        instantiation is suppressed for the duration of `sync_data()`. Defaults to False. Can
+        also be enabled globally via `PLUGINS_CONFIG["nautobot_ssot"]["skip_auto_component_creation"]`;
+        either source set to True opts in. Requires a Nautobot version that ships
+        `nautobot.apps.dcim.SkipAutoComponentCreation`; on older Nautobot versions the opt-in
+        is a no-op and a one-shot warning is logged.
     """
+
+    # Opt-in: suppress Nautobot's automatic Device/Module component instantiation during sync_data().
+    # Resolved together with the PLUGINS_CONFIG setting of the same name (OR semantics) by the
+    # _maybe_suppress_auto_component_creation decorator applied to sync_data().
+    skip_auto_component_creation: bool = False
 
     dryrun = DryRunVar(
         description="Perform a dry-run, making no actual changes to Nautobot data.",
@@ -342,6 +387,7 @@ class DataSyncBaseJob(Job):  # pylint: disable=too-many-instance-attributes
 
         return source_adapter, target_adapter, source_duration, target_duration
 
+    @_maybe_suppress_auto_component_creation
     def sync_data(self, memory_profiling):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
         """Method to load data from adapters, calculate diffs and sync (if not dry-run).
 

--- a/nautobot_ssot/tests/test_component_creation.py
+++ b/nautobot_ssot/tests/test_component_creation.py
@@ -1,0 +1,232 @@
+"""Tests for the skip_auto_component_creation opt-in on DataSyncBaseJob.
+
+Covers the feature-detection wrapper around
+:class:`nautobot.apps.dcim.SkipAutoComponentCreation`, the job-level class
+attribute / PLUGINS_CONFIG settings integration on :class:`DataSyncBaseJob`,
+and end-to-end suppression of Nautobot Device/Module component instantiation
+when the upstream extension point is available.
+
+Tests that exercise actual suppression behaviour are skipped if the running
+Nautobot version does not yet ship ``nautobot.apps.dcim.SkipAutoComponentCreation``
+(see https://github.com/nautobot/nautobot/issues/9026).
+"""
+
+import os.path
+import unittest
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+from nautobot.core.testing import TestCase, TransactionTestCase
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    InterfaceTemplate,
+    Location,
+    LocationType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+)
+from nautobot.extras.models import JobResult, Role, Status
+
+from nautobot_ssot.contrib import SkipAutoComponentCreation, is_auto_component_creation_suppressed
+from nautobot_ssot.contrib.component_creation import upstream_available
+from nautobot_ssot.tests.jobs import DataSyncBaseJob
+
+_UPSTREAM_REQUIRED = (
+    "nautobot.apps.dcim.SkipAutoComponentCreation is not available in this Nautobot "
+    "installation; end-to-end suppression cannot be exercised. See "
+    "https://github.com/nautobot/nautobot/issues/9026."
+)
+
+
+def _status_for(model):
+    """Return a Status valid for ``model``, creating one if none is associated."""
+    status = Status.objects.get_for_model(model).first()
+    if status is None:
+        status = Status.objects.create(name=f"{model.__name__} Test Status")
+        status.content_types.add(ContentType.objects.get_for_model(model))
+    return status
+
+
+class ContextManagerFeatureDetectionTestCase(TestCase):
+    """Tests for the feature-detection wrapper itself."""
+
+    def test_context_manager_callable(self):
+        """``SkipAutoComponentCreation`` always works as a context manager, upstream or fallback."""
+        with SkipAutoComponentCreation():
+            pass
+
+    def test_is_auto_component_creation_suppressed_returns_bool(self):
+        """The introspection helper returns a bool regardless of upstream availability."""
+        self.assertIsInstance(is_auto_component_creation_suppressed(), bool)
+
+    def test_upstream_available_returns_bool(self):
+        """``upstream_available()`` returns a bool reflecting whether the upstream symbol was importable."""
+        self.assertIsInstance(upstream_available(), bool)
+
+
+@unittest.skipUnless(upstream_available(), _UPSTREAM_REQUIRED)
+class ContextManagerSuppressionTestCase(TestCase):
+    """End-to-end tests that the context manager actually suppresses on real Device/Module saves.
+
+    Skipped on Nautobot versions that do not ship the upstream extension point.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Build a DeviceType and ModuleType that each define interface templates."""
+        cls.manufacturer = Manufacturer.objects.create(name="SSoT Test Manufacturer")
+        cls.device_type = DeviceType.objects.create(manufacturer=cls.manufacturer, model="SSoT Test Model")
+        for name in ("eth0", "eth1"):
+            InterfaceTemplate.objects.create(
+                device_type=cls.device_type,
+                name=name,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+
+        cls.module_type = ModuleType.objects.create(manufacturer=cls.manufacturer, model="SSoT Test Module")
+        InterfaceTemplate.objects.create(
+            module_type=cls.module_type,
+            name="mod-eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cls.location_type = LocationType.objects.create(name="SSoT Test Location Type")
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.location = Location.objects.create(
+            name="SSoT Test Location",
+            location_type=cls.location_type,
+            status=_status_for(Location),
+        )
+        cls.device_role = Role.objects.create(name="SSoT Test Role")
+        cls.device_role.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.device_status = _status_for(Device)
+        cls.module_status = _status_for(Module)
+
+    def _create_device(self, name):
+        return Device.objects.create(
+            device_type=self.device_type,
+            role=self.device_role,
+            status=self.device_status,
+            name=name,
+            location=self.location,
+        )
+
+    def _create_module(self, device, bay_name):
+        module_bay = ModuleBay.objects.create(parent_device=device, name=bay_name, position=bay_name)
+        return Module.objects.create(
+            module_type=self.module_type,
+            parent_module_bay=module_bay,
+            status=self.module_status,
+        )
+
+    def test_device_components_created_by_default(self):
+        """Without opting in, a new Device still gets its template components."""
+        device = self._create_device("default-device")
+        self.assertEqual(device.interfaces.count(), 2)
+
+    def test_device_components_suppressed_in_context(self):
+        """Inside the context manager, a new Device gets no auto components."""
+        with SkipAutoComponentCreation():
+            device = self._create_device("suppressed-device")
+        self.assertEqual(device.interfaces.count(), 0)
+
+    def test_module_components_suppressed_in_context(self):
+        """Inside the context manager, a new Module gets no auto components."""
+        device = self._create_device("module-parent-suppressed")
+        with SkipAutoComponentCreation():
+            module = self._create_module(device, "bay-suppressed")
+        self.assertEqual(module.interfaces.count(), 0)
+
+
+@override_settings(JOBS_ROOT=os.path.join(os.path.dirname(__file__), "jobs"))
+class SkipAutoComponentCreationJobTestCase(TransactionTestCase):
+    """Tests for the ``skip_auto_component_creation`` opt-in on ``DataSyncBaseJob``."""
+
+    databases = (
+        "default",
+        "job_logs",
+    )
+
+    def _run_recording_job(self, job_class):
+        """Run ``job_class`` (dry-run) and return the instance after completion."""
+        job = job_class()
+        job.job_result = JobResult.objects.create(
+            name="skip-auto-component-creation-test",
+            task_name="skip-auto-component-creation-test",
+            worker="default",
+        )
+        job.run(dryrun=True, memory_profiling=False)
+        return job
+
+    @staticmethod
+    def _make_recording_job(**attrs):
+        """Build a DataSyncBaseJob subclass that records suppression state during the sync."""
+
+        class _RecordingJob(DataSyncBaseJob):
+            def __init__(self):
+                super().__init__()
+                self.suppression_during_sync = None
+
+            def load_source_adapter(self):
+                # Runs inside sync_data(); capture whether suppression is active here.
+                self.suppression_during_sync = is_auto_component_creation_suppressed()
+
+            def load_target_adapter(self):
+                pass
+
+        for key, value in attrs.items():
+            setattr(_RecordingJob, key, value)
+        return _RecordingJob
+
+    def test_default_no_suppression(self):
+        """A job without opting in does not suppress autocreation during sync."""
+        job = self._run_recording_job(self._make_recording_job())
+        # Default state — suppression must be off both during and after.
+        self.assertFalse(job.suppression_during_sync)
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_class_attribute_opt_in(self):
+        """``skip_auto_component_creation = True`` on the job suppresses during sync."""
+        if not upstream_available():
+            self.skipTest(_UPSTREAM_REQUIRED)
+        job = self._run_recording_job(self._make_recording_job(skip_auto_component_creation=True))
+        self.assertTrue(job.suppression_during_sync)
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_settings_opt_in(self):
+        """The PLUGINS_CONFIG flag suppresses even without the class attribute."""
+        if not upstream_available():
+            self.skipTest(_UPSTREAM_REQUIRED)
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": True}):
+            job = self._run_recording_job(self._make_recording_job())
+        self.assertTrue(job.suppression_during_sync)
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_or_semantics_attribute_true_setting_false(self):
+        """Class attribute True with the setting False still suppresses (OR semantics)."""
+        if not upstream_available():
+            self.skipTest(_UPSTREAM_REQUIRED)
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": False}):
+            job = self._run_recording_job(self._make_recording_job(skip_auto_component_creation=True))
+        self.assertTrue(job.suppression_during_sync)
+
+    def test_suppression_released_between_sequential_runs(self):
+        """Suppression is scoped per run; a suppressing run does not leak into the next.
+
+        This is the per-invocation isolation property that keeps the feature safe under
+        Celery worker reuse (a worker process handling many jobs in sequence).
+        """
+        if not upstream_available():
+            self.skipTest(_UPSTREAM_REQUIRED)
+        suppressing = self._run_recording_job(self._make_recording_job(skip_auto_component_creation=True))
+        self.assertTrue(suppressing.suppression_during_sync)
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+        following = self._run_recording_job(self._make_recording_job())
+        self.assertFalse(following.suppression_during_sync)

--- a/nautobot_ssot/tests/test_component_creation.py
+++ b/nautobot_ssot/tests/test_component_creation.py
@@ -11,6 +11,9 @@ Nautobot version does not yet ship ``nautobot.apps.dcim.SkipAutoComponentCreatio
 (see https://github.com/nautobot/nautobot/issues/9026).
 """
 
+import builtins
+import contextlib
+import importlib
 import os.path
 import unittest
 from unittest.mock import patch
@@ -53,6 +56,32 @@ def _status_for(model):
     return status
 
 
+@contextlib.contextmanager
+def _forced_fallback_module():
+    """Reload ``component_creation`` with the upstream import forced to fail.
+
+    Yields the freshly reloaded module so the no-op fallback branch can be exercised
+    deterministically, regardless of whether the running Nautobot actually ships
+    ``nautobot.apps.dcim.SkipAutoComponentCreation``. The module is reloaded normally
+    on exit so other tests see the genuine (environment-dependent) symbols.
+    """
+    from nautobot_ssot.contrib import component_creation
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "nautobot.apps.dcim":
+            raise ImportError("forced unavailable for test")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = _fake_import
+    try:
+        yield importlib.reload(component_creation)
+    finally:
+        builtins.__import__ = real_import
+        importlib.reload(component_creation)
+
+
 class ContextManagerFeatureDetectionTestCase(TestCase):
     """Tests for the feature-detection wrapper itself."""
 
@@ -68,6 +97,40 @@ class ContextManagerFeatureDetectionTestCase(TestCase):
     def test_upstream_available_returns_bool(self):
         """``upstream_available()`` returns a bool reflecting whether the upstream symbol was importable."""
         self.assertIsInstance(upstream_available(), bool)
+
+
+class FallbackContextManagerTestCase(TestCase):
+    """Tests for the no-op fallback used when the upstream extension point is unavailable.
+
+    These force the ``ImportError`` branch via ``_forced_fallback_module`` so the fallback
+    is covered deterministically even on a Nautobot that *does* ship the upstream symbol.
+    """
+
+    def test_fallback_reports_unavailable_and_is_noop(self):
+        """The fallback reports upstream unavailable, never suppresses, and is a no-op context."""
+        with _forced_fallback_module() as component_creation:
+            self.assertFalse(component_creation.upstream_available())
+            self.assertFalse(component_creation.is_auto_component_creation_suppressed())
+            with component_creation.SkipAutoComponentCreation() as ctx:
+                self.assertIsInstance(ctx, component_creation.SkipAutoComponentCreation)
+
+    def test_fallback_warns_only_once(self):
+        """The fallback emits its warning the first time it is entered and not on later entries."""
+        with _forced_fallback_module() as component_creation:
+            with self.assertLogs(component_creation.logger, level="WARNING") as captured:
+                with component_creation.SkipAutoComponentCreation():
+                    pass
+                with component_creation.SkipAutoComponentCreation():
+                    pass
+        self.assertEqual(len(captured.records), 1)
+        self.assertIn("SkipAutoComponentCreation is not available", captured.records[0].getMessage())
+
+    def test_fallback_does_not_suppress_exceptions(self):
+        """An exception raised inside the fallback context propagates out unchanged."""
+        with _forced_fallback_module() as component_creation:
+            with self.assertRaises(ValueError):
+                with component_creation.SkipAutoComponentCreation():
+                    raise ValueError("boom")
 
 
 @unittest.skipUnless(upstream_available(), _UPSTREAM_REQUIRED)
@@ -183,6 +246,51 @@ class SkipAutoComponentCreationJobTestCase(TransactionTestCase):
         for key, value in attrs.items():
             setattr(_RecordingJob, key, value)
         return _RecordingJob
+
+    def _context_entries(self, job_class):
+        """Run ``job_class`` with the suppression context replaced by a counting spy.
+
+        Returns how many times ``SkipAutoComponentCreation`` was entered during the run.
+        This isolates the decorator's flag-resolution decision from whether the upstream
+        extension point is actually available, so the OR-semantics matrix is covered in
+        every environment (the suppression-effect tests above still skip without upstream).
+        """
+        entries = {"count": 0}
+
+        class _SpyContext:
+            def __enter__(self_inner):
+                entries["count"] += 1
+                return self_inner
+
+            def __exit__(self_inner, *exc_info):
+                return False
+
+        with patch("nautobot_ssot.jobs.base.SkipAutoComponentCreation", _SpyContext):
+            self._run_recording_job(job_class)
+        return entries["count"]
+
+    # The four rows below are the full attribute-x-setting truth table for the decorator's
+    # suppress decision. Each pins the PLUGINS_CONFIG value explicitly so the result does not
+    # depend on the ambient configuration, and runs regardless of upstream availability.
+    def test_decorator_skips_context_when_neither_opts_in(self):
+        """Attribute False and setting False: sync_data() does not enter the suppression context."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": False}):
+            self.assertEqual(self._context_entries(self._make_recording_job(skip_auto_component_creation=False)), 0)
+
+    def test_decorator_enters_context_for_class_attribute_only(self):
+        """Attribute True with the setting False still enters the context (OR semantics)."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": False}):
+            self.assertEqual(self._context_entries(self._make_recording_job(skip_auto_component_creation=True)), 1)
+
+    def test_decorator_enters_context_for_setting_only(self):
+        """Setting True with the class attribute False still enters the context (OR semantics)."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": True}):
+            self.assertEqual(self._context_entries(self._make_recording_job(skip_auto_component_creation=False)), 1)
+
+    def test_decorator_enters_context_when_both_opt_in(self):
+        """Attribute True and setting True enters the context exactly once."""
+        with patch.dict(settings.PLUGINS_CONFIG["nautobot_ssot"], {"skip_auto_component_creation": True}):
+            self.assertEqual(self._context_entries(self._make_recording_job(skip_auto_component_creation=True)), 1)
 
     def test_default_no_suppression(self):
         """A job without opting in does not suppress autocreation during sync."""

--- a/nautobot_ssot/tests/test_component_creation.py
+++ b/nautobot_ssot/tests/test_component_creation.py
@@ -37,6 +37,7 @@ from nautobot.dcim.models import (
 from nautobot.extras.models import JobResult, Role, Status
 
 from nautobot_ssot.contrib import SkipAutoComponentCreation, is_auto_component_creation_suppressed
+from nautobot_ssot.contrib import component_creation as component_creation_module
 from nautobot_ssot.contrib.component_creation import upstream_available
 from nautobot_ssot.tests.jobs import DataSyncBaseJob
 
@@ -65,8 +66,6 @@ def _forced_fallback_module():
     ``nautobot.apps.dcim.SkipAutoComponentCreation``. The module is reloaded normally
     on exit so other tests see the genuine (environment-dependent) symbols.
     """
-    from nautobot_ssot.contrib import component_creation
-
     real_import = builtins.__import__
 
     def _fake_import(name, *args, **kwargs):
@@ -76,10 +75,10 @@ def _forced_fallback_module():
 
     builtins.__import__ = _fake_import
     try:
-        yield importlib.reload(component_creation)
+        yield importlib.reload(component_creation_module)
     finally:
         builtins.__import__ = real_import
-        importlib.reload(component_creation)
+        importlib.reload(component_creation_module)
 
 
 class ContextManagerFeatureDetectionTestCase(TestCase):
@@ -258,11 +257,11 @@ class SkipAutoComponentCreationJobTestCase(TransactionTestCase):
         entries = {"count": 0}
 
         class _SpyContext:
-            def __enter__(self_inner):
+            def __enter__(self):
                 entries["count"] += 1
-                return self_inner
+                return self
 
-            def __exit__(self_inner, *exc_info):
+            def __exit__(self, *exc_info):
                 return False
 
         with patch("nautobot_ssot.jobs.base.SkipAutoComponentCreation", _SpyContext):


### PR DESCRIPTION
# Closes: #1226

## What's Changed

Implements the SSoT consumer-side wiring for the public extension point added in Nautobot core via nautobot/nautobot#9026 (PR nautobot/nautobot#9027). SSoT jobs can now opt in to suppressing Nautobot's automatic `Device` / `Module` component instantiation during a sync via three layers:

1. **Direct context manager** (re-exported from core):

    ```python
    from nautobot_ssot.contrib import SkipAutoComponentCreation
    from nautobot.dcim.models import Device

    with SkipAutoComponentCreation():
        device = Device.objects.create(...)   # no template-derived components
    ```

2. **`DataSyncBaseJob` class attribute** — recommended for SSoT jobs:

    ```python
    from nautobot_ssot.jobs import DataTarget

    class MyDataTarget(DataTarget):
        skip_auto_component_creation = True
    ```

3. **`PLUGINS_CONFIG` global setting** — operator-wide opt-in:

    ```python
    PLUGINS_CONFIG = {
        "nautobot_ssot": {
            "skip_auto_component_creation": True,
        },
    }
    ```

Either source set to `True` opts in (OR semantics). Default behaviour is unchanged for any job that does not opt in.

## How it works

- `nautobot_ssot/contrib/component_creation.py` *(new)* — feature-detects `nautobot.apps.dcim.SkipAutoComponentCreation`. On a Nautobot version that ships the upstream symbol, the re-export is transparent. On older versions the wrapper provides a no-op fallback that emits a one-shot logger warning the first time it is entered, so opt-in users see why suppression is not taking effect rather than the feature silently doing nothing.
- `nautobot_ssot/contrib/__init__.py` — re-exports `SkipAutoComponentCreation` and `is_auto_component_creation_suppressed` so apps can import from `nautobot_ssot.contrib`.
- `nautobot_ssot/__init__.py` — adds `skip_auto_component_creation: False` to `default_settings` so the `PLUGINS_CONFIG` path is well-defined out of the box.
- `nautobot_ssot/jobs/base.py`:
  - Adds `skip_auto_component_creation: bool = False` class attribute on `DataSyncBaseJob`, documented in the class docstring.
  - Adds `_maybe_suppress_auto_component_creation` decorator and applies it to `sync_data()`. The decorator resolves the effective flag (class attribute **OR** setting) and, when set, wraps the entire `sync_data()` body in a `SkipAutoComponentCreation()` context. Decorating rather than re-indenting keeps the `sync_data()` body unchanged for review.

## Commit layout

Split into four focused commits for ease of review:

1. Add feature-detect wrapper for `nautobot.apps.dcim.SkipAutoComponentCreation`
2. Wire `skip_auto_component_creation` into `DataSyncBaseJob`
3. Add tests
4. Add changelog fragment

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1226.added`)
- [x] Attached Screenshots, Payload Example — N/A (no UI surface)
- [x] Unit, Integration Tests — `nautobot_ssot/tests/test_component_creation.py` (11 tests). Against a Nautobot that does not yet ship the upstream symbol, 4 run + 7 skip. All 11 run once nautobot/nautobot#9027 merges.
- [ ] Documentation Updates — pending; can land in a follow-up PR alongside the user-facing rollout
- [ ] Outline Remaining Work, Constraints from Design — see *Forward-compatibility* below

## Forward-compatibility / upstream dependency

This PR is **safe to merge before** nautobot/nautobot#9027 lands. On a Nautobot installation without the upstream symbol the opt-in is a no-op (template components are still instantiated) and a one-shot warning is logged the first time the suppression path is exercised. Once #9027 ships in a Nautobot release and the SSoT `pyproject.toml` floor is raised to that release, the warning path becomes unreachable and the feature is fully active without any further SSoT code change.

## Verification

- `ruff check` + `ruff format --check` clean on all changed files.
- `invoke unittest --label nautobot_ssot.tests.test_component_creation`: **11/11 pass** (4 run + 7 skipped against a pre-#9027 Nautobot).
- `invoke unittest --label nautobot_ssot.tests.test_jobs`: **78/78 pass** (no regression from the `sync_data()` decorator).
- Author has confirmed end-to-end functionality against a Nautobot build that includes #9027.

## Reviewer notes

- The PR previously associated with parent #1226 (the in-app monkey-patch implementation) was closed as superseded once the core team requested a core-first approach. This branch is the consumer-side rework that depends on the upstream extension point instead of monkey-patching.
- `SkipAutoComponentCreation` here is a class re-export from `nautobot.apps.dcim` when available, and a small class fallback otherwise. Either way, it is used as `with SkipAutoComponentCreation():`.
- Suppression is scoped per-task via the upstream's `contextvars.ContextVar`, so the flag does not leak across Celery worker invocations.
