### PR TITLE
Fix test failing against nautobot next and cleanup

### DIFF
--- a/changes/1248.housekeeping
+++ b/changes/1248.housekeeping
@@ -1,0 +1,4 @@
+Fixed a test that was failing due to a recent change in Nautobot's next branch for 3.2.0.
+Fixed many test cases that were using TransactionTestCase when TestCase was acceptable.
+Fixed some of the test cases that were failing when running with --keepdb.
+Fixed all test cases to correctly import from nautobot.apps instead of nautobot.core or django.test.

--- a/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
@@ -3,7 +3,7 @@
 import ipaddress
 from unittest.mock import MagicMock, patch
 
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.aristacv.diffsync.adapters.cloudvision import (
@@ -13,56 +13,57 @@ from nautobot_ssot.integrations.aristacv.jobs import CloudVisionDataSource
 from nautobot_ssot.tests.aristacv.fixtures import fixtures
 
 
-class CloudvisionAdapterTestCase(TransactionTestCase):
+class CloudvisionAdapterTestCase(TestCase):
     """Test the CloudvisionAdapter class."""
 
     job_class = CloudVisionDataSource
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Method to initialize test case."""
-        super().setUp()
-        self.client = MagicMock()
-        self.client.comm_channel = MagicMock()
-        self.client.get_inventory = MagicMock(return_value=fixtures.INVENTORY_FIXTURE)
-        self.client.get_version = MagicMock(return_value="2024.3.0")
+        super().setUpTestData()
+        cls.client = MagicMock()
+        cls.client.comm_channel = MagicMock()
+        cls.client.get_inventory = MagicMock(return_value=fixtures.INVENTORY_FIXTURE)
+        cls.client.get_version = MagicMock(return_value="2024.3.0")
 
-        self.cloudvision = MagicMock()
-        self.cloudvision.get_tags_by_type = MagicMock()
-        self.cloudvision.get_tags_by_type.return_value = []
-        self.cloudvision.get_device_type = MagicMock()
-        self.cloudvision.get_device_type.return_value = "fixedSystem"
-        self.cloudvision.get_interfaces_fixed = MagicMock()
-        self.cloudvision.get_interfaces_fixed.return_value = fixtures.FIXED_INTERFACE_FIXTURE
-        self.cloudvision.get_interfaces_port_channel = MagicMock()
-        self.cloudvision.get_interfaces_port_channel.return_value = fixtures.PORT_CHANNEL_INTERFACE_FIXTURE
-        self.cloudvision.get_port_channel_members = MagicMock()
-        self.cloudvision.get_port_channel_members.return_value = fixtures.PORT_CHANNEL_MEMBERS_FIXTURE
+        cls.cloudvision = MagicMock()
+        cls.cloudvision.get_tags_by_type = MagicMock()
+        cls.cloudvision.get_tags_by_type.return_value = []
+        cls.cloudvision.get_device_type = MagicMock()
+        cls.cloudvision.get_device_type.return_value = "fixedSystem"
+        cls.cloudvision.get_interfaces_fixed = MagicMock()
+        cls.cloudvision.get_interfaces_fixed.return_value = fixtures.FIXED_INTERFACE_FIXTURE
+        cls.cloudvision.get_interfaces_port_channel = MagicMock()
+        cls.cloudvision.get_interfaces_port_channel.return_value = fixtures.PORT_CHANNEL_INTERFACE_FIXTURE
+        cls.cloudvision.get_port_channel_members = MagicMock()
+        cls.cloudvision.get_port_channel_members.return_value = fixtures.PORT_CHANNEL_MEMBERS_FIXTURE
         all_intf_names = [
             port["interface"] for port in (*fixtures.PORT_CHANNEL_INTERFACE_FIXTURE, *fixtures.FIXED_INTERFACE_FIXTURE)
         ]
-        self.cloudvision.get_all_interface_modes = MagicMock()
-        self.cloudvision.get_all_interface_modes.return_value = {name: "access" for name in all_intf_names}
-        self.cloudvision.get_all_interface_transceivers = MagicMock()
-        self.cloudvision.get_all_interface_transceivers.return_value = {
+        cls.cloudvision.get_all_interface_modes = MagicMock()
+        cls.cloudvision.get_all_interface_modes.return_value = {name: "access" for name in all_intf_names}
+        cls.cloudvision.get_all_interface_transceivers = MagicMock()
+        cls.cloudvision.get_all_interface_transceivers.return_value = {
             name: "1000BASE-T" for name in all_intf_names if not name.startswith("Port-Channel")
         }
-        self.cloudvision.get_all_interface_descriptions = MagicMock()
-        self.cloudvision.get_all_interface_descriptions.return_value = {
+        cls.cloudvision.get_all_interface_descriptions = MagicMock()
+        cls.cloudvision.get_all_interface_descriptions.return_value = {
             name: "Uplink to DC1" for name in all_intf_names
         }
-        self.cloudvision.get_routed_interface_description = MagicMock()
-        self.cloudvision.get_routed_interface_description.return_value = "hello!"
-        self.cloudvision.get_ip_interfaces = MagicMock()
-        self.cloudvision.get_ip_interfaces.return_value = fixtures.IP_INTF_FIXTURE
-        self.cloudvision.get_interface_vrf = MagicMock()
-        self.cloudvision.get_interface_vrf.return_value = "Global"
+        cls.cloudvision.get_routed_interface_description = MagicMock()
+        cls.cloudvision.get_routed_interface_description.return_value = "hello!"
+        cls.cloudvision.get_ip_interfaces = MagicMock()
+        cls.cloudvision.get_ip_interfaces.return_value = fixtures.IP_INTF_FIXTURE
+        cls.cloudvision.get_interface_vrf = MagicMock()
+        cls.cloudvision.get_interface_vrf.return_value = "Global"
 
-        self.job = self.job_class()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = cls.job_class()
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.cvp = CloudvisionAdapter(job=self.job, conn=self.client)
+        cls.cvp = CloudvisionAdapter(job=cls.job, conn=cls.client)
 
     def test_load_devices(self):
         """Test the load_devices() adapter method."""

--- a/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_cloudvision_adapter.py
@@ -49,9 +49,7 @@ class CloudvisionAdapterTestCase(TestCase):
             name: "1000BASE-T" for name in all_intf_names if not name.startswith("Port-Channel")
         }
         cls.cloudvision.get_all_interface_descriptions = MagicMock()
-        cls.cloudvision.get_all_interface_descriptions.return_value = {
-            name: "Uplink to DC1" for name in all_intf_names
-        }
+        cls.cloudvision.get_all_interface_descriptions.return_value = {name: "Uplink to DC1" for name in all_intf_names}
         cls.cloudvision.get_routed_interface_description = MagicMock()
         cls.cloudvision.get_routed_interface_description.return_value = "hello!"
         cls.cloudvision.get_ip_interfaces = MagicMock()
@@ -60,9 +58,7 @@ class CloudvisionAdapterTestCase(TestCase):
         cls.cloudvision.get_interface_vrf.return_value = "Global"
 
         cls.job = cls.job_class()
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.cvp = CloudvisionAdapter(job=cls.job, conn=cls.client)
 
     def test_load_devices(self):

--- a/nautobot_ssot/tests/aristacv/test_jobs.py
+++ b/nautobot_ssot/tests/aristacv/test_jobs.py
@@ -2,7 +2,7 @@
 
 from django.test import override_settings
 from django.urls import reverse
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.aristacv import jobs
 

--- a/nautobot_ssot/tests/aristacv/test_models_nautobot.py
+++ b/nautobot_ssot/tests/aristacv/test_models_nautobot.py
@@ -6,9 +6,10 @@ from unittest.mock import MagicMock, patch
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device as OrmDevice
 from nautobot.dcim.models import DeviceType, Interface, Location, LocationType, Manufacturer, Platform, SoftwareVersion
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import Namespace as OrmNamespace
 from nautobot.ipam.models import Prefix as OrmPrefix
@@ -32,19 +33,20 @@ from nautobot_ssot.integrations.aristacv.utils.nautobot import get_config
         },
     },
 )
-class TestNautobotNamespaceDelete(TransactionTestCase):
+class TestNautobotNamespaceDelete(TestCase):
     """Test NautobotNamespace.delete() conditional on delete_namespaces_on_sync."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Set up adapter with job and app_config."""
-        super().setUp()
-        self.adapter = MagicMock()
-        self.adapter.objects_to_delete = defaultdict(list)
-        self.adapter.job = MagicMock()
-        self.adapter.job.debug = False
-        self.adapter.job.app_config = get_config()._replace(delete_namespaces_on_sync=False)
+        super().setUpTestData()
+        cls.adapter = MagicMock()
+        cls.adapter.objects_to_delete = defaultdict(list)
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.debug = False
+        cls.adapter.job.app_config = get_config()._replace(delete_namespaces_on_sync=False)
 
     def test_namespace_delete_when_delete_on_sync_false(self):
         """When delete_namespaces_on_sync is False, delete() does not append to objects_to_delete."""
@@ -75,22 +77,24 @@ class TestNautobotNamespaceDelete(TransactionTestCase):
         },
     },
 )
-class TestNautobotPrefixDelete(TransactionTestCase):
+class TestNautobotPrefixDelete(TestCase):
     """Test NautobotPrefix.delete() conditional on delete_prefixes_on_sync."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Set up adapter with job and app_config."""
-        super().setUp()
-        self.adapter = MagicMock()
-        self.adapter.objects_to_delete = defaultdict(list)
-        self.adapter.job = MagicMock()
-        self.adapter.job.debug = False
-        self.adapter.job.app_config = get_config()._replace(delete_prefixes_on_sync=False)
-        self.ns = OrmNamespace.objects.create(name="PrefixTestNS")
-        self.status_active = Status.objects.get(name="Active")
-        self.prefix = OrmPrefix.objects.create(prefix="10.99.0.0/24", namespace=self.ns, status=self.status_active)
+        super().setUpTestData()
+        populate_status_choices()
+        cls.adapter = MagicMock()
+        cls.adapter.objects_to_delete = defaultdict(list)
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.debug = False
+        cls.adapter.job.app_config = get_config()._replace(delete_prefixes_on_sync=False)
+        cls.ns = OrmNamespace.objects.create(name="PrefixTestNS")
+        cls.status_active = Status.objects.get(name="Active")
+        cls.prefix = OrmPrefix.objects.create(prefix="10.99.0.0/24", namespace=cls.ns, status=cls.status_active)
 
     def test_prefix_delete_when_delete_on_sync_false(self):
         """When delete_prefixes_on_sync is False, delete() does not append to objects_to_delete."""
@@ -121,7 +125,7 @@ class TestNautobotPrefixDelete(TransactionTestCase):
         },
     },
 )
-class TestNautobotDeviceVersion(TransactionTestCase):
+class TestNautobotDeviceVersion(TestCase):
     """Test that NautobotDevice.create() and update() correctly assign software_version."""
 
     databases = ("default", "job_logs")
@@ -134,27 +138,29 @@ class TestNautobotDeviceVersion(TransactionTestCase):
     }
     IDS = {"name": "switch-01"}
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Set up adapter with job and app_config plus baseline ORM objects."""
-        super().setUp()
+        super().setUpTestData()
+        populate_status_choices()
         # spec=Adapter so pydantic's is_instance_of check on DiffSyncModel.adapter passes.
-        self.adapter = MagicMock(spec=Adapter)
-        self.adapter.job = MagicMock()
-        self.adapter.job.debug = False
-        self.adapter.job.app_config = get_config()
-        self.status_active = Status.objects.get(name="Active")
+        cls.adapter = MagicMock(spec=Adapter)
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.debug = False
+        cls.adapter.job.app_config = get_config()
+        cls.status_active = Status.objects.get(name="Active")
         arista_manu = Manufacturer.objects.get_or_create(name="Arista")[0]
-        self.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=arista_manu)[0]
-        self.device_type = DeviceType.objects.get_or_create(model="DCS-7150S-24", manufacturer=arista_manu)[0]
+        cls.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=arista_manu)[0]
+        cls.device_type = DeviceType.objects.get_or_create(model="DCS-7150S-24", manufacturer=arista_manu)[0]
         device_ct = ContentType.objects.get_for_model(OrmDevice)
-        self.role = Role.objects.get_or_create(name="Edge Router", color="ff0000")[0]
-        self.role.content_types.add(device_ct)
+        cls.role = Role.objects.get_or_create(name="Edge Router", color="ff0000")[0]
+        cls.role.content_types.add(device_ct)
         location_type = LocationType.objects.get_or_create(name="Site")[0]
         location_type.content_types.add(device_ct)
-        self.location = Location.objects.create(
+        cls.location = Location.objects.create(
             name="UpdateSite",
             location_type=location_type,
-            status=self.status_active,
+            status=cls.status_active,
         )
 
     def test_create_assigns_software_version(self):
@@ -225,37 +231,39 @@ class TestNautobotDeviceVersion(TransactionTestCase):
         self.assertIsNone(device.software_version)
 
 
-class TestNautobotPortCreate(TransactionTestCase):
+class TestNautobotPortCreate(TestCase):
     """Test NautobotPort.create() handles breakout interface names and lag references."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Create the minimal Nautobot scaffolding (status/site/devicetype/role/device)."""
-        super().setUp()
-        self.status_active, _ = Status.objects.get_or_create(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active, _ = Status.objects.get_or_create(name="Active")
         arista_manu, _ = Manufacturer.objects.get_or_create(name="Arista")
 
         loc_type, _ = LocationType.objects.get_or_create(name="Site")
-        self.status_active.content_types.add(ContentType.objects.get_for_model(Location))
-        self.site, _ = Location.objects.get_or_create(name="HQ", status=self.status_active, location_type=loc_type)
+        cls.status_active.content_types.add(ContentType.objects.get_for_model(Location))
+        cls.site, _ = Location.objects.get_or_create(name="HQ", status=cls.status_active, location_type=loc_type)
 
-        self.device_type, _ = DeviceType.objects.get_or_create(model="DCS-7280CR2-60", manufacturer=arista_manu)
+        cls.device_type, _ = DeviceType.objects.get_or_create(model="DCS-7280CR2-60", manufacturer=arista_manu)
         role, _ = Role.objects.get_or_create(name="Switch")
 
-        self.device = OrmDevice.objects.create(
+        cls.device = OrmDevice.objects.create(
             name="ams01-switch-01",
-            device_type=self.device_type,
-            status=self.status_active,
+            device_type=cls.device_type,
+            status=cls.status_active,
             role=role,
-            location=self.site,
+            location=cls.site,
         )
 
-        self.warnings = []
+        cls.warnings = []
         mock_job = MagicMock()
         mock_job.debug = False
-        mock_job.logger.warning = lambda msg: self.warnings.append(str(msg))
-        self.adapter = NautobotAdapter(job=mock_job)
+        mock_job.logger.warning = lambda msg: cls.warnings.append(str(msg))
+        cls.adapter = NautobotAdapter(job=mock_job)
 
     def _attrs(self, **overrides):
         attrs = {
@@ -304,50 +312,52 @@ class TestNautobotPortCreate(TransactionTestCase):
         },
     },
 )
-class TestNautobotDeviceUpdate(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotDeviceUpdate(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test NautobotDevice.update() persists supported attribute changes."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Build a Device with Active status and a configured adapter."""
-        super().setUp()
-        self.adapter = MagicMock()
-        self.adapter.job = MagicMock()
-        self.adapter.job.app_config = get_config()
+        super().setUpTestData()
+        populate_status_choices()
+        cls.adapter = MagicMock()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.app_config = get_config()
 
         device_ct = ContentType.objects.get_for_model(OrmDevice)
         location_ct = ContentType.objects.get_for_model(Location)
 
-        self.status_active = Status.objects.get(name="Active")
-        self.status_offline, _ = Status.objects.get_or_create(name="Offline")
-        for status in (self.status_active, self.status_offline):
+        cls.status_active = Status.objects.get(name="Active")
+        cls.status_offline, _ = Status.objects.get_or_create(name="Offline")
+        for status in (cls.status_active, cls.status_offline):
             status.content_types.add(device_ct)
             status.content_types.add(location_ct)
 
-        self.role, _ = Role.objects.get_or_create(name="aristacv-test-switch")
-        self.role.content_types.add(device_ct)
-        self.manufacturer, _ = Manufacturer.objects.get_or_create(name="Arista")
-        self.device_type, _ = DeviceType.objects.get_or_create(
+        cls.role, _ = Role.objects.get_or_create(name="aristacv-test-switch")
+        cls.role.content_types.add(device_ct)
+        cls.manufacturer, _ = Manufacturer.objects.get_or_create(name="Arista")
+        cls.device_type, _ = DeviceType.objects.get_or_create(
             model="aristacv-test-dt",
-            manufacturer=self.manufacturer,
+            manufacturer=cls.manufacturer,
         )
-        self.location_type, _ = LocationType.objects.get_or_create(name="Site")
-        self.location_type.content_types.add(device_ct)
-        self.location = Location.objects.create(
+        cls.location_type, _ = LocationType.objects.get_or_create(name="Site")
+        cls.location_type.content_types.add(device_ct)
+        cls.location = Location.objects.create(
             name="DeviceUpdateSite",
-            location_type=self.location_type,
-            status=self.status_active,
+            location_type=cls.location_type,
+            status=cls.status_active,
         )
-        self.device = OrmDevice(
+        cls.device = OrmDevice(
             name="sw-update-test",
-            status=self.status_active,
-            role=self.role,
-            device_type=self.device_type,
-            location=self.location,
+            status=cls.status_active,
+            role=cls.role,
+            device_type=cls.device_type,
+            location=cls.location,
         )
-        self.device.validated_save()
-        self.platform, _ = Platform.objects.get_or_create(name="arista.eos.eos")
+        cls.device.validated_save()
+        cls.platform, _ = Platform.objects.get_or_create(name="arista.eos.eos")
 
     def test_update_persists_status_change(self):
         """update() with a status attribute writes the new status to the database."""

--- a/nautobot_ssot/tests/aristacv/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_nautobot_adapter.py
@@ -2,7 +2,7 @@
 
 from diffsync.enum import DiffSyncModelFlags
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
 from nautobot.extras.models import JobResult, Role, Status
 from nautobot.ipam.models import Namespace as OrmNamespace
@@ -12,7 +12,7 @@ from nautobot_ssot.integrations.aristacv.diffsync.adapters.nautobot import Nauto
 from nautobot_ssot.integrations.aristacv.jobs import CloudVisionDataSource
 
 
-class NautobotAdapterTestCase(TransactionTestCase):
+class NautobotAdapterTestCase(TestCase):
     """Test the NautobotAdapter class."""
 
     job_class = CloudVisionDataSource
@@ -21,7 +21,8 @@ class NautobotAdapterTestCase(TransactionTestCase):
         "job_logs",
     )
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Create Nautobot objects to test with."""
         status_active, _ = Status.objects.get_or_create(name="Active")
         arista_manu, _ = Manufacturer.objects.get_or_create(name="Arista")
@@ -47,11 +48,11 @@ class NautobotAdapterTestCase(TransactionTestCase):
             location=hq_site,
         )
 
-        self.job = self.job_class()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = cls.job_class()
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.nb_adapter = NautobotAdapter(job=self.job)
+        cls.nb_adapter = NautobotAdapter(job=cls.job)
 
     def test_load_devices(self):
         """Test the load_devices() function."""

--- a/nautobot_ssot/tests/aristacv/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/aristacv/test_nautobot_adapter.py
@@ -49,9 +49,7 @@ class NautobotAdapterTestCase(TestCase):
         )
 
         cls.job = cls.job_class()
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.nb_adapter = NautobotAdapter(job=cls.job)
 
     def test_load_devices(self):

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from cloudvision.Connector.codec.custom_types import FrozenDict, Path
 from cvprac.cvp_client import CvpLoginError
 from django.test import override_settings
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from parameterized import parameterized
 
 from nautobot_ssot.integrations.aristacv.utils import cloudvision

--- a/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_nautobot.py
@@ -1,8 +1,9 @@
 """Tests of CloudVision utility methods."""
 
 from django.test import override_settings
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer, Platform, SoftwareVersion
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Status, Tag
 
 from nautobot_ssot.integrations.aristacv.constants import ARISTA_PLATFORM
@@ -14,10 +15,12 @@ class TestNautobotUtils(TestCase):
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure shared test vars."""
-        self.arista_manu = Manufacturer.objects.get_or_create(name="Arista")[0]
-        self.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=self.arista_manu)[0]
+        populate_status_choices()
+        cls.arista_manu = Manufacturer.objects.get_or_create(name="Arista")[0]
+        cls.arista_platform = Platform.objects.get_or_create(name=ARISTA_PLATFORM, manufacturer=cls.arista_manu)[0]
 
     def test_verify_site_success(self):
         """Test the verify_site method for existing Site."""

--- a/nautobot_ssot/tests/bootstrap/test_bootstrap_adapter.py
+++ b/nautobot_ssot/tests/bootstrap/test_bootstrap_adapter.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import yaml
 from deepdiff import DeepDiff
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.bootstrap.diffsync.adapters.bootstrap import (
@@ -110,7 +110,7 @@ def assert_deep_diff(test_case, actual, expected, keys_to_normalize=None):
     test_case.assertEqual(diff, {})
 
 
-class TestBootstrapAdapterTestCase(TransactionTestCase):
+class TestBootstrapAdapterTestCase(TestCase):
     """Test NautobotSsotBootstrapAdapter class."""
 
     databases = ("default", "job_logs")
@@ -119,19 +119,20 @@ class TestBootstrapAdapterTestCase(TransactionTestCase):
         super().__init__(*args, **kwargs)
         self.max_diff = None
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Initialize test case."""
-        self.job = BootstrapDataSource()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = BootstrapDataSource()
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
 
-        self.bootstrap_client = MagicMock()
-        self.bootstrap_client.get_global_settings.return_value = GLOBAL_YAML_SETTINGS
-        self.bootstrap_client.get_develop_settings.return_value = DEVELOP_YAML_SETTINGS
-        self.bootstrap_client.get_production_settings.return_value = GLOBAL_YAML_SETTINGS
+        cls.bootstrap_client = MagicMock()
+        cls.bootstrap_client.get_global_settings.return_value = GLOBAL_YAML_SETTINGS
+        cls.bootstrap_client.get_develop_settings.return_value = DEVELOP_YAML_SETTINGS
+        cls.bootstrap_client.get_production_settings.return_value = GLOBAL_YAML_SETTINGS
 
-        self.bootstrap = BootstrapAdapter(job=self.job, sync=None, client=self.bootstrap_client)
+        cls.bootstrap = BootstrapAdapter(job=cls.job, sync=None, client=cls.bootstrap_client)
 
     def test_develop_settings(self):
         self.assertEqual(self.bootstrap_client.get_develop_settings(), DEVELOP_YAML_SETTINGS)

--- a/nautobot_ssot/tests/bootstrap/test_bootstrap_adapter.py
+++ b/nautobot_ssot/tests/bootstrap/test_bootstrap_adapter.py
@@ -123,9 +123,7 @@ class TestBootstrapAdapterTestCase(TestCase):
     def setUpTestData(cls):
         """Initialize test case."""
         cls.job = BootstrapDataSource()
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
 
         cls.bootstrap_client = MagicMock()
         cls.bootstrap_client.get_global_settings.return_value = GLOBAL_YAML_SETTINGS

--- a/nautobot_ssot/tests/bootstrap/test_bootstrap_setup.py
+++ b/nautobot_ssot/tests/bootstrap/test_bootstrap_setup.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import yaml
+from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import ProtectedError
 from django.utils.text import slugify
 from nautobot.circuits.models import (
     Circuit,
@@ -199,44 +201,20 @@ class NautobotTestSetup:
 
     def _empty_database(self):
         """Empty the database before trying to populate data."""
-        for model in (
-            Circuit,
-            CircuitTermination,
-            CircuitType,
-            ComputedField,
-            Contact,
-            CustomField,
-            Device,
-            DeviceType,
-            DynamicGroup,
-            ExternalIntegration,
-            GitRepository,
-            GraphQLQuery,
-            InventoryItem,
-            JobResult,
-            Location,
-            LocationType,
-            Manufacturer,
-            Namespace,
-            Platform,
-            Prefix,
-            Provider,
-            ProviderNetwork,
-            RIR,
-            Role,
-            ScheduledJob,
-            Secret,
-            SecretsGroup,
-            Status,
-            Tag,
-            Team,
-            Tenant,
-            TenantGroup,
-            VLAN,
-            VLANGroup,
-            VRF,
-        ):
-            model.objects.all().delete()
+        database_empty = False
+        recursion_limit = 10
+        while not database_empty:
+            recursion_limit -= 1
+            if recursion_limit == 0:
+                raise RuntimeError("Unable to empty database")
+            database_empty = True
+            for model in apps.get_models():
+                if model._meta.label_lower in ("extras.job", "extras.jobqueue", "contenttypes.contenttype"):
+                    continue
+                try:
+                    model.objects.all().delete()
+                except ProtectedError:
+                    database_empty = False
 
     def _initialize_data(self):
         self._setup_tags()

--- a/nautobot_ssot/tests/bootstrap/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/bootstrap/test_nautobot_adapter.py
@@ -6,7 +6,7 @@
 from datetime import datetime, timezone
 
 from deepdiff import DeepDiff
-from django.test import TransactionTestCase
+from nautobot.apps.testing import TransactionTestCase
 
 from .test_bootstrap_setup import (
     GLOBAL_JSON_SETTINGS,

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 from diffsync.exceptions import ObjectNotFound
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.citrix_adm.diffsync.adapters.citrix_adm import CitrixAdmAdapter
@@ -17,7 +17,7 @@ from nautobot_ssot.tests.citrix_adm.fixtures import (
 )
 
 
-class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestCitrixAdmAdapterTestCase(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test NautobotSsotCitrixAdmAdapter class."""
 
     databases = ("default", "job_logs")
@@ -32,32 +32,33 @@ class TestCitrixAdmAdapterTestCase(TransactionTestCase):  # pylint: disable=too-
         self.addr = None
         super().__init__(*args, **kwargs)
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure shared objects for test cases."""
-        super().setUp()
-        self.instance = MagicMock()
-        self.instance.name = "Test"
-        self.instance.remote_url = "https://test.example.com"
-        self.instance.verify_ssl = True
+        super().setUpTestData()
+        cls.instance = MagicMock()
+        cls.instance.name = "Test"
+        cls.instance.remote_url = "https://test.example.com"
+        cls.instance.verify_ssl = True
 
-        self.citrix_adm_client = MagicMock()
-        self.citrix_adm_client.get_sites.return_value = SITE_FIXTURE_RECV
-        self.citrix_adm_client.get_devices.return_value = DEVICE_FIXTURE_RECV
-        self.citrix_adm_client.get_vlan_bindings.side_effect = VLAN_FIXTURE_RECV
-        self.citrix_adm_client.get_nsip6.side_effect = NSIP6_FIXTURE_RECV
-        self.job = CitrixAdmDataSource()
-        self.job.debug = True
-        self.job.location_map = {}
-        self.job.parent_location = None
-        self.job.hostname_mapping = {}
-        self.job.logger.warning = MagicMock()
-        self.job.logger.info = MagicMock()
-        self.job.logger.debug = MagicMock()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.citrix_adm_client = MagicMock()
+        cls.citrix_adm_client.get_sites.return_value = SITE_FIXTURE_RECV
+        cls.citrix_adm_client.get_devices.return_value = DEVICE_FIXTURE_RECV
+        cls.citrix_adm_client.get_vlan_bindings.side_effect = VLAN_FIXTURE_RECV
+        cls.citrix_adm_client.get_nsip6.side_effect = NSIP6_FIXTURE_RECV
+        cls.job = CitrixAdmDataSource()
+        cls.job.debug = True
+        cls.job.location_map = {}
+        cls.job.parent_location = None
+        cls.job.hostname_mapping = {}
+        cls.job.logger.warning = MagicMock()
+        cls.job.logger.info = MagicMock()
+        cls.job.logger.debug = MagicMock()
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.citrix_adm = CitrixAdmAdapter(job=self.job, sync=None, instances=[self.instance])
-        self.citrix_adm.conn = self.citrix_adm_client
+        cls.citrix_adm = CitrixAdmAdapter(job=cls.job, sync=None, instances=[cls.instance])
+        cls.citrix_adm.conn = cls.citrix_adm_client
 
     def test_load_site(self):
         """Test Nautobot SSoT Citrix ADM load_site() function."""

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_citrix_adm.py
@@ -54,9 +54,7 @@ class TestCitrixAdmAdapterTestCase(TestCase):  # pylint: disable=too-many-instan
         cls.job.logger.warning = MagicMock()
         cls.job.logger.info = MagicMock()
         cls.job.logger.debug = MagicMock()
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.citrix_adm = CitrixAdmAdapter(job=cls.job, sync=None, instances=[cls.instance])
         cls.citrix_adm.conn = cls.citrix_adm_client
 

--- a/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/citrix_adm/test_adapters_nautobot.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from diffsync.exceptions import ObjectNotFound
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import ProtectedError
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,
@@ -14,6 +14,7 @@ from nautobot.dcim.models import (
     LocationType,
     Manufacturer,
 )
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult, Role, Status
 from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
@@ -22,7 +23,7 @@ from nautobot_ssot.integrations.citrix_adm.diffsync.adapters.nautobot import Nau
 from nautobot_ssot.integrations.citrix_adm.jobs import CitrixAdmDataSource
 
 
-class NautobotDiffSyncTestCase(TransactionTestCase):
+class NautobotDiffSyncTestCase(TestCase):
     """Test the NautobotAdapter class."""
 
     databases = ("default", "job_logs")
@@ -33,35 +34,40 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         self.hq_site = None
         self.ny_region = None
 
-    def setUp(self):  # pylint: disable=too-many-locals
+    def setUp(self):
+        self.job.logger.info.reset_mock()
+        self.job.logger.warning.reset_mock()
+
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=too-many-locals
         """Per-test-case data setup."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
 
-        self.job = CitrixAdmDataSource()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
-        )
-        self.nb_adapter = NautobotAdapter(job=self.job, sync=None)
-        self.job.logger.info = MagicMock()
-        self.job.logger.warning = MagicMock()
-        self.build_nautobot_objects()
+        cls.job = CitrixAdmDataSource()
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
+        cls.nb_adapter = NautobotAdapter(job=cls.job, sync=None)
+        cls.job.logger.info = MagicMock()
+        cls.job.logger.warning = MagicMock()
+        cls.build_nautobot_objects()
 
-    def build_nautobot_objects(self):
+    @classmethod
+    def build_nautobot_objects(cls):
         """Build out Nautobot objects to test loading."""
         test_tenant = Tenant.objects.get_or_create(name="Test")[0]
         region_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        self.ny_region = Location.objects.create(name="NY", location_type=region_type, status=self.status_active)
-        self.ny_region.validated_save()
+        cls.ny_region = Location.objects.create(name="NY", location_type=region_type, status=cls.status_active)
+        cls.ny_region.validated_save()
 
         site_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
         site_type.content_types.add(ContentType.objects.get_for_model(Device))
-        self.job.dc_loctype = site_type
-        self.job.parent_location = self.ny_region
-        self.hq_site = Location.objects.create(
-            parent=self.ny_region, name="HQ", location_type=site_type, status=self.status_active
+        cls.job.dc_loctype = site_type
+        cls.job.parent_location = cls.ny_region
+        cls.hq_site = Location.objects.create(
+            parent=cls.ny_region, name="HQ", location_type=site_type, status=cls.status_active
         )
-        self.hq_site.validated_save()
+        cls.hq_site.validated_save()
 
         citrix_manu, _ = Manufacturer.objects.get_or_create(name="Citrix")
         srx_devicetype, _ = DeviceType.objects.get_or_create(model="SDX", manufacturer=citrix_manu)
@@ -73,8 +79,8 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
             device_type=srx_devicetype,
             role=core_role,
             serial="FQ123456",
-            location=self.hq_site,
-            status=self.status_active,
+            location=cls.hq_site,
+            status=cls.status_active,
             tenant=test_tenant,
         )
         core_router._custom_field_data["system_of_record"] = "Citrix ADM"  # pylint: disable=protected-access
@@ -83,18 +89,18 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
             name="Management",
             type="virtual",
             device=core_router,
-            status=self.status_active,
+            status=cls.status_active,
         )
         mgmt_intf.validated_save()
 
         global_ns = Namespace.objects.get_or_create(name="Global")[0]
         mgmt4_pf = Prefix.objects.create(
-            prefix="10.1.1.0/24", namespace=global_ns, status=self.status_active, tenant=test_tenant
+            prefix="10.1.1.0/24", namespace=global_ns, status=cls.status_active, tenant=test_tenant
         )
         mgmt6_pf = Prefix.objects.create(
             prefix="2001:db8:3333:4444:5555:6666:7777:8888/128",
             namespace=global_ns,
-            status=self.status_active,
+            status=cls.status_active,
             tenant=test_tenant,
         )
         mgmt4_pf._custom_field_data["system_of_record"] = "Citrix ADM"  # pylint: disable=protected-access
@@ -106,7 +112,7 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
             address="10.1.1.1/24",
             namespace=global_ns,
             parent=mgmt4_pf,
-            status=self.status_active,
+            status=cls.status_active,
             tenant=test_tenant,
         )
         mgmt_addr._custom_field_data["system_of_record"] = "Citrix ADM"  # pylint: disable=protected-access
@@ -114,7 +120,7 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         mgmt_addr6 = IPAddress.objects.create(
             address="2001:db8:3333:4444:5555:6666:7777:8888/128",
             parent=mgmt6_pf,
-            status=self.status_active,
+            status=cls.status_active,
             tenant=test_tenant,
         )
         mgmt_addr6._custom_field_data["system_of_record"] = "Citrix ADM"  # pylint: disable=protected-access

--- a/nautobot_ssot/tests/citrix_adm/test_models_nautobot.py
+++ b/nautobot_ssot/tests/citrix_adm/test_models_nautobot.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, Location, LocationType
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Status
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
@@ -15,29 +16,31 @@ from nautobot_ssot.integrations.citrix_adm.diffsync.models.nautobot import Nauto
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_citrix_adm": True}})
-class TestNautobotDatacenter(TransactionTestCase):
+class TestNautobotDatacenter(TestCase):
     """Test the NautobotDatacenter class."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure shared objects."""
-        super().setUp()
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.warning = MagicMock()
-        self.status_active = Status.objects.get(name="Active")
-        self.test_dc = NautobotDatacenter(name="Test", region="", latitude=None, longitude=None, uuid=None)
+        super().setUpTestData()
+        populate_status_choices()
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.warning = MagicMock()
+        cls.status_active = Status.objects.get(name="Active")
+        cls.test_dc = NautobotDatacenter(name="Test", region="", latitude=None, longitude=None, uuid=None)
         region_lt = LocationType.objects.get_or_create(name="Region")[0]
-        self.global_region = Location.objects.create(name="Global", location_type=region_lt, status=self.status_active)
+        cls.global_region = Location.objects.create(name="Global", location_type=region_lt, status=cls.status_active)
         site_lt, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_lt})
         site_lt.content_types.add(ContentType.objects.get_for_model(Device))
-        self.site_obj = Location.objects.create(
+        cls.site_obj = Location.objects.create(
             name="HQ",
             location_type=site_lt,
-            parent=self.global_region,
-            status=self.status_active,
+            parent=cls.global_region,
+            status=cls.status_active,
         )
-        self.adapter.job.dc_loctype = site_lt
-        self.adapter.job.parent_loc = None
+        cls.adapter.job.dc_loctype = site_lt
+        cls.adapter.job.parent_loc = None
 
     def test_create(self):
         """Validate the NautobotDatacenter create() method creates a Site."""
@@ -87,36 +90,38 @@ class TestNautobotDatacenter(TransactionTestCase):
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_citrix_adm": True}})
-class TestNautobotAddress(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotAddress(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test the NautobotAddress class."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure shared objects."""
-        super().setUp()
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.warning = MagicMock()
-        self.status_active = Status.objects.get(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.warning = MagicMock()
+        cls.status_active = Status.objects.get(name="Active")
         region_lt = LocationType.objects.get_or_create(name="Region")[0]
-        self.global_region = Location.objects.create(name="Global", location_type=region_lt, status=self.status_active)
+        cls.global_region = Location.objects.create(name="Global", location_type=region_lt, status=cls.status_active)
         site_lt, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_lt})
         site_lt.content_types.add(ContentType.objects.get_for_model(Device))
-        self.site_obj = Location.objects.create(
+        cls.site_obj = Location.objects.create(
             name="HQ",
             location_type=site_lt,
-            parent=self.global_region,
-            status=self.status_active,
+            parent=cls.global_region,
+            status=cls.status_active,
         )
-        self.global_namespace = Namespace.objects.get_or_create(name="Global")[0]
-        self.test_namespace = Namespace.objects.get_or_create(name="Test")[0]
-        self.adapter.job.dc_loctype = site_lt
-        self.adapter.job.parent_loc = None
-        self.adapter.job.tenant = Tenant.objects.create(name="Test")
-        self.test_prefix = Prefix.objects.create(
-            prefix="10.1.1.0/24", namespace=self.test_namespace, status=self.status_active
+        cls.global_namespace = Namespace.objects.get_or_create(name="Global")[0]
+        cls.test_namespace = Namespace.objects.get_or_create(name="Test")[0]
+        cls.adapter.job.dc_loctype = site_lt
+        cls.adapter.job.parent_loc = None
+        cls.adapter.job.tenant = Tenant.objects.create(name="Test")
+        cls.test_prefix = Prefix.objects.create(
+            prefix="10.1.1.0/24", namespace=cls.test_namespace, status=cls.status_active
         )
-        self.update_ip_obj = IPAddress.objects.create(
-            address="10.1.1.1/24", namespace=self.test_namespace, status=self.status_active
+        cls.update_ip_obj = IPAddress.objects.create(
+            address="10.1.1.1/24", namespace=cls.test_namespace, status=cls.status_active
         )
 
     def test_create(self):

--- a/nautobot_ssot/tests/citrix_adm/test_utils_citrix_adm.py
+++ b/nautobot_ssot/tests/citrix_adm/test_utils_citrix_adm.py
@@ -4,7 +4,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import requests
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from requests.exceptions import HTTPError
 
 from nautobot_ssot.integrations.citrix_adm.utils.citrix_adm import (

--- a/nautobot_ssot/tests/contrib/nautobot_model/test_method_get_synced_parameters.py
+++ b/nautobot_ssot/tests/contrib/nautobot_model/test_method_get_synced_parameters.py
@@ -1,6 +1,6 @@
 """Tests for contrib.NautobotModel."""
 
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.contrib.model import NautobotModel
 

--- a/nautobot_ssot/tests/contrib/test_sorting.py
+++ b/nautobot_ssot/tests/contrib/test_sorting.py
@@ -4,7 +4,7 @@ from typing import Annotated, List, Optional
 from unittest import skip
 from unittest.mock import MagicMock
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import Tag
 from nautobot.tenancy.models import Tenant
 from typing_extensions import TypedDict, get_type_hints

--- a/nautobot_ssot/tests/contrib_base_classes.py
+++ b/nautobot_ssot/tests/contrib_base_classes.py
@@ -11,8 +11,9 @@ import nautobot.ipam.models as ipam_models
 import nautobot.tenancy.models as tenancy_models
 from diffsync.exceptions import ObjectNotCreated, ObjectNotDeleted, ObjectNotUpdated
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.extras.management import populate_status_choices
 from typing_extensions import TypedDict
 
 from nautobot_ssot.contrib import (
@@ -29,14 +30,14 @@ class TestCaseWithDeviceData(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        populate_status_choices()
         cls.status_active = extras_models.Status.objects.get(name="Active")
         cls.device_role = extras_models.Role.objects.create(name="Switch")
         cls.device_role.content_types.set([ContentType.objects.get_for_model(dcim_models.Device)])
         cls.manufacturer = dcim_models.Manufacturer.objects.create(name="Generic Inc.")
         cls.device_type = dcim_models.DeviceType.objects.create(model="Generic Switch", manufacturer=cls.manufacturer)
-        cls.location_type, created = dcim_models.LocationType.objects.get_or_create(name="Site")
-        if created:
-            cls.location_type.content_types.add(ContentType.objects.get_for_model(dcim_models.Device))
+        cls.location_type, _ = dcim_models.LocationType.objects.get_or_create(name="Site")
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(dcim_models.Device))
         cls.location = dcim_models.Location.objects.create(
             name="Bremen",
             location_type=cls.location_type,
@@ -54,6 +55,12 @@ class TestCaseWithDeviceData(TestCase):
                 device=device,
                 name="Loopback 1",
                 type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                status=cls.status_active,
+            )
+            dcim_models.Interface.objects.create(
+                device=device,
+                name="Ethernet1",
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
                 status=cls.status_active,
             )
         cls.namespace, _ = ipam_models.Namespace.objects.get_or_create(name="Global")

--- a/nautobot_ssot/tests/device42/unit/test_device42_adapter.py
+++ b/nautobot_ssot/tests/device42/unit/test_device42_adapter.py
@@ -4,7 +4,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import LocationType
 from nautobot.extras.models import JobResult
 from parameterized import parameterized
@@ -45,54 +45,55 @@ IPADDRESS_FIXTURE = load_json("./nautobot_ssot/tests/device42/fixtures/get_ip_ad
 IPADDRESS_CF_FIXTURE = load_json("./nautobot_ssot/tests/device42/fixtures/get_ipaddr_custom_fields_recv.json")
 
 
-class Device42AdapterTestCase(TransactionTestCase):  # pylint: disable=too-many-public-methods
+class Device42AdapterTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """Test the Device42Adapter class."""
 
     job_class = Device42DataSource
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Method to initialize test case."""
         # Create a mock client
-        self.d42_client = MagicMock()
-        self.d42_client.get_buildings.return_value = BUILDING_FIXTURE
-        self.d42_client.get_rooms.return_value = ROOM_FIXTURE
-        self.d42_client.get_racks.return_value = RACK_FIXTURE
-        self.d42_client.get_vendors.return_value = VENDOR_FIXTURE
-        self.d42_client.get_hardware_models.return_value = HARDWARE_FIXTURE
-        self.d42_client.get_vrfgroups.return_value = VRFGROUP_FIXTURE
-        self.d42_client.get_vlans_with_location.return_value = VLAN_FIXTURE
-        self.d42_client.get_subnet_default_custom_fields.return_value = SUBNET_DEFAULT_CFS_FIXTURE
-        self.d42_client.get_subnet_custom_fields.return_value = SUBNET_CFS_FIXTURE
-        self.d42_client.get_subnets.return_value = SUBNET_FIXTURE
-        self.d42_client.get_devices.return_value = DEVICE_FIXTURE
-        self.d42_client.get_cluster_members.return_value = CLUSTER_MEMBER_FIXTURE
-        self.d42_client.get_ports_with_vlans.return_value = PORTS_W_VLANS_FIXTURE
-        self.d42_client.get_ports_wo_vlans.return_value = PORTS_WO_VLANS_FIXTURE
-        self.d42_client.get_port_custom_fields.return_value = PORT_CUSTOM_FIELDS
-        self.d42_client.get_ip_addrs.return_value = IPADDRESS_FIXTURE
-        self.d42_client.get_ipaddr_custom_fields.return_value = IPADDRESS_CF_FIXTURE
-        self.d42_client.get_port_default_custom_fields.return_value = {}
-        self.d42_client.get_ipaddr_default_custom_fields.return_value = {}
+        cls.d42_client = MagicMock()
+        cls.d42_client.get_buildings.return_value = BUILDING_FIXTURE
+        cls.d42_client.get_rooms.return_value = ROOM_FIXTURE
+        cls.d42_client.get_racks.return_value = RACK_FIXTURE
+        cls.d42_client.get_vendors.return_value = VENDOR_FIXTURE
+        cls.d42_client.get_hardware_models.return_value = HARDWARE_FIXTURE
+        cls.d42_client.get_vrfgroups.return_value = VRFGROUP_FIXTURE
+        cls.d42_client.get_vlans_with_location.return_value = VLAN_FIXTURE
+        cls.d42_client.get_subnet_default_custom_fields.return_value = SUBNET_DEFAULT_CFS_FIXTURE
+        cls.d42_client.get_subnet_custom_fields.return_value = SUBNET_CFS_FIXTURE
+        cls.d42_client.get_subnets.return_value = SUBNET_FIXTURE
+        cls.d42_client.get_devices.return_value = DEVICE_FIXTURE
+        cls.d42_client.get_cluster_members.return_value = CLUSTER_MEMBER_FIXTURE
+        cls.d42_client.get_ports_with_vlans.return_value = PORTS_W_VLANS_FIXTURE
+        cls.d42_client.get_ports_wo_vlans.return_value = PORTS_WO_VLANS_FIXTURE
+        cls.d42_client.get_port_custom_fields.return_value = PORT_CUSTOM_FIELDS
+        cls.d42_client.get_ip_addrs.return_value = IPADDRESS_FIXTURE
+        cls.d42_client.get_ipaddr_custom_fields.return_value = IPADDRESS_CF_FIXTURE
+        cls.d42_client.get_port_default_custom_fields.return_value = {}
+        cls.d42_client.get_ipaddr_default_custom_fields.return_value = {}
 
-        self.job = self.job_class()
-        self.job.building_loctype = LocationType.objects.get_or_create(name="Site")[0]
-        self.job.logger = MagicMock()
-        self.job.logger.info = MagicMock()
-        self.job.logger.warning = MagicMock()
-        self.job.debug = True
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = cls.job_class()
+        cls.job.building_loctype = LocationType.objects.get_or_create(name="Site")[0]
+        cls.job.logger = MagicMock()
+        cls.job.logger.info = MagicMock()
+        cls.job.logger.warning = MagicMock()
+        cls.job.debug = True
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.device42 = Device42Adapter(job=self.job, sync=None, client=self.d42_client)
-        self.mock_device = MagicMock()
-        self.mock_device.name = "cluster1 - Switch 1"
-        self.mock_device.os_version = "1.0"
-        self.cluster_dev = MagicMock()
-        self.cluster_dev.name = "cluster1"
-        self.master_dev = MagicMock()
-        self.master_dev.name = "cluster1"
-        self.master_dev.os_version = ""
+        cls.device42 = Device42Adapter(job=cls.job, sync=None, client=cls.d42_client)
+        cls.mock_device = MagicMock()
+        cls.mock_device.name = "cluster1 - Switch 1"
+        cls.mock_device.os_version = "1.0"
+        cls.cluster_dev = MagicMock()
+        cls.cluster_dev.name = "cluster1"
+        cls.master_dev = MagicMock()
+        cls.master_dev.name = "cluster1"
+        cls.master_dev.os_version = ""
 
     @patch(
         "nautobot_ssot.integrations.device42.utils.device42.PLUGIN_CFG",

--- a/nautobot_ssot/tests/device42/unit/test_device42_adapter.py
+++ b/nautobot_ssot/tests/device42/unit/test_device42_adapter.py
@@ -82,9 +82,7 @@ class Device42AdapterTestCase(TestCase):  # pylint: disable=too-many-public-meth
         cls.job.logger.info = MagicMock()
         cls.job.logger.warning = MagicMock()
         cls.job.debug = True
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.device42 = Device42Adapter(job=cls.job, sync=None, client=cls.d42_client)
         cls.mock_device = MagicMock()
         cls.mock_device.name = "cluster1 - Switch 1"

--- a/nautobot_ssot/tests/device42/unit/test_models_nautobot_ipam.py
+++ b/nautobot_ssot/tests/device42/unit/test_models_nautobot_ipam.py
@@ -5,25 +5,27 @@ from unittest.mock import MagicMock, patch
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
 from django.forms import ValidationError
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer, Platform
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import VLAN, VRF, IPAddress, IPAddressToInterface, Namespace, Prefix
 
 from nautobot_ssot.integrations.device42.diffsync.models.nautobot import ipam
 
 
-class TestNautobotVRFGroup(TransactionTestCase):
+class TestNautobotVRFGroup(TestCase):
     """Test the NautobotVRFGroup class."""
 
-    def setUp(self):
-        self.adapter = Adapter()
-        self.adapter.namespace_map = {}
-        self.adapter.vrf_map = {}
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.info = MagicMock()
-        self.vrf = VRF.objects.create(name="Test")
-        self.vrf.validated_save()
+    @classmethod
+    def setUpTestData(cls):
+        cls.adapter = Adapter()
+        cls.adapter.namespace_map = {}
+        cls.adapter.vrf_map = {}
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.info = MagicMock()
+        cls.vrf = VRF.objects.create(name="Test")
+        cls.vrf.validated_save()
 
     def test_create(self):
         """Validate the NautobotVRFGroup create() method creates a VRF."""
@@ -96,22 +98,24 @@ class TestNautobotVRFGroup(TransactionTestCase):
         self.assertEqual(self.adapter.objects_to_delete["vrf"][0].id, self.vrf.id)
 
 
-class TestNautobotSubnet(TransactionTestCase):
+class TestNautobotSubnet(TestCase):
     """Test the NautobotSubnet class."""
 
-    def setUp(self):
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
-        self.test_ns = Namespace.objects.get_or_create(name="Test")[0]
-        self.test_vrf = VRF.objects.get_or_create(name="Test", namespace=self.test_ns)[0]
-        self.prefix = Prefix.objects.create(prefix="10.0.0.0/24", namespace=self.test_ns, status=self.status_active)
-        self.adapter = Adapter()
-        self.adapter.namespace_map = {"Test": self.test_ns.id}
-        self.adapter.vrf_map = {"Test": self.test_vrf.id}
-        self.adapter.status_map = {"Active": self.status_active.id}
-        self.adapter.prefix_map = {}
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.info = MagicMock()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        cls.test_ns = Namespace.objects.get_or_create(name="Test")[0]
+        cls.test_vrf = VRF.objects.get_or_create(name="Test", namespace=cls.test_ns)[0]
+        cls.prefix = Prefix.objects.create(prefix="10.0.0.0/24", namespace=cls.test_ns, status=cls.status_active)
+        cls.adapter = Adapter()
+        cls.adapter.namespace_map = {"Test": cls.test_ns.id}
+        cls.adapter.vrf_map = {"Test": cls.test_vrf.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.prefix_map = {}
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.info = MagicMock()
 
     def test_create(self):
         """Validate the NautobotSubnet create() method creates a Prefix."""
@@ -188,7 +192,7 @@ class TestNautobotSubnet(TransactionTestCase):
         self.assertEqual(self.adapter.objects_to_delete["subnet"][0].id, self.prefix.id)
 
 
-class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotIPAddress(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test the NautobotIPAddress class."""
 
     def __init__(self, *args, **kwargs):
@@ -196,53 +200,55 @@ class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-in
         super().__init__(*args, **kwargs)
         self.addr = None
 
-    def setUp(self):
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
         status_reserved = Status.objects.get(name="Reserved")
         loc_type = LocationType.objects.get_or_create(name="Site")[0]
         loc_type.content_types.add(ContentType.objects.get_for_model(Device))
         loc_type.content_types.add(ContentType.objects.get_for_model(Prefix))
-        loc = Location.objects.get_or_create(name="Test Site", location_type=loc_type, status=self.status_active)[0]
+        loc = Location.objects.get_or_create(name="Test Site", location_type=loc_type, status=cls.status_active)[0]
         cisco_manu = Manufacturer.objects.get_or_create(name="Cisco")[0]
         csr1000v = DeviceType.objects.get_or_create(model="CSR1000v", manufacturer=cisco_manu)[0]
         ios_platform = Platform.objects.create(name="Cisco IOS", manufacturer=cisco_manu)
         router_role = Role.objects.create(name="Router")
         router_role.content_types.add(ContentType.objects.get_for_model(Device))
-        self.test_dev = Device.objects.create(
+        cls.test_dev = Device.objects.create(
             name="Test Device",
             device_type=csr1000v,
             location=loc,
             platform=ios_platform,
             role=router_role,
-            status=self.status_active,
+            status=cls.status_active,
         )
-        self.test_dev2 = Device.objects.create(
+        cls.test_dev2 = Device.objects.create(
             name="Device2",
             device_type=csr1000v,
             location=loc,
             platform=ios_platform,
             role=router_role,
-            status=self.status_active,
+            status=cls.status_active,
         )
-        self.dev_eth0 = Interface.objects.create(
-            name="eth0", type="virtual", device=self.test_dev, status=self.status_active, mgmt_only=True
+        cls.dev_eth0 = Interface.objects.create(
+            name="eth0", type="virtual", device=cls.test_dev, status=cls.status_active, mgmt_only=True
         )
-        self.dev2_eth0 = Interface.objects.create(
-            name="eth0", type="virtual", device=self.test_dev2, status=self.status_active, mgmt_only=True
+        cls.dev2_eth0 = Interface.objects.create(
+            name="eth0", type="virtual", device=cls.test_dev2, status=cls.status_active, mgmt_only=True
         )
-        self.dev2_mgmt = Interface.objects.create(
-            name="mgmt0", type="virtual", device=self.test_dev2, status=self.status_active, mgmt_only=True
+        cls.dev2_mgmt = Interface.objects.create(
+            name="mgmt0", type="virtual", device=cls.test_dev2, status=cls.status_active, mgmt_only=True
         )
-        self.test_ns = Namespace.objects.get_or_create(name="Test")[0]
-        self.prefix = Prefix.objects.create(
+        cls.test_ns = Namespace.objects.get_or_create(name="Test")[0]
+        cls.prefix = Prefix.objects.create(
             prefix="10.0.0.0/24",
             location=loc,
-            namespace=self.test_ns,
-            status=self.status_active,
+            namespace=cls.test_ns,
+            status=cls.status_active,
         )
-        self.ids = {"address": "10.0.0.1/24", "subnet": "10.0.0.0/24"}
-        self.attrs = {
+        cls.ids = {"address": "10.0.0.1/24", "subnet": "10.0.0.0/24"}
+        cls.attrs = {
             "namespace": "Test",
             "available": False,
             "label": "Test",
@@ -253,21 +259,21 @@ class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-in
             "custom_fields": {},
         }
 
-        self.adapter = Adapter()
-        self.adapter.objects_to_create = {"ports": []}
-        self.adapter.namespace_map = {"Test": self.test_ns.id}
-        self.adapter.status_map = {"Active": self.status_active.id, "Reserved": status_reserved.id}
-        self.adapter.prefix_map = {"10.0.0.0/24": self.prefix.id}
-        self.adapter.device_map = {"Test Device": self.test_dev.id}
-        self.adapter.port_map = {
-            "Test Device": {"eth0": self.dev_eth0.id},
-            "Device2": {"mgmt0": self.dev2_mgmt.id, "eth0": self.dev2_eth0.id},
+        cls.adapter = Adapter()
+        cls.adapter.objects_to_create = {"ports": []}
+        cls.adapter.namespace_map = {"Test": cls.test_ns.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id, "Reserved": status_reserved.id}
+        cls.adapter.prefix_map = {"10.0.0.0/24": cls.prefix.id}
+        cls.adapter.device_map = {"Test Device": cls.test_dev.id}
+        cls.adapter.port_map = {
+            "Test Device": {"eth0": cls.dev_eth0.id},
+            "Device2": {"mgmt0": cls.dev2_mgmt.id, "eth0": cls.dev2_eth0.id},
         }
-        self.adapter.ipaddr_map = {}
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.info = MagicMock()
-        self.mock_addr = ipam.NautobotIPAddress(**self.ids, **self.attrs)
-        self.mock_addr.adapter = self.adapter
+        cls.adapter.ipaddr_map = {}
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.info = MagicMock()
+        cls.mock_addr = ipam.NautobotIPAddress(**cls.ids, **cls.attrs)
+        cls.mock_addr.adapter = cls.adapter
 
     def test_create_with_existing_interface(self):
         """Validate the NautobotIPAddress.create() functionality with existing Interface."""
@@ -411,7 +417,7 @@ class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-in
         )
 
 
-class TestNautobotVLAN(TransactionTestCase):
+class TestNautobotVLAN(TestCase):
     """Test the NautobotVLAN class."""
 
     def __init__(self, *args, **kwargs):
@@ -419,33 +425,35 @@ class TestNautobotVLAN(TransactionTestCase):
         super().__init__(*args, **kwargs)
         self.vlan = None
 
-    def setUp(self):
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
 
         site_type = LocationType.objects.get_or_create(name="Site")[0]
         site_type.content_types.add(ContentType.objects.get_for_model(Device))
         site_type.content_types.add(ContentType.objects.get_for_model(VLAN))
 
-        self.test_site = Location.objects.create(name="HQ", location_type=site_type, status=self.status_active)
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.info = MagicMock()
-        self.adapter.status_map = {"Active": self.status_active.id}
-        self.adapter.site_map = {"HQ": self.test_site.id}
-        self.adapter.vlan_map = {"HQ": {}}
-        self.ids = {
+        cls.test_site = Location.objects.create(name="HQ", location_type=site_type, status=cls.status_active)
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.info = MagicMock()
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.site_map = {"HQ": cls.test_site.id}
+        cls.adapter.vlan_map = {"HQ": {}}
+        cls.ids = {
             "vlan_id": 1,
             "building": None,
         }
-        self.attrs = {
+        cls.attrs = {
             "name": "Test",
             "description": "Test VLAN",
             "tags": [],
             "custom_fields": {},
         }
-        self.mock_vlan = ipam.NautobotVLAN(**self.ids, **self.attrs)
-        self.mock_vlan.adapter = self.adapter
+        cls.mock_vlan = ipam.NautobotVLAN(**cls.ids, **cls.attrs)
+        cls.mock_vlan.adapter = cls.adapter
 
     def test_create_with_undefined_building(self):
         """Validate the NautobotVLAN.create() functionality with an undefined building."""

--- a/nautobot_ssot/tests/device42/unit/test_utils_device42.py
+++ b/nautobot_ssot/tests/device42/unit/test_utils_device42.py
@@ -4,7 +4,7 @@ import json
 from unittest.mock import patch
 
 import responses
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from parameterized import parameterized
 
 from nautobot_ssot.exceptions import MissingConfigSetting

--- a/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
@@ -49,9 +49,7 @@ class TestNautobotUtils(TestCase):  # pylint: disable=too-many-instance-attribut
         _dr.validated_save()
         cls.dev = Device(name="Test", role=_dr, device_type=_dt, location=cls.site, status=cls.status_active)
         cls.dev.validated_save()
-        cls.intf = Interface(
-            name="Management", type="virtual", mode="access", device=cls.dev, status=cls.status_active
-        )
+        cls.intf = Interface(name="Management", type="virtual", mode="access", device=cls.dev, status=cls.status_active)
         cls.intf.validated_save()
         cls.mock_dev = NautobotDevice(
             name="Test",

--- a/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
+++ b/nautobot_ssot/tests/device42/unit/test_utils_nautobot.py
@@ -5,9 +5,10 @@ from uuid import UUID
 
 from diffsync.exceptions import ObjectNotFound
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import CustomField, Role, Status
 from nautobot.ipam.models import VLAN
 
@@ -20,37 +21,39 @@ from nautobot_ssot.integrations.device42.utils.nautobot import (
 )
 
 
-class TestNautobotUtils(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotUtils(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test Nautobot utility methods."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Setup shared test objects."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
-        self.cisco_manu, _ = Manufacturer.objects.get_or_create(name="Cisco")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        cls.cisco_manu, _ = Manufacturer.objects.get_or_create(name="Cisco")
         site_lt = LocationType.objects.get_or_create(name="Site")[0]
         site_lt.content_types.add(ContentType.objects.get_for_model(Device))
         site_lt.content_types.add(ContentType.objects.get_for_model(VLAN))
-        self.site = Location.objects.create(
+        cls.site = Location.objects.create(
             name="Test Site",
-            status=self.status_active,
+            status=cls.status_active,
             location_type=site_lt,
         )
-        self.site.validated_save()
-        _dt = DeviceType.objects.create(model="CSR1000v", manufacturer=self.cisco_manu)
+        cls.site.validated_save()
+        _dt = DeviceType.objects.create(model="CSR1000v", manufacturer=cls.cisco_manu)
         _dt.validated_save()
         _dr = Role.objects.create(name="CORE")
         _dr.content_types.add(ContentType.objects.get_for_model(Device))
         _dr.validated_save()
-        self.dev = Device(name="Test", role=_dr, device_type=_dt, location=self.site, status=self.status_active)
-        self.dev.validated_save()
-        self.intf = Interface(
-            name="Management", type="virtual", mode="access", device=self.dev, status=self.status_active
+        cls.dev = Device(name="Test", role=_dr, device_type=_dt, location=cls.site, status=cls.status_active)
+        cls.dev.validated_save()
+        cls.intf = Interface(
+            name="Management", type="virtual", mode="access", device=cls.dev, status=cls.status_active
         )
-        self.intf.validated_save()
-        self.mock_dev = NautobotDevice(
+        cls.intf.validated_save()
+        cls.mock_dev = NautobotDevice(
             name="Test",
             building="Microsoft HQ",
             room=None,
@@ -69,23 +72,23 @@ class TestNautobotUtils(TransactionTestCase):  # pylint: disable=too-many-instan
             custom_fields=None,
             uuid=None,
         )
-        self.mock_vlan = VLAN(
+        cls.mock_vlan = VLAN(
             vid=1,
             name="Test",
-            location=self.site,
-            status=self.status_active,
+            location=cls.site,
+            status=cls.status_active,
         )
-        self.mock_vlan.validated_save()
-        self.adapter = MagicMock()
-        self.adapter.get = MagicMock()
-        self.adapter.platform_map = {}
-        self.adapter.vlan_map = {"Microsoft HQ": {}, "Global": {}}
-        self.adapter.vlan_map["Microsoft HQ"][1] = self.mock_vlan.id
-        self.adapter.site_map = {}
-        self.adapter.status_map = {}
-        self.adapter.objects_to_create = {"platforms": [], "vlans": [], "tagged_vlans": []}
-        self.adapter.site_map["Test Site"] = self.site.id
-        self.adapter.status_map["Active"] = self.status_active.id
+        cls.mock_vlan.validated_save()
+        cls.adapter = MagicMock()
+        cls.adapter.get = MagicMock()
+        cls.adapter.platform_map = {}
+        cls.adapter.vlan_map = {"Microsoft HQ": {}, "Global": {}}
+        cls.adapter.vlan_map["Microsoft HQ"][1] = cls.mock_vlan.id
+        cls.adapter.site_map = {}
+        cls.adapter.status_map = {}
+        cls.adapter.objects_to_create = {"platforms": [], "vlans": [], "tagged_vlans": []}
+        cls.adapter.site_map["Test Site"] = cls.site.id
+        cls.adapter.status_map["Active"] = cls.status_active.id
 
     def test_verify_platform_ios(self):
         """Test the verify_platform method with IOS."""

--- a/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_dna_center.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TransactionTestCase
 from nautobot.dcim.models import (
     Controller,
     ControllerManagedDeviceGroup,

--- a/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
@@ -42,9 +42,7 @@ class NautobotDiffSyncTestCase(TestCase):  # pylint: disable=too-many-instance-a
         populate_status_choices()
         cls.status_active = Status.objects.get(name="Active")
         cls.reg_loc_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        cls.site_loc_type, _ = LocationType.objects.update_or_create(
-            name="Site", defaults={"parent": cls.reg_loc_type}
-        )
+        cls.site_loc_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": cls.reg_loc_type})
         cls.site_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
         cls.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=cls.site_loc_type)[0]
         cls.floor_loc_type.content_types.add(ContentType.objects.get_for_model(Device))

--- a/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/dna_center/test_adapters_nautobot.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from diffsync.exceptions import ObjectNotFound
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,
@@ -15,6 +15,7 @@ from nautobot.dcim.models import (
     Manufacturer,
     Platform,
 )
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult, Role, Status
 from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix
 
@@ -22,7 +23,7 @@ from nautobot_ssot.integrations.dna_center.diffsync.adapters.nautobot import Nau
 from nautobot_ssot.integrations.dna_center.jobs import DnaCenterDataSource
 
 
-class NautobotDiffSyncTestCase(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class NautobotDiffSyncTestCase(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test the NautobotAdapter class."""
 
     databases = ("default", "job_logs")
@@ -34,17 +35,19 @@ class NautobotDiffSyncTestCase(TransactionTestCase):  # pylint: disable=too-many
         self.hq_site = None
         self.floor_loc = None
 
-    def setUp(self):  # pylint: disable=too-many-locals
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=too-many-locals
         """Per-test-case data setup."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
-        self.reg_loc_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        self.site_loc_type, _ = LocationType.objects.update_or_create(
-            name="Site", defaults={"parent": self.reg_loc_type}
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        cls.reg_loc_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
+        cls.site_loc_type, _ = LocationType.objects.update_or_create(
+            name="Site", defaults={"parent": cls.reg_loc_type}
         )
-        self.site_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
-        self.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=self.site_loc_type)[0]
-        self.floor_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.site_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=cls.site_loc_type)[0]
+        cls.floor_loc_type.content_types.add(ContentType.objects.get_for_model(Device))
 
         job = DnaCenterDataSource()
         job.job_result = JobResult.objects.create(
@@ -52,10 +55,10 @@ class NautobotDiffSyncTestCase(TransactionTestCase):  # pylint: disable=too-many
         )
         job.logger.info = MagicMock()
         job.logger.warning = MagicMock()
-        job.area_loctype = self.reg_loc_type
-        job.building_loctype = self.site_loc_type
-        job.floor_loctype = self.floor_loc_type
-        self.nb_adapter = NautobotAdapter(job=job, sync=None)
+        job.area_loctype = cls.reg_loc_type
+        job.building_loctype = cls.site_loc_type
+        job.floor_loctype = cls.floor_loc_type
+        cls.nb_adapter = NautobotAdapter(job=job, sync=None)
 
     def build_nautobot_objects(self):  # pylint: disable=too-many-locals, too-many-statements
         """Build out Nautobot objects to test loading."""

--- a/nautobot_ssot/tests/dna_center/test_jobs.py
+++ b/nautobot_ssot/tests/dna_center/test_jobs.py
@@ -6,8 +6,8 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
-from nautobot.apps.testing import TestCase, TransactionTestCase
 from django.urls import reverse
+from nautobot.apps.testing import TestCase, TransactionTestCase
 from nautobot.core.testing import run_job_for_testing
 from nautobot.dcim.models import Controller, ControllerManagedDeviceGroup, Device, Interface, Location, LocationType
 from nautobot.extras.choices import CustomFieldTypeChoices, SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices

--- a/nautobot_ssot/tests/dna_center/test_jobs.py
+++ b/nautobot_ssot/tests/dna_center/test_jobs.py
@@ -6,7 +6,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase, TransactionTestCase
+from nautobot.apps.testing import TestCase, TransactionTestCase
 from django.urls import reverse
 from nautobot.core.testing import run_job_for_testing
 from nautobot.dcim.models import Controller, ControllerManagedDeviceGroup, Device, Interface, Location, LocationType

--- a/nautobot_ssot/tests/dna_center/test_models_nautobot.py
+++ b/nautobot_ssot/tests/dna_center/test_models_nautobot.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Controller,
     ControllerManagedDeviceGroup,
@@ -16,6 +16,7 @@ from nautobot.dcim.models import (
     Manufacturer,
     Platform,
 )
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import IPAddress, Prefix
 from nautobot.tenancy.models import Tenant
@@ -30,19 +31,21 @@ from nautobot_ssot.integrations.dna_center.diffsync.models.nautobot import (
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"dna_center_import_global": True}})
-class TestNautobotArea(TransactionTestCase):
+class TestNautobotArea(TestCase):
     """Test the NautobotArea class."""
 
-    def setUp(self):
-        super().setUp()
-        self.region_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.area_loctype = self.region_type
-        self.adapter.job.logger.info = MagicMock()
-        self.adapter.region_map = {}
-        self.adapter.locationtype_map = {"Region": self.region_type.id}
-        self.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
+        cls.region_type = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.area_loctype = cls.region_type
+        cls.adapter.job.logger.info = MagicMock()
+        cls.adapter.region_map = {}
+        cls.adapter.locationtype_map = {"Region": cls.region_type.id}
+        cls.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
 
     def test_create(self):
         """Validate the NautobotArea create() method creates a Region."""
@@ -70,35 +73,37 @@ class TestNautobotArea(TransactionTestCase):
 @override_settings(
     PLUGINS_CONFIG={"nautobot_ssot": {"dna_center_delete_locations": True, "dna_center_update_locations": True}}
 )
-class TestNautobotBuilding(TransactionTestCase):
+class TestNautobotBuilding(TestCase):
     """Test the NautobotBuilding class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
 
-        self.reg_loc = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
-        loc_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": self.reg_loc})
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.debug = True
-        self.adapter.job.area_loctype = self.reg_loc
-        self.adapter.job.building_loctype = loc_type
-        self.adapter.job.logger.info = MagicMock()
-        self.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
+        cls.reg_loc = LocationType.objects.get_or_create(name="Region", nestable=True)[0]
+        loc_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": cls.reg_loc})
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.debug = True
+        cls.adapter.job.area_loctype = cls.reg_loc
+        cls.adapter.job.building_loctype = loc_type
+        cls.adapter.job.logger.info = MagicMock()
+        cls.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
         ga_tenant = Tenant.objects.create(name="G&A")
-        self.adapter.tenant_map = {"G&A": ga_tenant.id}
+        cls.adapter.tenant_map = {"G&A": ga_tenant.id}
         ny_region = Location.objects.create(
-            name="NY", location_type=self.reg_loc, status=Status.objects.get(name="Active")
+            name="NY", location_type=cls.reg_loc, status=Status.objects.get(name="Active")
         )
-        self.adapter.locationtype_map = {"Region": self.reg_loc.id, "Site": loc_type.id}
-        self.sec_site = Location.objects.create(
+        cls.adapter.locationtype_map = {"Region": cls.reg_loc.id, "Site": loc_type.id}
+        cls.sec_site = Location.objects.create(
             name="Site 2", parent=ny_region, status=Status.objects.get(name="Active"), location_type=loc_type
         )
-        self.sec_site.validated_save()
-        self.adapter.site_map = {None: {"NY": ny_region.id}, "NY": {"Site 2": self.sec_site.id}}
-        self.test_bldg = NautobotBuilding(
+        cls.sec_site.validated_save()
+        cls.adapter.site_map = {None: {"NY": ny_region.id}, "NY": {"Site 2": cls.sec_site.id}}
+        cls.test_bldg = NautobotBuilding(
             name="Site 2",
             address="",
             area="NY",
@@ -106,9 +111,9 @@ class TestNautobotBuilding(TransactionTestCase):
             latitude=0,
             longitude=0,
             tenant="G&A",
-            uuid=self.sec_site.id,
+            uuid=cls.sec_site.id,
         )
-        self.test_bldg.adapter = self.adapter
+        cls.test_bldg.adapter = cls.adapter
 
     def test_create(self):
         """Validate the NautobotBuilding create() method creates a Site."""
@@ -182,32 +187,34 @@ class TestNautobotBuilding(TransactionTestCase):
         self.assertEqual(ds_mock_site, result)
 
 
-class TestNautobotFloor(TransactionTestCase):
+class TestNautobotFloor(TestCase):
     """Test the NautobotFloor class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
 
         site_loc_type = LocationType.objects.get_or_create(name="Site")[0]
-        self.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=site_loc_type)[0]
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.building_loctype = site_loc_type
-        self.adapter.job.floor_loctype = self.floor_loc_type
-        self.adapter.job.logger.info = MagicMock()
+        cls.floor_loc_type = LocationType.objects.get_or_create(name="Floor", parent=site_loc_type)[0]
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.building_loctype = site_loc_type
+        cls.adapter.job.floor_loctype = cls.floor_loc_type
+        cls.adapter.job.logger.info = MagicMock()
         ga_tenant = Tenant.objects.create(name="G&A")
-        self.adapter.tenant_map = {"G&A": ga_tenant.id}
+        cls.adapter.tenant_map = {"G&A": ga_tenant.id}
 
-        self.adapter.locationtype_map = {"Site": site_loc_type.id, "Floor": self.floor_loc_type.id}
-        self.hq_site, _ = Location.objects.get_or_create(
+        cls.adapter.locationtype_map = {"Site": site_loc_type.id, "Floor": cls.floor_loc_type.id}
+        cls.hq_site, _ = Location.objects.get_or_create(
             name="HQ", location_type=site_loc_type, status=Status.objects.get(name="Active")
         )
-        self.adapter.site_map = {"NY": {"HQ": self.hq_site.id}}
-        self.adapter.floor_map = {}
-        self.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
-        self.adapter.objects_to_delete = {"floors": []}
+        cls.adapter.site_map = {"NY": {"HQ": cls.hq_site.id}}
+        cls.adapter.floor_map = {}
+        cls.adapter.status_map = {"Active": Status.objects.get(name="Active").id}
+        cls.adapter.objects_to_delete = {"floors": []}
 
     def test_create(self):
         """Test the NautobotFloor create() method creates a LocationType: Floor."""
@@ -279,42 +286,44 @@ class TestNautobotFloor(TransactionTestCase):
         self.assertEqual(ds_mock_floor, result)
 
 
-class TestNautobotDevice(TransactionTestCase):
+class TestNautobotDevice(TestCase):
     """Test NautobotDevice class."""
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
 
-        self.status_active = Status.objects.get(name="Active")
-        self.site_lt = LocationType.objects.get_or_create(name="Site")[0]
+        cls.status_active = Status.objects.get(name="Active")
+        cls.site_lt = LocationType.objects.get_or_create(name="Site")[0]
 
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.logger.info = MagicMock()
-        self.ga_tenant = Tenant.objects.create(name="G&A")
-        self.adapter.device_map = {}
-        self.adapter.floor_map = {}
-        self.adapter.site_map = {}
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.logger.info = MagicMock()
+        cls.ga_tenant = Tenant.objects.create(name="G&A")
+        cls.adapter.device_map = {}
+        cls.adapter.floor_map = {}
+        cls.adapter.site_map = {}
         ios_platform = Platform.objects.get_or_create(name="IOS", network_driver="cisco_ios")[0]
-        self.adapter.platform_map = {"cisco_ios": ios_platform.id}
-        self.adapter.status_map = {"Active": self.status_active.id}
-        self.adapter.tenant_map = {"G&A": self.ga_tenant.id}
+        cls.adapter.platform_map = {"cisco_ios": ios_platform.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.tenant_map = {"G&A": cls.ga_tenant.id}
 
-        self.hq_site = Location.objects.create(name="HQ", status=self.status_active, location_type=self.site_lt)
+        cls.hq_site = Location.objects.create(name="HQ", status=cls.status_active, location_type=cls.site_lt)
 
         dnac_controller = Controller.objects.get_or_create(
-            name="DNA Center", status=self.status_active, location=self.hq_site
+            name="DNA Center", status=cls.status_active, location=cls.hq_site
         )[0]
         dnac_group = ControllerManagedDeviceGroup.objects.create(
             name="DNA Center Managed Devices", controller=dnac_controller
         )
-        self.adapter.job.controller_group = dnac_group
-        self.adapter.job.dnac = dnac_controller
+        cls.adapter.job.controller_group = dnac_group
+        cls.adapter.job.dnac = dnac_controller
 
-        self.ids = {
+        cls.ids = {
             "name": "core-router.testexample.com",
         }
-        self.attrs = {
+        cls.attrs = {
             "controller_group": "DNA Center Managed Devices",
             "floor": "HQ - Floor 1",
             "management_addr": "10.10.0.1",
@@ -329,7 +338,7 @@ class TestNautobotDevice(TransactionTestCase):
             "vendor": "Cisco",
             "version": "16.12.3",
         }
-        self.adapter.objects_to_create = {"devices": [], "metadata": []}  # pylint: disable=no-member
+        cls.adapter.objects_to_create = {"devices": [], "metadata": []}  # pylint: disable=no-member
 
     def test_create(self):
         """Test the NautobotDevice create() method creates a Device."""
@@ -356,67 +365,69 @@ class TestNautobotDevice(TransactionTestCase):
         self.assertTrue(new_dev.software_version.version, self.attrs["version"])
 
 
-class TestNautobotIPAddressOnInterface(TransactionTestCase):
+class TestNautobotIPAddressOnInterface(TestCase):
     """Test NautobotIPAddressOnInterface class."""
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        populate_status_choices()
 
-        self.status_active = Status.objects.get(name="Active")
-        self.site_lt = LocationType.objects.get_or_create(name="Site")[0]
+        cls.status_active = Status.objects.get(name="Active")
+        cls.site_lt = LocationType.objects.get_or_create(name="Site")[0]
 
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.objects_to_create = {"mappings": [], "primary_ip4": []}  # pylint: disable=no-member
-        self.ga_tenant = Tenant.objects.create(name="G&A")
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.objects_to_create = {"mappings": [], "primary_ip4": []}  # pylint: disable=no-member
+        cls.ga_tenant = Tenant.objects.create(name="G&A")
         ios_platform = Platform.objects.get_or_create(name="IOS", network_driver="cisco_ios")[0]
 
-        self.hq_site = Location.objects.create(name="HQ", status=self.status_active, location_type=self.site_lt)
+        cls.hq_site = Location.objects.create(name="HQ", status=cls.status_active, location_type=cls.site_lt)
 
         dnac_controller = Controller.objects.get_or_create(
-            name="DNA Center", status=self.status_active, location=self.hq_site
+            name="DNA Center", status=cls.status_active, location=cls.hq_site
         )[0]
         dnac_group = ControllerManagedDeviceGroup.objects.create(
             name="DNA Center Managed Devices", controller=dnac_controller
         )
-        self.adapter.job.controller_group = dnac_group
-        self.adapter.job.dnac = dnac_controller
+        cls.adapter.job.controller_group = dnac_group
+        cls.adapter.job.dnac = dnac_controller
 
         test_device = Device.objects.create(
             name="core-router.testexample.com",
-            status=self.status_active,
-            location=self.hq_site,
+            status=cls.status_active,
+            location=cls.hq_site,
             device_type=DeviceType.objects.get_or_create(
                 model="Nexus 9300", manufacturer=Manufacturer.objects.get_or_create(name="Cisco")[0]
             )[0],
             platform=ios_platform,
             role=Role.objects.get_or_create(name="core")[0],
             serial="1234567890",
-            tenant=self.ga_tenant,
+            tenant=cls.ga_tenant,
             controller_managed_device_group=dnac_group,
         )
-        self.adapter.device_map = {"core-router.testexample.com": test_device.id}
+        cls.adapter.device_map = {"core-router.testexample.com": test_device.id}
         mgmt_intf = Interface.objects.create(
             name="mgmt0",
             device=test_device,
-            status=self.status_active,
+            status=cls.status_active,
             type="virtual",
             enabled=True,
             mac_address="00:11:22:33:44:55",
         )
-        self.adapter.port_map = {"core-router.testexample.com": {"mgmt0": mgmt_intf.id}}
+        cls.adapter.port_map = {"core-router.testexample.com": {"mgmt0": mgmt_intf.id}}
         parent_pf = Prefix.objects.create(
             prefix="10.1.1.0/24",
-            status=self.status_active,
+            status=cls.status_active,
         )
         mgmt_ip = IPAddress.objects.create(
             host="10.1.1.1",
             mask_length=24,
             parent=parent_pf,
-            status=self.status_active,
-            tenant=self.ga_tenant,
+            status=cls.status_active,
+            tenant=cls.ga_tenant,
         )
-        self.adapter.ipaddr_map = {"10.1.1.1": mgmt_ip.id}
+        cls.adapter.ipaddr_map = {"10.1.1.1": mgmt_ip.id}
 
     def test_create(self):
         """Test the NautobotIPAddressOnInterface create() method creates an IPAddress on an Interface."""

--- a/nautobot_ssot/tests/dna_center/test_utils_dna_center.py
+++ b/nautobot_ssot/tests/dna_center/test_utils_dna_center.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, create_autospec, patch
 
 from dnacentersdk.exceptions import dnacentersdkException
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from parameterized import parameterized
 from requests import Response
 

--- a/nautobot_ssot/tests/infoblox/test_infoblox_models.py
+++ b/nautobot_ssot/tests/infoblox/test_infoblox_models.py
@@ -4,7 +4,7 @@
 import unittest
 from unittest.mock import Mock
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.infoblox.choices import (
     DNSRecordTypeChoices,

--- a/nautobot_ssot/tests/infoblox/test_models.py
+++ b/nautobot_ssot/tests/infoblox/test_models.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from unittest import mock
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.models import ExternalIntegration, Secret, SecretsGroup, SecretsGroupAssociation, Status
 

--- a/nautobot_ssot/tests/infoblox/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/infoblox/test_nautobot_adapter.py
@@ -3,7 +3,7 @@
 from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import RelationshipAssociation, Status
 from nautobot.ipam.models import VLAN, IPAddress, Namespace, Prefix, VLANGroup
 

--- a/nautobot_ssot/tests/infoblox/test_tags_and_cfs.py
+++ b/nautobot_ssot/tests/infoblox/test_tags_and_cfs.py
@@ -4,7 +4,7 @@ import datetime
 from unittest.mock import Mock
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.choices import CustomFieldTypeChoices
 from nautobot.extras.models import CustomField, Status, Tag
 from nautobot.ipam.models import VLAN, IPAddress, Namespace, Prefix, VLANGroup

--- a/nautobot_ssot/tests/infoblox/test_utils.py
+++ b/nautobot_ssot/tests/infoblox/test_utils.py
@@ -3,7 +3,8 @@
 import unittest
 import unittest.mock
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Status
 from nautobot.ipam.models import VLAN, VLANGroup
 
@@ -175,30 +176,32 @@ class TestUtils(unittest.TestCase):
 class TestNautobotUtils(TestCase):
     """Test infoblox.utils.nautobot.py."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Setup Test Cases."""
+        populate_status_choices()
         active_status = Status.objects.get(name="Active")
-        self.vlan_group_1 = VLANGroup.objects.create(name="one")
-        self.vlan_group_2 = VLANGroup.objects.create(name="two")
-        self.vlan_10 = VLAN.objects.create(
+        cls.vlan_group_1 = VLANGroup.objects.create(name="one")
+        cls.vlan_group_2 = VLANGroup.objects.create(name="two")
+        cls.vlan_10 = VLAN.objects.create(
             vid=10,
             name="ten",
             status=active_status,
-            vlan_group=self.vlan_group_1,
+            vlan_group=cls.vlan_group_1,
         )
-        self.vlan_20 = VLAN.objects.create(
+        cls.vlan_20 = VLAN.objects.create(
             vid=20,
             name="twenty",
             status=active_status,
-            vlan_group=self.vlan_group_1,
+            vlan_group=cls.vlan_group_1,
         )
-        self.vlan_30 = VLAN.objects.create(
+        cls.vlan_30 = VLAN.objects.create(
             vid=30,
             name="thirty",
             status=active_status,
-            vlan_group=self.vlan_group_2,
+            vlan_group=cls.vlan_group_2,
         )
-        self.vlan_40 = VLAN.objects.create(
+        cls.vlan_40 = VLAN.objects.create(
             vid=40,
             name="forty",
             status=active_status,

--- a/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
@@ -4,8 +4,8 @@ import json
 from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
-from nautobot.apps.testing import TestCase
 from ipfabric.models.device import Device
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.ipfabric.diffsync.adapter_ipfabric import IPFabricDiffSync

--- a/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_ipfabric_adapter.py
@@ -4,7 +4,7 @@ import json
 from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from ipfabric.models.device import Device
 from nautobot.extras.models import JobResult
 

--- a/nautobot_ssot/tests/ipfabric/test_jobs.py
+++ b/nautobot_ssot/tests/ipfabric/test_jobs.py
@@ -3,8 +3,8 @@
 from copy import deepcopy
 
 from django.conf import settings
-from nautobot.apps.testing import TestCase
 from django.urls import reverse
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.ipfabric import jobs
 

--- a/nautobot_ssot/tests/ipfabric/test_jobs.py
+++ b/nautobot_ssot/tests/ipfabric/test_jobs.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 from django.conf import settings
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from django.urls import reverse
 
 from nautobot_ssot.integrations.ipfabric import jobs

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -4,7 +4,7 @@ import unittest
 
 from django.contrib.contenttypes.models import ContentType
 from nautobot.core.choices import ColorChoices
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,
@@ -15,6 +15,7 @@ from nautobot.dcim.models import (
     Platform,
     VirtualChassis,
 )
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Status, Tag
 from nautobot.ipam.models import IPAddress, Prefix, get_default_namespace
 
@@ -30,6 +31,7 @@ class TestNautobotAdapter(TestCase):
     """Test cases for InfoBlox Nautobot adapter."""
 
     def setUp(self):
+        populate_status_choices()
         device_ct = ContentType.objects.get_for_model(Device)
         self.active_status = Status.objects.get(name="Active")
         self.ssot_tag, _ = Tag.objects.get_or_create(

--- a/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/ipfabric/test_nautobot_adapter.py
@@ -3,8 +3,8 @@
 import unittest
 
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.choices import ColorChoices
 from nautobot.apps.testing import TestCase
+from nautobot.core.choices import ColorChoices
 from nautobot.dcim.models import (
     Device,
     DeviceType,

--- a/nautobot_ssot/tests/ipfabric/test_nbutils.py
+++ b/nautobot_ssot/tests/ipfabric/test_nbutils.py
@@ -8,10 +8,11 @@ from unittest import mock
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import Error as DjangoBaseDBError
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.core.choices import ColorChoices
 from nautobot.dcim.models import DeviceType, Interface, Location, LocationType, Manufacturer, Platform, VirtualChassis
 from nautobot.dcim.models.devices import Device
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Role, Tag
 from nautobot.extras.models.statuses import Status
 from nautobot.ipam.models import VLAN, IPAddress, Prefix, get_default_namespace
@@ -42,6 +43,7 @@ class TestNautobotUtils(TestCase):
 
     def setUp(self):
         """Setup."""
+        populate_status_choices()
         job_scoped_cache.clear_all()
         site_location_type = LocationType.objects.update_or_create(name="Site")[0]
         locaiton_cts = [

--- a/nautobot_ssot/tests/librenms/test_librenms_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_librenms_adapter.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, Location, LocationType
 from nautobot.extras.models import JobResult, Status
 
@@ -12,7 +12,7 @@ from nautobot_ssot.integrations.librenms.jobs import LibrenmsDataSource
 from nautobot_ssot.tests.librenms.fixtures import DEVICE_FIXTURE_RECV, LOCATION_FIXURE_RECV
 
 
-class TestLibreNMSAdapterTestCase(TransactionTestCase):
+class TestLibreNMSAdapterTestCase(TestCase):
     """Test NautobotSsotLibreNMSAdapter class."""
 
     databases = ("default", "job_logs")
@@ -21,40 +21,41 @@ class TestLibreNMSAdapterTestCase(TransactionTestCase):
         """Initialize test case."""
         super().__init__(*args, **kwargs)
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Setup shared objects for tests."""
         # Create Active status first
-        self.active_status, _ = Status.objects.get_or_create(
+        cls.active_status, _ = Status.objects.get_or_create(
             name="Active",
             defaults={
                 "color": "4caf50",
             },
         )
-        self.active_status.content_types.add(ContentType.objects.get_for_model(Device))
-        self.active_status.content_types.add(ContentType.objects.get_for_model(Location))
+        cls.active_status.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.active_status.content_types.add(ContentType.objects.get_for_model(Location))
 
-        self.librenms_client = MagicMock()
-        self.librenms_client.name = "Test"
-        self.librenms_client.remote_url = "https://test.com"
-        self.librenms_client.verify_ssl = True
+        cls.librenms_client = MagicMock()
+        cls.librenms_client.name = "Test"
+        cls.librenms_client.remote_url = "https://test.com"
+        cls.librenms_client.verify_ssl = True
 
         # Mock device and location data
-        self.librenms_client.get_librenms_devices.return_value = DEVICE_FIXTURE_RECV
-        self.librenms_client.get_librenms_locations.return_value = LOCATION_FIXURE_RECV
+        cls.librenms_client.get_librenms_devices.return_value = DEVICE_FIXTURE_RECV
+        cls.librenms_client.get_librenms_locations.return_value = LOCATION_FIXURE_RECV
 
-        self.job = LibrenmsDataSource()
-        self.job.hostname_field = "sysName"
-        self.job.sync_locations = True
-        self.job.location_type = LocationType.objects.get_or_create(name="Site")[0]
-        self.job.default_role = MagicMock()
-        self.job.default_role.name = "network"
-        self.job.tenant = None  # No tenant for test
-        self.job.logger.warning = MagicMock()
-        self.job.sync_locations = True
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = LibrenmsDataSource()
+        cls.job.hostname_field = "sysName"
+        cls.job.sync_locations = True
+        cls.job.location_type = LocationType.objects.get_or_create(name="Site")[0]
+        cls.job.default_role = MagicMock()
+        cls.job.default_role.name = "network"
+        cls.job.tenant = None  # No tenant for test
+        cls.job.logger.warning = MagicMock()
+        cls.job.sync_locations = True
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.librenms_adapter = LibrenmsAdapter(job=self.job, sync=None, librenms_api=self.librenms_client)
+        cls.librenms_adapter = LibrenmsAdapter(job=cls.job, sync=None, librenms_api=cls.librenms_client)
 
     @patch("nautobot_ssot.integrations.librenms.diffsync.adapters.librenms.has_required_values")
     def test_data_loading(self, mock_has_required_values):

--- a/nautobot_ssot/tests/librenms/test_librenms_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_librenms_adapter.py
@@ -52,9 +52,7 @@ class TestLibreNMSAdapterTestCase(TestCase):
         cls.job.tenant = None  # No tenant for test
         cls.job.logger.warning = MagicMock()
         cls.job.sync_locations = True
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.librenms_adapter = LibrenmsAdapter(job=cls.job, sync=None, librenms_api=cls.librenms_client)
 
     @patch("nautobot_ssot.integrations.librenms.diffsync.adapters.librenms.has_required_values")

--- a/nautobot_ssot/tests/librenms/test_librenms_model.py
+++ b/nautobot_ssot/tests/librenms/test_librenms_model.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device as NautobotDevice
 from nautobot.dcim.models import DeviceType, Location, LocationType, Manufacturer
 from nautobot.extras.models import Role, Status

--- a/nautobot_ssot/tests/librenms/test_librenms_validators.py
+++ b/nautobot_ssot/tests/librenms/test_librenms_validators.py
@@ -3,7 +3,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from parameterized import parameterized
 
 from nautobot_ssot.integrations.librenms.utils import (

--- a/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
@@ -75,9 +75,7 @@ class TestNautobotAdapterTestCase(TestCase):
         cls.job = LibrenmsDataSource()
         cls.job.logger.warning = MagicMock()
         cls.job.sync_locations = True
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
 
         cls.nautobot_adapter = NautobotAdapter(job=cls.job, sync=None)
 

--- a/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
@@ -4,7 +4,7 @@ import json
 from unittest.mock import MagicMock
 
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device as ORMDevice
 from nautobot.dcim.models import DeviceType, LocationType, Manufacturer, Platform
 from nautobot.dcim.models import Location as ORMLocation
@@ -30,26 +30,27 @@ DEVICE_FIXTURE = load_json("./nautobot_ssot/tests/librenms/fixtures/get_librenms
 LOCATION_FIXTURE = load_json("./nautobot_ssot/tests/librenms/fixtures/get_librenms_locations.json")["locations"]
 
 
-class TestNautobotAdapterTestCase(TransactionTestCase):
+class TestNautobotAdapterTestCase(TestCase):
     """Test NautobotAdapter class for loading devices from the ORM."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Initialize test case and populate the database."""
-        self.active_status, _ = Status.objects.get_or_create(name="Active")
-        self.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+        cls.active_status, _ = Status.objects.get_or_create(name="Active")
+        cls.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
 
-        self.site_type, _ = LocationType.objects.get_or_create(name="Site")
-        self.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+        cls.site_type, _ = LocationType.objects.get_or_create(name="Site")
+        cls.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
 
         for location in LOCATION_FIXTURE:
             ORMLocation.objects.create(
                 name=location["location"],
-                location_type=self.site_type,
+                location_type=cls.site_type,
                 latitude=location.get("lat"),
                 longitude=location.get("lng"),
-                status=self.active_status,
+                status=cls.active_status,
             )
 
         for device in DEVICE_FIXTURE[:1]:
@@ -71,14 +72,14 @@ class TestNautobotAdapterTestCase(TransactionTestCase):
                 platform=_platform,
             )
 
-        self.job = LibrenmsDataSource()
-        self.job.logger.warning = MagicMock()
-        self.job.sync_locations = True
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = LibrenmsDataSource()
+        cls.job.logger.warning = MagicMock()
+        cls.job.sync_locations = True
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
 
-        self.nautobot_adapter = NautobotAdapter(job=self.job, sync=None)
+        cls.nautobot_adapter = NautobotAdapter(job=cls.job, sync=None)
 
     def test_load_devices(self):
         """Test that devices are correctly loaded from the Nautobot ORM."""

--- a/nautobot_ssot/tests/meraki/test_adapters_meraki.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_meraki.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, Location, LocationType
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult, Status
 
 from nautobot_ssot.integrations.meraki.diffsync.adapters.meraki import MerakiAdapter
@@ -13,50 +14,52 @@ from nautobot_ssot.integrations.meraki.jobs import MerakiDataSource
 from nautobot_ssot.tests.meraki.fixtures import fixtures as fix
 
 
-class TestMerakiAdapterTestCase(TransactionTestCase):
+class TestMerakiAdapterTestCase(TestCase):
     """Test NautobotSsotMerakiAdapter class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Initialize test case."""
-        super().setUp()
+        super().setUpTestData()
+        populate_status_choices()
 
-        self.status_active = Status.objects.get(name="Active")
-        self.meraki_client = MagicMock()
-        self.meraki_client.get_org_networks.return_value = fix.GET_ORG_NETWORKS_SENT_FIXTURE
-        self.meraki_client.network_map = fix.NETWORK_MAP_FIXTURE
-        self.meraki_client.get_org_devices.return_value = fix.GET_ORG_DEVICES_FIXTURE
-        self.meraki_client.get_org_device_statuses.return_value = fix.GET_ORG_DEVICE_STATUSES_RECV_FIXTURE
-        self.meraki_client.get_org_uplink_addresses_by_device.return_value = (
+        cls.status_active = Status.objects.get(name="Active")
+        cls.meraki_client = MagicMock()
+        cls.meraki_client.get_org_networks.return_value = fix.GET_ORG_NETWORKS_SENT_FIXTURE
+        cls.meraki_client.network_map = fix.NETWORK_MAP_FIXTURE
+        cls.meraki_client.get_org_devices.return_value = fix.GET_ORG_DEVICES_FIXTURE
+        cls.meraki_client.get_org_device_statuses.return_value = fix.GET_ORG_DEVICE_STATUSES_RECV_FIXTURE
+        cls.meraki_client.get_org_uplink_addresses_by_device.return_value = (
             fix.GET_ORG_UPLINK_ADDRESSES_BY_DEVICE_FIXTURE
         )
-        self.meraki_client.get_management_ports.return_value = fix.GET_MANAGEMENT_PORTS_RECV_FIXTURE
-        self.meraki_client.get_uplink_settings.return_value = fix.GET_UPLINK_SETTINGS_RECV
-        self.meraki_client.get_switchport_statuses.return_value = fix.GET_SWITCHPORT_STATUSES
-        self.meraki_client.get_org_uplink_statuses.return_value = fix.GET_ORG_UPLINK_STATUSES_RECV_FIXTURE
-        self.meraki_client.get_appliance_switchports.return_value = fix.GET_APPLIANCE_SWITCHPORTS_FIXTURE
-        self.meraki_client.get_org_switchports.return_value = fix.GET_ORG_SWITCHPORTS_RECV_FIXTURE
+        cls.meraki_client.get_management_ports.return_value = fix.GET_MANAGEMENT_PORTS_RECV_FIXTURE
+        cls.meraki_client.get_uplink_settings.return_value = fix.GET_UPLINK_SETTINGS_RECV
+        cls.meraki_client.get_switchport_statuses.return_value = fix.GET_SWITCHPORT_STATUSES
+        cls.meraki_client.get_org_uplink_statuses.return_value = fix.GET_ORG_UPLINK_STATUSES_RECV_FIXTURE
+        cls.meraki_client.get_appliance_switchports.return_value = fix.GET_APPLIANCE_SWITCHPORTS_FIXTURE
+        cls.meraki_client.get_org_switchports.return_value = fix.GET_ORG_SWITCHPORTS_RECV_FIXTURE
 
         site_loctype = LocationType.objects.get_or_create(name="Site")[0]
         site_loctype.content_types.add(ContentType.objects.get_for_model(Device))
-        self.job = MerakiDataSource()
-        self.job.logger.debug = MagicMock()
-        self.job.logger.warning = MagicMock()
-        self.job.instance = MagicMock()
-        self.job.instance.controller_managed_device_groups = MagicMock()
-        self.job.instance.controller_managed_device_groups.first().name = "Meraki Managed Device Group"
-        self.job.instance.controller_managed_device_groups.count().return_value = 1
-        self.job.hostname_mapping = []
-        self.job.devicetype_mapping = [("MS", "Switch"), ("MX", "Firewall")]
-        self.job.network_loctype = site_loctype
-        self.job.location_map = {}
-        self.job.device_status = None
-        self.job.location = None
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="fake task", worker="default"
+        cls.job = MerakiDataSource()
+        cls.job.logger.debug = MagicMock()
+        cls.job.logger.warning = MagicMock()
+        cls.job.instance = MagicMock()
+        cls.job.instance.controller_managed_device_groups = MagicMock()
+        cls.job.instance.controller_managed_device_groups.first().name = "Meraki Managed Device Group"
+        cls.job.instance.controller_managed_device_groups.count().return_value = 1
+        cls.job.hostname_mapping = []
+        cls.job.devicetype_mapping = [("MS", "Switch"), ("MX", "Firewall")]
+        cls.job.network_loctype = site_loctype
+        cls.job.location_map = {}
+        cls.job.device_status = None
+        cls.job.location = None
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="fake task", worker="default"
         )
-        self.meraki = MerakiAdapter(job=self.job, sync=None, client=self.meraki_client)
+        cls.meraki = MerakiAdapter(job=cls.job, sync=None, client=cls.meraki_client)
 
     def test_data_loading(self):
         """Test Nautobot SSoT for Meraki load() function."""

--- a/nautobot_ssot/tests/meraki/test_adapters_meraki.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_meraki.py
@@ -56,9 +56,7 @@ class TestMerakiAdapterTestCase(TestCase):
         cls.job.location_map = {}
         cls.job.device_status = None
         cls.job.location = None
-        cls.job.job_result = JobResult.objects.create(
-            name=cls.job.class_path, task_name="fake task", worker="default"
-        )
+        cls.job.job_result = JobResult.objects.create(name=cls.job.class_path, task_name="fake task", worker="default")
         cls.meraki = MerakiAdapter(job=cls.job, sync=None, client=cls.meraki_client)
 
     def test_data_loading(self):

--- a/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer, Platform
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult, Note, Role, Status
 from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix
 
@@ -15,30 +16,32 @@ from nautobot_ssot.integrations.meraki.jobs import MerakiDataSource
 User = get_user_model()
 
 
-class NautobotDiffSyncTestCase(TransactionTestCase):
+class NautobotDiffSyncTestCase(TestCase):
     """Test the NautobotAdapter class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):  # pylint: disable=too-many-locals disable=too-many-statements
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=too-many-locals disable=too-many-statements
         """Per-test-case data setup."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
 
-        self.region_type = LocationType.objects.get_or_create(name="Region", defaults={"nestable": True})[0]
+        cls.region_type = LocationType.objects.get_or_create(name="Region", defaults={"nestable": True})[0]
         global_region = Location.objects.create(
             name="Global Region",
-            location_type=self.region_type,
-            status=self.status_active,
+            location_type=cls.region_type,
+            status=cls.status_active,
         )
         global_region.validated_save()
-        self.site_type = LocationType.objects.get_or_create(name="Site")[0]
-        self.site_type.content_types.add(ContentType.objects.get_for_model(Device))
-        self.site_type.content_types.add(ContentType.objects.get_for_model(Prefix))
+        cls.site_type = LocationType.objects.get_or_create(name="Site")[0]
+        cls.site_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.site_type.content_types.add(ContentType.objects.get_for_model(Prefix))
         site1 = Location.objects.create(
             name="Lab",
-            location_type=self.site_type,
-            status=self.status_active,
+            location_type=cls.site_type,
+            status=cls.status_active,
             time_zone="America/Chicago",
         )
         site1.validated_save()
@@ -66,7 +69,7 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         lab01 = Device.objects.create(
             name="Lab01",
             serial="ABC-123-456",
-            status=self.status_active,
+            status=cls.status_active,
             role=core_role,
             device_type=mx84,
             platform=meraki_plat,
@@ -91,7 +94,7 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
             mode="access",
             mgmt_only=True,
             type="1000base-t",
-            status=self.status_active,
+            status=cls.status_active,
         )
         lab01_mgmt.validated_save()
         lab01_mgmt.custom_field_data["system_of_record"] = "Meraki SSoT"
@@ -99,9 +102,9 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
 
         test_ns = Namespace.objects.create(name="Test")
         lab_prefix = Prefix.objects.create(
-            prefix="10.0.0.0/24", location=site1, namespace=test_ns, status=self.status_active
+            prefix="10.0.0.0/24", location=site1, namespace=test_ns, status=cls.status_active
         )
-        lab01_mgmt_ip = IPAddress.objects.create(address="10.0.0.1/24", parent=lab_prefix, status=self.status_active)
+        lab01_mgmt_ip = IPAddress.objects.create(address="10.0.0.1/24", parent=lab_prefix, status=cls.status_active)
         lab_prefix.custom_field_data["system_of_record"] = "Meraki SSoT"
         lab_prefix.validated_save()
         lab01_mgmt_ip.custom_field_data["system_of_record"] = "Meraki SSoT"
@@ -113,11 +116,11 @@ class NautobotDiffSyncTestCase(TransactionTestCase):
         job.parent_location = global_region
         job.hostname_mapping = []
         job.devicetype_mapping = [("MS", "Switch"), ("MX", "Firewall")]
-        job.network_loctype = self.site_type
+        job.network_loctype = cls.site_type
         job.tenant = None
         job.device_status = None
         job.job_result = JobResult.objects.create(name=job.class_path, task_name="fake task", worker="default")
-        self.nb_adapter = NautobotAdapter(job=job, sync=None)
+        cls.nb_adapter = NautobotAdapter(job=job, sync=None)
 
     def test_data_loading(self):
         """Test the load() function."""

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -29,9 +29,7 @@ class TestNautobotPrefix(TestCase):  # pylint: disable=too-many-instance-attribu
         cls.status_active = Status.objects.get(name="Active")
         site_lt = LocationType.objects.get_or_create(name="Site")[0]
         site_lt.content_types.add(ContentType.objects.get_for_model(Prefix))
-        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[
-            0
-        ]
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[0]
         cls.update_site = Location.objects.get_or_create(
             name="Update", location_type=site_lt, status=cls.status_active
         )[0]
@@ -108,9 +106,7 @@ class TestNautobotIPAddress(TestCase):  # pylint: disable=too-many-instance-attr
         cls.status_active = Status.objects.get(name="Active")
         site_lt = LocationType.objects.get_or_create(name="Site")[0]
         site_lt.content_types.add(ContentType.objects.get_for_model(Prefix))
-        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[
-            0
-        ]
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[0]
         cls.update_site = Location.objects.get_or_create(
             name="Update", location_type=site_lt, status=cls.status_active
         )[0]

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, patch
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Location, LocationType
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Status
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
@@ -15,37 +16,39 @@ from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import NautobotI
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
-class TestNautobotPrefix(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotPrefix(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test the NautobotPrefix class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure common variables and objects for tests."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
         site_lt = LocationType.objects.get_or_create(name="Site")[0]
         site_lt.content_types.add(ContentType.objects.get_for_model(Prefix))
-        self.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=self.status_active)[
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[
             0
         ]
-        self.update_site = Location.objects.get_or_create(
-            name="Update", location_type=site_lt, status=self.status_active
+        cls.update_site = Location.objects.get_or_create(
+            name="Update", location_type=site_lt, status=cls.status_active
         )[0]
-        self.test_tenant = Tenant.objects.get_or_create(name="Test")[0]
-        self.update_tenant = Tenant.objects.get_or_create(name="Update")[0]
-        self.test_ns = Namespace.objects.get_or_create(name="Test")[0]
-        self.prefix = Prefix.objects.create(
-            prefix="10.0.0.0/24", namespace=self.test_ns, status=self.status_active, tenant=self.test_tenant
+        cls.test_tenant = Tenant.objects.get_or_create(name="Test")[0]
+        cls.update_tenant = Tenant.objects.get_or_create(name="Update")[0]
+        cls.test_ns = Namespace.objects.get_or_create(name="Test")[0]
+        cls.prefix = Prefix.objects.create(
+            prefix="10.0.0.0/24", namespace=cls.test_ns, status=cls.status_active, tenant=cls.test_tenant
         )
-        self.adapter = Adapter()
-        self.adapter.namespace_map = {"Test": self.test_ns.id, "Update": self.update_site.id}
-        self.adapter.site_map = {"Test": self.test_site, "Update": self.update_site}
-        self.adapter.tenant_map = {"Test": self.test_tenant.id, "Update": self.update_tenant.id}
-        self.adapter.status_map = {"Active": self.status_active.id}
-        self.adapter.prefix_map = {}
-        self.adapter.objects_to_create = {"prefixes": []}
-        self.adapter.objects_to_delete = {"prefixes": []}
+        cls.adapter = Adapter()
+        cls.adapter.namespace_map = {"Test": cls.test_ns.id, "Update": cls.update_site.id}
+        cls.adapter.site_map = {"Test": cls.test_site, "Update": cls.update_site}
+        cls.adapter.tenant_map = {"Test": cls.test_tenant.id, "Update": cls.update_tenant.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.prefix_map = {}
+        cls.adapter.objects_to_create = {"prefixes": []}
+        cls.adapter.objects_to_delete = {"prefixes": []}
 
     def test_create(self):
         """Validate the NautobotPrefix create() method creates a Prefix."""
@@ -92,54 +95,56 @@ class TestNautobotPrefix(TransactionTestCase):  # pylint: disable=too-many-insta
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
-class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-instance-attributes
+class TestNautobotIPAddress(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test the NautobotIPAddress class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Configure common variables and objects for tests."""
-        super().setUp()
-        self.status_active = Status.objects.get(name="Active")
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
         site_lt = LocationType.objects.get_or_create(name="Site")[0]
         site_lt.content_types.add(ContentType.objects.get_for_model(Prefix))
-        self.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=self.status_active)[
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[
             0
         ]
-        self.update_site = Location.objects.get_or_create(
-            name="Update", location_type=site_lt, status=self.status_active
+        cls.update_site = Location.objects.get_or_create(
+            name="Update", location_type=site_lt, status=cls.status_active
         )[0]
-        self.test_tenant = Tenant.objects.get_or_create(name="Test")[0]
-        self.update_tenant = Tenant.objects.get_or_create(name="Update")[0]
-        self.test_ns = Namespace.objects.get_or_create(name="Test")[0]
-        self.prefix = Prefix(
-            prefix="10.0.0.0/24", namespace=self.test_ns, status=self.status_active, tenant=self.test_tenant
+        cls.test_tenant = Tenant.objects.get_or_create(name="Test")[0]
+        cls.update_tenant = Tenant.objects.get_or_create(name="Update")[0]
+        cls.test_ns = Namespace.objects.get_or_create(name="Test")[0]
+        cls.prefix = Prefix(
+            prefix="10.0.0.0/24", namespace=cls.test_ns, status=cls.status_active, tenant=cls.test_tenant
         )
-        self.adapter = Adapter()
-        self.adapter.job = MagicMock()
-        self.adapter.job.debug = True
-        self.adapter.job.logger = MagicMock()
-        self.adapter.job.logger.debug = MagicMock()
-        self.adapter.job.logger.error = MagicMock()
-        self.adapter.namespace_map = {"Test": self.test_ns.id, "Update": self.update_site.id}
-        self.adapter.site_map = {"Test": self.test_site, "Update": self.update_site}
-        self.adapter.tenant_map = {"Test": self.test_tenant.id, "Update": self.update_tenant.id}
-        self.adapter.status_map = {"Active": self.status_active.id}
-        self.adapter.ipaddr_map = {}
-        self.adapter.prefix_map = {"10.0.0.0/24": self.prefix.id}
-        self.adapter.objects_to_create = {"ipaddrs": [], "ipaddrs-to-prefixes": [], "prefixes": []}
-        self.adapter.objects_to_delete = {"ipaddrs": []}
-        self.test_ipaddr = IPAddress(
-            address="10.0.0.1/24", parent=self.prefix, status=self.status_active, tenant=self.test_tenant
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.debug = True
+        cls.adapter.job.logger = MagicMock()
+        cls.adapter.job.logger.debug = MagicMock()
+        cls.adapter.job.logger.error = MagicMock()
+        cls.adapter.namespace_map = {"Test": cls.test_ns.id, "Update": cls.update_site.id}
+        cls.adapter.site_map = {"Test": cls.test_site, "Update": cls.update_site}
+        cls.adapter.tenant_map = {"Test": cls.test_tenant.id, "Update": cls.update_tenant.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.ipaddr_map = {}
+        cls.adapter.prefix_map = {"10.0.0.0/24": cls.prefix.id}
+        cls.adapter.objects_to_create = {"ipaddrs": [], "ipaddrs-to-prefixes": [], "prefixes": []}
+        cls.adapter.objects_to_delete = {"ipaddrs": []}
+        cls.test_ipaddr = IPAddress(
+            address="10.0.0.1/24", parent=cls.prefix, status=cls.status_active, tenant=cls.test_tenant
         )
-        self.test_ip = NautobotIPAddress(
+        cls.test_ip = NautobotIPAddress(
             host="10.0.0.1",
             mask_length=24,
             prefix="10.0.0.0/24",
             tenant="Test",
-            uuid=self.test_ipaddr.id,
+            uuid=cls.test_ipaddr.id,
         )
-        self.test_ip.adapter = self.adapter
+        cls.test_ip.adapter = cls.adapter
 
     def test_create(self):
         """Validate the NautobotAddress create() method creates an IPAddress."""

--- a/nautobot_ssot/tests/servicenow/test_adapter_nautobot.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_nautobot.py
@@ -1,6 +1,6 @@
 """Unit tests for the Nautobot DiffSync adapter."""
 
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.models import JobResult, Role, Status
 
@@ -8,13 +8,14 @@ from nautobot_ssot.integrations.servicenow.diffsync.adapter_nautobot import Naut
 from nautobot_ssot.integrations.servicenow.jobs import ServiceNowDataTarget
 
 
-class NautobotDiffSyncTestCase(TransactionTestCase):
+class NautobotDiffSyncTestCase(TestCase):
     """Test the NautobotDiffSync adapter class."""
 
     job_class = ServiceNowDataTarget
     databases = ("default", "job_logs")
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Per-test-case data setup."""
         status_active, _ = Status.objects.get_or_create(name="Active")
 

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
@@ -575,7 +575,7 @@ class MockServiceNowClient:
             yield from []
 
 
-class ServiceNowDiffSyncTestCase(TransactionTestCase):
+class ServiceNowDiffSyncTestCase(TestCase):
     """Test the ServiceNowDiffSync adapter class."""
 
     job_class = ServiceNowDataTarget

--- a/nautobot_ssot/tests/servicenow/test_jobs.py
+++ b/nautobot_ssot/tests/servicenow/test_jobs.py
@@ -4,8 +4,8 @@ import os
 from unittest import mock
 
 from django.test import override_settings
-from nautobot.apps.testing import TestCase
 from django.urls import reverse
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.models import Role, Secret, SecretsGroup, SecretsGroupAssociation, Status

--- a/nautobot_ssot/tests/servicenow/test_jobs.py
+++ b/nautobot_ssot/tests/servicenow/test_jobs.py
@@ -3,7 +3,8 @@
 import os
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from nautobot.apps.testing import TestCase
 from django.urls import reverse
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices

--- a/nautobot_ssot/tests/servicenow/test_pysnow.py
+++ b/nautobot_ssot/tests/servicenow/test_pysnow.py
@@ -3,7 +3,7 @@
 import warnings
 from unittest.mock import MagicMock, mock_open, patch
 
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.servicenow.third_party.pysnow.attachment import Attachment
 

--- a/nautobot_ssot/tests/slurpit/test_jobs.py
+++ b/nautobot_ssot/tests/slurpit/test_jobs.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 from django.conf import settings
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from django.urls import reverse
 
 from nautobot_ssot.integrations.slurpit import jobs

--- a/nautobot_ssot/tests/slurpit/test_jobs.py
+++ b/nautobot_ssot/tests/slurpit/test_jobs.py
@@ -3,8 +3,8 @@
 from copy import deepcopy
 
 from django.conf import settings
-from nautobot.apps.testing import TestCase
 from django.urls import reverse
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.slurpit import jobs
 

--- a/nautobot_ssot/tests/slurpit/test_slurpit_adapter.py
+++ b/nautobot_ssot/tests/slurpit/test_slurpit_adapter.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock
 
 from nautobot.dcim.models import LocationType
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult
 from nautobot.ipam.models import Namespace
 from slurpit.models.device import Device
@@ -40,6 +41,7 @@ class SlurpitDiffSyncTestCase(TestCase):
     """Test the SlurpitDiffSync adapter class."""
 
     def setUp(self):
+        populate_status_choices()
         slurpit_client = AsyncMock()
         slurpit_client.site.get_sites = AsyncMock(return_value=SITE_FIXTURE)
         slurpit_client.device.get_devices = AsyncMock(return_value=DEVICE_FIXTURE)

--- a/nautobot_ssot/tests/solarwinds/test_jobs.py
+++ b/nautobot_ssot/tests/solarwinds/test_jobs.py
@@ -3,7 +3,7 @@
 import uuid
 from unittest.mock import MagicMock
 
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TransactionTestCase
 from nautobot.dcim.models import LocationType
 from nautobot.extras.models import JobResult
 

--- a/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
+++ b/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
@@ -36,9 +36,7 @@ class TestSolarWindsAdapterTestCase(TestCase):  # pylint: disable=too-many-publi
         cls.location_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
         cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
 
-        cls.parent, _ = Location.objects.get_or_create(
-            name="USA", location_type=region_type, status=cls.status_active
-        )
+        cls.parent, _ = Location.objects.get_or_create(name="USA", location_type=region_type, status=cls.status_active)
 
         cls.job = SolarWindsDataSource()
         cls.job.debug = True

--- a/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
+++ b/nautobot_ssot/tests/solarwinds/test_solarwinds_adapter.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call, patch
 
 from diffsync.enum import DiffSyncModelFlags
 from django.contrib.contenttypes.models import ContentType
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, Location, LocationType
 from nautobot.extras.models import JobResult, Role, Status
 
@@ -14,51 +14,52 @@ from nautobot_ssot.integrations.solarwinds.diffsync.adapters.solarwinds import S
 from nautobot_ssot.integrations.solarwinds.jobs import SolarWindsDataSource
 
 
-class TestSolarWindsAdapterTestCase(TransactionTestCase):  # pylint: disable=too-many-public-methods
+class TestSolarWindsAdapterTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """Test NautobotSsotSolarWindsAdapter class."""
 
     databases = ("default", "job_logs")
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=invalid-name
         """Initialize test case."""
-        self.status_active = Status.objects.get_or_create(name="Active")[0]
-        self.status_active.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.status_active = Status.objects.get_or_create(name="Active")[0]
+        cls.status_active.content_types.add(ContentType.objects.get_for_model(Device))
 
-        self.solarwinds_client = MagicMock()
-        self.solarwinds_client.get_top_level_containers.return_value = fix.GET_TOP_LEVEL_CONTAINERS_FIXTURE
-        self.solarwinds_client.get_filtered_container_ids.return_value = {"HQ": 1}
-        self.solarwinds_client.get_container_nodes.side_effect = fix.get_container_nodes
+        cls.solarwinds_client = MagicMock()
+        cls.solarwinds_client.get_top_level_containers.return_value = fix.GET_TOP_LEVEL_CONTAINERS_FIXTURE
+        cls.solarwinds_client.get_filtered_container_ids.return_value = {"HQ": 1}
+        cls.solarwinds_client.get_container_nodes.side_effect = fix.get_container_nodes
 
-        self.containers = "HQ"
+        cls.containers = "HQ"
 
         region_type, _ = LocationType.objects.get_or_create(name="Region")
-        self.location_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
-        self.location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.location_type, _ = LocationType.objects.update_or_create(name="Site", defaults={"parent": region_type})
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
 
-        self.parent, _ = Location.objects.get_or_create(
-            name="USA", location_type=region_type, status=self.status_active
+        cls.parent, _ = Location.objects.get_or_create(
+            name="USA", location_type=region_type, status=cls.status_active
         )
 
-        self.job = SolarWindsDataSource()
-        self.job.debug = True
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="Fake task", user=None, id=uuid.uuid4()
+        cls.job = SolarWindsDataSource()
+        cls.job.debug = True
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="Fake task", user=None, id=uuid.uuid4()
         )
-        self.job.logger = MagicMock()
-        self.job.logger.debug = MagicMock()
-        self.job.logger.error = MagicMock()
-        self.job.logger.info = MagicMock()
-        self.job.logger.warning = MagicMock()
-        self.job.location_type = self.location_type
-        self.job.location_override = None
-        self.job.parent = self.parent
-        self.job.default_role = Role.objects.get_or_create(name="Router")[0]
-        self.solarwinds = SolarWindsAdapter(
-            job=self.job,
+        cls.job.logger = MagicMock()
+        cls.job.logger.debug = MagicMock()
+        cls.job.logger.error = MagicMock()
+        cls.job.logger.info = MagicMock()
+        cls.job.logger.warning = MagicMock()
+        cls.job.location_type = cls.location_type
+        cls.job.location_override = None
+        cls.job.parent = cls.parent
+        cls.job.default_role = Role.objects.get_or_create(name="Router")[0]
+        cls.solarwinds = SolarWindsAdapter(
+            job=cls.job,
             sync=None,
-            client=self.solarwinds_client,
-            containers=self.containers,
-            location_type=self.location_type,
+            client=cls.solarwinds_client,
+            containers=cls.containers,
+            location_type=cls.location_type,
         )
 
     def test_data_loading_wo_parent(self):

--- a/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
+++ b/nautobot_ssot/tests/solarwinds/test_utils_solarwinds.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import requests
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 from parameterized import parameterized
 
@@ -18,27 +18,34 @@ from nautobot_ssot.integrations.solarwinds.utils.solarwinds import (
 from nautobot_ssot.tests.solarwinds.conftest import create_solarwinds_client
 
 
-class TestSolarWindsClientTestCase(TransactionTestCase):  # pylint: disable=too-many-public-methods
+class TestSolarWindsClientTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """Test the SolarWindsClient class."""
 
     databases = ("default", "job_logs")
 
     def setUp(self):
-        """Configure shared variables for tests."""
-        self.job = SolarWindsDataSource()
-        self.job.job_result = JobResult.objects.create(
-            name=self.job.class_path, task_name="Fake task", user=None, id=uuid.uuid4()
-        )
-        self.job.integration = MagicMock()
-        self.job.integration.extra_config = {"batch_size": 10}
-        self.job.logger.debug = MagicMock()
-        self.job.logger.error = MagicMock()
-        self.job.logger.info = MagicMock()
-        self.job.logger.warning = MagicMock()
-        self.test_client = create_solarwinds_client(job=self.job)
+        self.job.logger.debug.reset_mock()
+        self.job.logger.error.reset_mock()
+        self.job.logger.info.reset_mock()
+        self.job.logger.warning.reset_mock()
 
-        self.test_nodes = [{"Name": "Router01", "MemberPrimaryID": 1}, {"Name": "Switch01", "MemberPrimaryID": 2}]
-        self.node_details = {1: {"NodeHostname": "Router01", "NodeID": 1}, 2: {"NodeHostname": "Switch01", "NodeID": 2}}
+    @classmethod
+    def setUpTestData(cls):
+        """Configure shared variables for tests."""
+        cls.job = SolarWindsDataSource()
+        cls.job.job_result = JobResult.objects.create(
+            name=cls.job.class_path, task_name="Fake task", user=None, id=uuid.uuid4()
+        )
+        cls.job.integration = MagicMock()
+        cls.job.integration.extra_config = {"batch_size": 10}
+        cls.job.logger.debug = MagicMock()
+        cls.job.logger.error = MagicMock()
+        cls.job.logger.info = MagicMock()
+        cls.job.logger.warning = MagicMock()
+        cls.test_client = create_solarwinds_client(job=cls.job)
+
+        cls.test_nodes = [{"Name": "Router01", "MemberPrimaryID": 1}, {"Name": "Switch01", "MemberPrimaryID": 2}]
+        cls.node_details = {1: {"NodeHostname": "Router01", "NodeID": 1}, 2: {"NodeHostname": "Switch01", "NodeID": 2}}
 
     def test_solarwinds_client_initialization(self):
         """Validate the SolarWindsClient functionality."""

--- a/nautobot_ssot/tests/test_api.py
+++ b/nautobot_ssot/tests/test_api.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.users.models import Token
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -45,7 +45,7 @@ class NautobotAdapterOneToOneRelationTests(TestCaseWithDeviceData):
             device = NautobotDevice
 
         device = dcim_models.Device.objects.first()
-        interface = dcim_models.Interface.objects.get(name="Loopback 1", device=device)
+        interface = dcim_models.Interface.objects.get(name="Ethernet1", device=device)
         interface.ip_addresses.add(self.ip_address_1)
         device.primary_ip4 = self.ip_address_1
         device.validated_save()
@@ -63,8 +63,8 @@ class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):
 
     def setUp(self):
         dcim_models.Cable.objects.create(
-            termination_a=dcim_models.Interface.objects.all().filter(name="Loopback 1").first(),
-            termination_b=dcim_models.Interface.objects.all().filter(name="Loopback 1").last(),
+            termination_a=dcim_models.Interface.objects.all().filter(name="Ethernet1").first(),
+            termination_b=dcim_models.Interface.objects.all().filter(name="Ethernet1").last(),
             status=extras_models.Status.objects.get(name="Active"),
         )
         super().setUp()
@@ -88,11 +88,11 @@ class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):
         expected = {
             "termination_a__app_label": "dcim",
             "termination_a__model": "interface",
-            "termination_a__name": "Loopback 1",
+            "termination_a__name": "Ethernet1",
             "termination_a__device__name": "sw01",
             "termination_b__app_label": "dcim",
             "termination_b__model": "interface",
-            "termination_b__name": "Loopback 1",
+            "termination_b__name": "Ethernet1",
             "termination_b__device__name": "sw02",
         }
         for key, value in expected.items():

--- a/nautobot_ssot/tests/test_contrib_model.py
+++ b/nautobot_ssot/tests/test_contrib_model.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
 from nautobot.circuits import models as circuits_models
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim import models as dcim_models
 from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.extras import models as extras_models
@@ -229,7 +229,7 @@ class BaseModelManyToManyTest(TestCase):
         tag_diffsync.update(attrs={"content_types": content_types})
 
         tag.refresh_from_db()
-        self.assertEqual(
+        self.assertCountEqual(
             list(tag.content_types.values("app_label", "model")),
             content_types,
             "Adding objects to a many-to-many relationship based on more than one parameter through 'NautobotModel'"

--- a/nautobot_ssot/tests/test_contrib_model.py
+++ b/nautobot_ssot/tests/test_contrib_model.py
@@ -4,8 +4,8 @@ from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
-from nautobot.circuits import models as circuits_models
 from nautobot.apps.testing import TestCase
+from nautobot.circuits import models as circuits_models
 from nautobot.dcim import models as dcim_models
 from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.extras import models as extras_models

--- a/nautobot_ssot/tests/test_jobs.py
+++ b/nautobot_ssot/tests/test_jobs.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, call, patch
 
 from django.db.utils import IntegrityError, OperationalError
 from django.test import override_settings
-from nautobot.core.testing import TransactionTestCase
+from nautobot.apps.testing import TransactionTestCase
 from nautobot.extras.models import JobLogEntry, JobResult
 
 from nautobot_ssot.choices import SyncLogEntryActionChoices, SyncLogEntryStatusChoices

--- a/nautobot_ssot/tests/test_management.py
+++ b/nautobot_ssot/tests/test_management.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,

--- a/nautobot_ssot/tests/test_models.py
+++ b/nautobot_ssot/tests/test_models.py
@@ -4,7 +4,7 @@ import datetime
 import time
 import uuid
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from django.utils.timezone import now
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.models import JobResult

--- a/nautobot_ssot/tests/test_models.py
+++ b/nautobot_ssot/tests/test_models.py
@@ -4,8 +4,8 @@ import datetime
 import time
 import uuid
 
-from nautobot.apps.testing import TestCase
 from django.utils.timezone import now
+from nautobot.apps.testing import TestCase
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.models import JobResult
 

--- a/nautobot_ssot/tests/test_render_diff.py
+++ b/nautobot_ssot/tests/test_render_diff.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.templatetags.render_diff import (
     _flatten_diff,

--- a/nautobot_ssot/tests/utils/test_cache.py
+++ b/nautobot_ssot/tests/utils/test_cache.py
@@ -1,6 +1,6 @@
 """Unittests for caching classes."""
 
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Location, LocationType
 from nautobot.extras.models import Status
 

--- a/nautobot_ssot/tests/utils/test_orm.py
+++ b/nautobot_ssot/tests/utils/test_orm.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.circuits.models import Provider
 from nautobot.dcim.models import Location, LocationType
 from nautobot.extras.choices import RelationshipTypeChoices

--- a/nautobot_ssot/tests/utils/test_typing.py
+++ b/nautobot_ssot/tests/utils/test_typing.py
@@ -1,6 +1,6 @@
 """Unittests for typing utility functions."""
 
-from nautobot.core.testing import TestCase
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.utils.typing import get_inner_type
 

--- a/nautobot_ssot/tests/vsphere/test_jobs.py
+++ b/nautobot_ssot/tests/vsphere/test_jobs.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 from django.conf import settings
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from django.urls import reverse
 
 from nautobot_ssot.integrations.vsphere import jobs

--- a/nautobot_ssot/tests/vsphere/test_jobs.py
+++ b/nautobot_ssot/tests/vsphere/test_jobs.py
@@ -3,8 +3,8 @@
 from copy import deepcopy
 
 from django.conf import settings
-from nautobot.apps.testing import TestCase
 from django.urls import reverse
+from nautobot.apps.testing import TestCase
 
 from nautobot_ssot.integrations.vsphere import jobs
 

--- a/nautobot_ssot/tests/vsphere/test_models.py
+++ b/nautobot_ssot/tests/vsphere/test_models.py
@@ -6,11 +6,12 @@ from copy import deepcopy
 from unittest import mock
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.choices import (
     SecretsGroupAccessTypeChoices,
     SecretsGroupSecretTypeChoices,
 )
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import (
     ExternalIntegration,
     Secret,
@@ -33,8 +34,10 @@ from nautobot_ssot.integrations.vsphere.models import SSOTvSphereConfig
 class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """Tests for the SSOTvSphereConfig models."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Setup testing."""
+        populate_status_choices()
         vm_status_map = {
             "POWERED_OFF": "Offline",
             "POWERED_ON": "Active",
@@ -57,7 +60,7 @@ class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-me
                 "parameters": {"variable": "NAUTOBOT_SSOT_VSPHERE_PASSWORD"},
             },
         )
-        self.sg_username, _ = SecretsGroupAssociation.objects.get_or_create(
+        cls.sg_username, _ = SecretsGroupAssociation.objects.get_or_create(
             secrets_group=secrets_group,
             access_type=SecretsGroupAccessTypeChoices.TYPE_REST,
             secret_type=SecretsGroupSecretTypeChoices.TYPE_USERNAME,
@@ -65,7 +68,7 @@ class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-me
                 "secret": inf_username,
             },
         )
-        self.sg_password, _ = SecretsGroupAssociation.objects.get_or_create(
+        cls.sg_password, _ = SecretsGroupAssociation.objects.get_or_create(
             secrets_group=secrets_group,
             access_type=SecretsGroupAccessTypeChoices.TYPE_REST,
             secret_type=SecretsGroupSecretTypeChoices.TYPE_PASSWORD,
@@ -73,7 +76,7 @@ class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-me
                 "secret": inf_password,
             },
         )
-        self.external_integration = ExternalIntegration.objects.create(
+        cls.external_integration = ExternalIntegration.objects.create(
             name="vSphereModelUnitTestInstance",
             remote_url="https://vsphere.local",
             secrets_group=secrets_group,
@@ -81,10 +84,10 @@ class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-me
             timeout=60,
         )
 
-        self.vsphere_config_dict = {
+        cls.vsphere_config_dict = {
             "name": "vSphereModelUnitTestConfig",
             "description": "Unit Test Config",
-            "vsphere_instance": self.external_integration,
+            "vsphere_instance": cls.external_integration,
             "enable_sync_to_nautobot": True,
             "default_vm_status_map": vm_status_map,
             "default_ip_status_map": ip_status_map,
@@ -94,7 +97,7 @@ class SSOTvSphereConfigTestCase(TestCase):  # pylint: disable=too-many-public-me
             "job_enabled": True,
         }
 
-        self.suspended_status, _ = Status.objects.get_or_create(name="Suspended")
+        cls.suspended_status, _ = Status.objects.get_or_create(name="Suspended")
 
     def test_create_vsphere_config_required_fields_only(self):
         """Successfully create vSphere config with required fields only."""

--- a/nautobot_ssot/tests/vsphere/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/vsphere/test_nautobot_adapter.py
@@ -3,7 +3,7 @@
 # pylint: disable=protected-access
 from unittest.mock import MagicMock
 
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models.statuses import Status
 from nautobot.extras.models.tags import Tag
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
@@ -31,42 +31,45 @@ from .vsphere_fixtures import create_default_vsphere_config
 class TestNautobotAdapter(TestCase):  # pylint: disable=too-many-instance-attributes
     """Test cases for vSphere Nautobot adapter."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         test_cluster_type, _ = ClusterType.objects.get_or_create(name="Test")
-        self.test_cluster_group, _ = ClusterGroup.objects.get_or_create(name="Test Group")
-        self.test_cluster, _ = Cluster.objects.get_or_create(
+        cls.test_cluster_group, _ = ClusterGroup.objects.get_or_create(name="Test Group")
+        cls.test_cluster, _ = Cluster.objects.update_or_create(
             name="Test Cluster",
-            cluster_type=test_cluster_type,
-            cluster_group=self.test_cluster_group,
+            defaults={
+                "cluster_type": test_cluster_type,
+                "cluster_group": cls.test_cluster_group,
+            },
         )
-        self.status, _ = Status.objects.get_or_create(name="Active")
-        self.ssot_tag, _ = Tag.objects.get_or_create(name="SSoT Synced from vSphere")
-        self.test_virtualmachine, _ = VirtualMachine.objects.get_or_create(
+        cls.status, _ = Status.objects.get_or_create(name="Active")
+        cls.ssot_tag, _ = Tag.objects.get_or_create(name="SSoT Synced from vSphere")
+        cls.test_virtualmachine, _ = VirtualMachine.objects.get_or_create(
             name="Test VM",
-            cluster=self.test_cluster,
-            status=self.status,
+            cluster=cls.test_cluster,
+            status=cls.status,
             vcpus=2,
             memory=4094,
             disk=50,
         )
-        self.test_virtualmachine.tags.set([self.ssot_tag])
-        self.vm_interface_1, _ = VMInterface.objects.get_or_create(
+        cls.test_virtualmachine.tags.set([cls.ssot_tag])
+        cls.vm_interface_1, _ = VMInterface.objects.get_or_create(
             name="Test Interface",
             enabled=True,
-            virtual_machine=self.test_virtualmachine,
+            virtual_machine=cls.test_virtualmachine,
             mac_address="AA:BB:CC:DD:EE:FF",
-            status=self.status,
+            status=cls.status,
         )
 
-        self.prefix, _ = Prefix.objects.get_or_create(
+        cls.prefix, _ = Prefix.objects.get_or_create(
             network="192.168.1.0",
             prefix_length=24,
             namespace=Namespace.objects.get(name="Global"),
-            status=self.status,
+            status=cls.status,
             type="network",
         )
-        self.vm_ip, _ = IPAddress.objects.get_or_create(host="192.168.1.1", mask_length=24, status=self.status)
-        self.vm_ip.vm_interfaces.set([self.vm_interface_1])
+        cls.vm_ip, _ = IPAddress.objects.get_or_create(host="192.168.1.1", mask_length=24, status=cls.status)
+        cls.vm_ip.vm_interfaces.set([cls.vm_interface_1])
 
     def test_load(self):
         self.test_virtualmachine.primary_ip4 = self.vm_ip

--- a/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_create.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_create.py
@@ -4,7 +4,7 @@
 from unittest.mock import MagicMock
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
 from nautobot.extras.models.statuses import Status
 from nautobot.extras.models.tags import Tag
 from nautobot.ipam.models import IPAddress, Prefix

--- a/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_delete.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_delete.py
@@ -4,7 +4,8 @@
 from unittest.mock import MagicMock
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models.statuses import Status
 from nautobot.extras.models.tags import Tag
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
@@ -32,6 +33,7 @@ class TestVSphereDiffSyncModelsDelete(TestCase):
 
     def setUp(self):
         """Test class SetUp."""
+        populate_status_choices()
         self.config = create_default_vsphere_config()
         self.vsphere_adapter = VsphereDiffSync(client=MagicMock(), config=self.config, cluster_filters=None)
         self.active_status, _ = Status.objects.get_or_create(name="Active")

--- a/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_update.py
+++ b/nautobot_ssot/tests/vsphere/test_vsphere_diffsync_models_update.py
@@ -4,7 +4,8 @@
 from unittest.mock import MagicMock
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from nautobot.apps.testing import TestCase
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models.statuses import Status
 from nautobot.extras.models.tags import Tag
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
@@ -33,6 +34,7 @@ class TestVSphereDiffSyncModelsUpdate(TestCase):
 
     def setUp(self):
         """Test class SetUp."""
+        populate_status_choices()
         self.config = create_default_vsphere_config()
         self.vsphere_adapter = VsphereDiffSync(
             client=MagicMock(),


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-1260

## What's Changed

- Fixed a test that was failing due to a recent change in Nautobot's next branch for 3.2.0: https://github.com/nautobot/nautobot/pull/8974. This does not fix the failures when creating cables in the tests/contrib_base_classes NautobotCable model due to the changes to the Cable data model in core.
- Fixed many test cases that were using TransactionTestCase when TestCase was acceptable. This improves the performance of tests significantly
- Fixed some of the test cases that were failing when running with `--keepdb` but not all of them
- Fixed all test cases to correctly import from `nautobot.apps` instead of `nautobot.core` or `django.test`

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
