### PR TITLE
Add ObjectMetadataAnnotation to the SSoT contrib framework

### DIFF
--- a/changes/1249.added
+++ b/changes/1249.added
@@ -1,0 +1,1 @@
+Added `ObjectMetadataAnnotation` to `nautobot_ssot.contrib`, letting DiffSync models on the `NautobotModel` base read and write a field's value to Nautobot ObjectMetadata.

--- a/changes/791.fixed
+++ b/changes/791.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in the SSoT contrib adapter where a custom-relationship foreign key matching more than one association raised an `AttributeError` instead of logging a warning.

--- a/changes/791.housekeeping
+++ b/changes/791.housekeeping
@@ -1,0 +1,1 @@
+Added unit tests bringing the SSoT contrib `types.py` and `adapter.py` modules to 100% test coverage.

--- a/docs/dev/contrib_object_metadata.md
+++ b/docs/dev/contrib_object_metadata.md
@@ -1,0 +1,52 @@
+# ObjectMetadata-Backed Fields (`ObjectMetadataAnnotation`)
+
+`ObjectMetadataAnnotation` marks a DiffSync model field whose value lives in Nautobot
+`ObjectMetadata` instead of a model field or custom field. Use it to persist an external
+system's identifier (e.g. a record ID) on a Nautobot object so future syncs can correlate
+the two records.
+
+## Usage
+
+```python
+from typing import Annotated, Optional
+
+from nautobot.dcim.models import Manufacturer
+from nautobot_ssot.contrib import NautobotModel, ObjectMetadataAnnotation
+
+
+class ManufacturerModel(NautobotModel):
+    _model = Manufacturer
+    _modelname = "manufacturer"
+    _identifiers = ("name",)
+    _attributes = ("external_id",)
+
+    name: str
+    external_id: Annotated[
+        Optional[str], ObjectMetadataAnnotation(metadata_type_name="External System ID")
+    ] = None
+```
+
+On load, `external_id` is read from the object's `ObjectMetadata` of type
+`"External System ID"`. On create/update, the value is written back to that metadata (one
+whole-object row per annotated field).
+
+## Prerequisite: the MetadataType is integration-owned
+
+Like `CustomFieldAnnotation` and `CustomRelationshipAnnotation`, contrib does **not** create
+the backing schema. Your integration must create the `MetadataType` and attach the relevant
+content type(s) before syncing (e.g. in a prerequisite step or migration):
+
+```python
+from django.contrib.contenttypes.models import ContentType
+from nautobot.dcim.models import Manufacturer
+from nautobot.extras.models.metadata import MetadataType
+
+metadata_type, _ = MetadataType.objects.get_or_create(
+    name="External System ID", defaults={"data_type": "text"}
+)
+metadata_type.content_types.add(ContentType.objects.get_for_model(Manufacturer))
+```
+
+Reads are lenient (missing type or row resolves to `None`). Writes are strict: a missing or
+misconfigured `MetadataType` raises `ObjectCrudException`. A `None` value is a no-op
+(existing metadata is left unchanged; syncing `None` does not clear it).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
   - Developer Guide:
       - Upgrading from SSoT 2.x to 3.x: "dev/upgrade.md"
       - Extending the App: "dev/extending.md"
+      - ObjectMetadata-Backed Fields: "dev/contrib_object_metadata.md"
       - Developing Jobs: "dev/jobs.md"
       - Debugging Jobs: "dev/debugging.md"
       - Contributing to the App: "dev/contributing.md"

--- a/nautobot_ssot/contrib/__init__.py
+++ b/nautobot_ssot/contrib/__init__.py
@@ -9,6 +9,7 @@ from nautobot_ssot.contrib.model import NautobotModel
 from nautobot_ssot.contrib.types import (
     CustomFieldAnnotation,
     CustomRelationshipAnnotation,
+    ObjectMetadataAnnotation,
     RelationshipSideEnum,
 )
 
@@ -17,6 +18,7 @@ __all__ = (
     "CustomRelationshipAnnotation",
     "NautobotAdapter",
     "NautobotModel",
+    "ObjectMetadataAnnotation",
     "RelationshipSideEnum",
     "SkipAutoComponentCreation",
     "is_auto_component_creation_suppressed",

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -20,6 +20,7 @@ from nautobot_ssot.contrib.base import BaseNautobotAdapter, BaseNautobotModel
 from nautobot_ssot.contrib.types import (
     CustomFieldAnnotation,
     CustomRelationshipAnnotation,
+    ObjectMetadataAnnotation,
     RelationshipSideEnum,
 )
 from nautobot_ssot.utils.cache import ORMCache
@@ -101,6 +102,11 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
                 parameters[parameter_name] = database_object.cf[field_key]
             return
 
+        # Handle ObjectMetadata-backed fields. See ObjectMetadataAnnotation docstring for more details.
+        if isinstance(annotation, ObjectMetadataAnnotation):
+            parameters[parameter_name] = self._get_object_metadata_value(database_object, annotation)
+            return
+
         is_custom_relationship = isinstance(annotation, CustomRelationshipAnnotation)
 
         # Handling of foreign keys where the local side is the many and the remote side the one.
@@ -138,6 +144,18 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
             parameters[parameter_name] = getattr(self, f"load_param_{parameter_name}")(parameter_name, database_object)
         else:
             parameters[parameter_name] = getattr(database_object, parameter_name)
+
+    @staticmethod
+    def _get_object_metadata_value(database_object, annotation: ObjectMetadataAnnotation):
+        """Return the value of the ObjectMetadata matching the annotation, or None.
+
+        Reads from the prefetched `associated_object_metadata` relation, so callers must
+        prefetch it (handled by `NautobotModel._get_queryset`) to avoid N+1 queries.
+        """
+        for metadata in database_object.associated_object_metadata.all():
+            if metadata.metadata_type.name == annotation.metadata_type_name:
+                return metadata.value
+        return None
 
     def _load_single_object(self, database_object, diffsync_model, parameter_names):
         """Load a single diffsync object from a single database object."""

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -321,7 +321,7 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
             return None
         if association_count > 1:
             self.job.logger.warning(
-                f"Foreign key ({database_object.__name__}.{parameter_name}) "
+                f"Foreign key ({type(database_object).__name__}.{parameter_name}) "
                 "custom relationship matched two associations - this shouldn't happen."
             )
 

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -13,12 +13,13 @@ from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.db.models import ProtectedError, QuerySet
 from nautobot.extras.choices import RelationshipTypeChoices
 from nautobot.extras.models import Relationship, RelationshipAssociation
-from nautobot.extras.models.metadata import ObjectMetadata
+from nautobot.extras.models.metadata import MetadataType, ObjectMetadata
 
 from nautobot_ssot.contrib.base import BaseNautobotModel
 from nautobot_ssot.contrib.types import (
     CustomFieldAnnotation,
     CustomRelationshipAnnotation,
+    ObjectMetadataAnnotation,
     RelationshipSideEnum,
 )
 from nautobot_ssot.utils.diffsync import DiffSyncModelUtilityMixin
@@ -47,6 +48,12 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
         prefetch_related_parameters = [
             "__".join(parameter.split("__")[:-1]) for parameter in parameter_names if "__" in parameter
         ]
+        # If any synced attribute is backed by ObjectMetadata, prefetch it (with its type) to avoid N+1 reads.
+        if any(
+            isinstance(cls.get_attr_annotation(parameter), ObjectMetadataAnnotation)
+            for parameter in cls.get_synced_attributes()
+        ):
+            prefetch_related_parameters.append("associated_object_metadata__metadata_type")
         qs = cls.get_queryset()
         return qs.prefetch_related(*prefetch_related_parameters)
 
@@ -134,6 +141,12 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
             obj.cf[annotation.key] = value
             return
 
+        # Handle ObjectMetadata-backed fields. The actual write happens post-save (it needs a pk),
+        # so just stash the pending value here. See ObjectMetadataAnnotation docstring for more details.
+        if isinstance(annotation, ObjectMetadataAnnotation):
+            relationship_fields["object_metadata_fields"][field] = (annotation, value)
+            return
+
         custom_relationship_annotation = annotation if isinstance(annotation, CustomRelationshipAnnotation) else None
 
         # Prepare handling of foreign keys and custom relationship foreign keys.
@@ -219,6 +232,8 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
             "custom_relationship_foreign_keys": defaultdict(dict),
             # Example: TODO
             "custom_relationship_many_to_many_fields": defaultdict(dict),
+            # Example: {"external_id": (ObjectMetadataAnnotation(...), "SN-123")}
+            "object_metadata_fields": defaultdict(dict),
         }
         for field, value in parameters.items():
             cls._handle_single_field(field, obj, value, relationship_fields, adapter)
@@ -245,6 +260,9 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
 
         # Set many-to-many fields after saving.
         cls._set_many_to_many_fields(relationship_fields["many_to_many_fields"], obj)
+
+        # Write ObjectMetadata-backed fields last, since they require a saved object (pk).
+        cls._set_object_metadata_fields(relationship_fields["object_metadata_fields"], obj, adapter)
 
     @classmethod
     def _set_custom_relationship_to_many_fields(cls, custom_relationship_many_to_many_fields, obj, adapter):
@@ -389,6 +407,38 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
                     f"Found multiple instances for {field_name} with: {related_model_dict}"
                 ) from error
             setattr(obj, field_name, related_object)
+
+    @classmethod
+    def _set_object_metadata_fields(cls, object_metadata_fields, obj, adapter):
+        """Write ObjectMetadata rows for fields carrying an ObjectMetadataAnnotation.
+
+        One whole-object (`scoped_fields=[]`) row per annotation. A `None` value is a no-op.
+        The backing `MetadataType` must already exist with the object's content type attached;
+        otherwise an `ObjectCrudException` is raised.
+        """
+        for field, (annotation, value) in object_metadata_fields.items():
+            if value is None:
+                continue
+            try:
+                metadata_type = adapter.get_from_orm_cache({"name": annotation.metadata_type_name}, MetadataType)
+            except MetadataType.DoesNotExist as error:
+                raise ObjectCrudException(
+                    f"No such MetadataType '{annotation.metadata_type_name}' required by field '{field}'. "
+                    f"The integration must create it (and attach the '{obj._meta.label}' content type) before syncing."
+                ) from error
+            obj_metadata = obj.associated_object_metadata.filter(metadata_type=metadata_type).first() or ObjectMetadata(
+                metadata_type=metadata_type, assigned_object=obj
+            )
+            # Note: the `value` setter eagerly calls clean(), so the assignment is inside the try too.
+            try:
+                obj_metadata.value = value
+                obj_metadata.scoped_fields = []
+                obj_metadata.validated_save()
+            except ValidationError as error:
+                raise ObjectCrudException(
+                    f"Failed to write ObjectMetadata '{annotation.metadata_type_name}' for field "
+                    f"'{field}' on {obj}: {error}"
+                ) from error
 
     @classmethod
     def _update_obj_metadata(cls, obj, adapter):

--- a/nautobot_ssot/contrib/types.py
+++ b/nautobot_ssot/contrib/types.py
@@ -87,3 +87,28 @@ class CustomFieldAnnotation(CustomAnnotation):
                 self.key = self.name
             else:
                 raise ValueError("The 'key' field on CustomFieldAnnotation needs to be set.")
+
+
+@dataclass
+class ObjectMetadataAnnotation(CustomAnnotation):
+    """Mark a DiffSync model field as backed by Nautobot ObjectMetadata.
+
+    Fields annotated with this type are read from / written to `ObjectMetadata`
+    (keyed by `metadata_type_name`) instead of a regular model field or custom field.
+    The backing `MetadataType` must already exist and have the model's content type
+    attached; this annotation does not create it.
+
+    Attributes:
+        metadata_type_name: The `MetadataType.name` to read/write.
+        data_type: Informational `MetadataTypeDataTypeChoices` value; defaults to `"text"`.
+
+    Example:
+        ```python
+        external_id: Annotated[
+            Optional[str], ObjectMetadataAnnotation(metadata_type_name="External System ID")
+        ] = None
+        ```
+    """
+
+    metadata_type_name: str
+    data_type: str = "text"

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -501,7 +501,7 @@ class NautobotAdapterCustomLoaderTest(TestCase):
             top_level = ("tenant",)
             tenant = TenantModel
 
-            def load_param_description(self, parameter_name, database_object):
+            def load_param_description(self, _parameter_name, _database_object):
                 """Return a fixed value to exercise the custom-loader branch."""
                 return "custom-loaded"
 

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -5,6 +5,7 @@ from unittest import skip
 from unittest.mock import MagicMock
 
 from diffsync import ObjectNotFound
+from diffsync.exceptions import ObjectCrudException
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
@@ -18,7 +19,13 @@ from nautobot.ipam import models as ipam_models
 from nautobot.tenancy import models as tenancy_models
 from typing_extensions import TypedDict
 
-from nautobot_ssot.contrib import CustomFieldAnnotation, NautobotAdapter, NautobotModel
+from nautobot_ssot.contrib import (
+    CustomFieldAnnotation,
+    CustomRelationshipAnnotation,
+    NautobotAdapter,
+    NautobotModel,
+    RelationshipSideEnum,
+)
 from nautobot_ssot.tests.contrib_base_classes import (
     NautobotCable,
     NautobotDevice,
@@ -407,3 +414,237 @@ class AdapterCustomRelationshipSortingTest(NautobotAdapter):
             "name",
         ),
     )
+
+
+class CustomFieldAnnotationValidationTest(TestCase):
+    """Cover validation on the CustomFieldAnnotation dataclass."""
+
+    def test_requires_key_or_name(self):
+        """A CustomFieldAnnotation with neither 'key' nor 'name' raises ValueError."""
+        with self.assertRaises(ValueError):
+            CustomFieldAnnotation()
+
+
+class NautobotAdapterUtilityCoverageTests(TestCase):
+    """Cover small utility / edge branches of NautobotAdapter."""
+
+    def test_progress_logger_disabled_is_noop(self):
+        """With the progress logger disabled, log_loaded_objects does nothing."""
+        adapter = TestAdapter(job=MagicMock())
+        adapter.enable_progress_logger = False
+        adapter.log_loaded_objects()
+        self.assertEqual(adapter.objects_loaded, 0)
+        adapter.job.logger.info.assert_not_called()
+
+    def test_progress_logger_logs_on_interval(self):
+        """With the progress logger enabled, log_loaded_objects logs when the interval is hit."""
+        adapter = TestAdapter(job=MagicMock())
+        adapter.enable_progress_logger = True
+        adapter.progress_logger_interval = 1
+        adapter.log_loaded_objects()
+        self.assertEqual(adapter.objects_loaded, 1)
+        adapter.job.logger.info.assert_called_once()
+
+    def test_validate_adapter_requires_top_level(self):
+        """Instantiating an adapter without 'top_level' raises ValueError."""
+
+        class NoTopLevelAdapter(NautobotAdapter):
+            """Adapter missing the required 'top_level' attribute."""
+
+        with self.assertRaises(ValueError):
+            NoTopLevelAdapter(job=MagicMock())
+
+    def test_get_parameter_names(self):
+        """_get_parameter_names returns the model's synced attributes."""
+        self.assertEqual(
+            NautobotAdapter._get_parameter_names(NautobotTenant),  # pylint: disable=protected-access
+            NautobotTenant.get_synced_attributes(),
+        )
+
+    def test_invalidate_cache_is_deprecated(self):
+        """The deprecated invalidate_cache method logs a warning and delegates to the cache."""
+        adapter = TestAdapter(job=MagicMock())
+        adapter.invalidate_cache()
+        adapter.job.logger.warning.assert_called_once()
+
+    def test_get_diffsync_class_missing_attribute(self):
+        """Requesting a diffsync class not defined on the adapter raises AttributeError.
+
+        (diffsync validates 'top_level' at class-definition time, so this is exercised via a
+        direct call, mirroring how child-model names are resolved at runtime.)
+        """
+        adapter = TestAdapter(job=MagicMock())
+        with self.assertRaises(AttributeError):
+            adapter._get_diffsync_class("does_not_exist")  # pylint: disable=protected-access
+
+
+class NautobotAdapterCustomLoaderTest(TestCase):
+    """Cover the per-parameter custom loader (load_param_<field>) branch."""
+
+    def test_load_param_custom_loader(self):
+        """A 'load_param_<field>' method on the adapter overrides the loaded value."""
+
+        class TenantModel(NautobotModel):
+            """Tenant model with a normal field served by a custom loader."""
+
+            _model = tenancy_models.Tenant
+            _modelname = "tenant"
+            _identifiers = ("name",)
+            _attributes = ("description",)
+
+            name: str
+            description: Optional[str] = None
+
+        class Adapter(NautobotAdapter):
+            """Adapter providing a custom loader for 'description'."""
+
+            top_level = ("tenant",)
+            tenant = TenantModel
+
+            def load_param_description(self, parameter_name, database_object):
+                """Return a fixed value to exercise the custom-loader branch."""
+                return "custom-loaded"
+
+        tenancy_models.Tenant.objects.create(name="LoaderTenant", description="original")
+        adapter = Adapter(job=MagicMock())
+        adapter.load()
+        self.assertEqual(adapter.get(TenantModel, "LoaderTenant").description, "custom-loaded")
+
+
+class NautobotAdapterPydanticErrorTest(TestCase):
+    """Cover the pydantic-ValidationError -> ValueError translation during load."""
+
+    def test_pydantic_validation_error_becomes_value_error(self):
+        """A value that fails pydantic validation during load is re-raised as ValueError."""
+
+        class BadTenantModel(NautobotModel):
+            """Model whose 'description' is typed int, but the DB holds a non-numeric string."""
+
+            _model = tenancy_models.Tenant
+            _modelname = "tenant"
+            _identifiers = ("name",)
+            _attributes = ("description",)
+
+            name: str
+            description: int
+
+        class Adapter(NautobotAdapter):
+            """Adapter for the deliberately mistyped model."""
+
+            top_level = ("tenant",)
+            tenant = BadTenantModel
+
+        tenancy_models.Tenant.objects.create(name="BadTenant", description="not-an-int")
+        adapter = Adapter(job=MagicMock())
+        with self.assertRaises(ValueError):
+            adapter.load()
+
+
+class _ProviderDict(TypedDict):
+    """Typed dict describing the interesting fields of a related Provider."""
+
+    name: str
+
+
+class TenantToOneDestinationModel(NautobotModel):
+    """Destination-side, to-one custom relationship field (no '__') for one-to-many edge coverage."""
+
+    _model = tenancy_models.Tenant
+    _modelname = "tenant"
+    _identifiers = ("name",)
+    _attributes = ("provider",)
+
+    name: str
+    provider: Annotated[
+        Optional[_ProviderDict],
+        CustomRelationshipAnnotation(name="Test Relationship", side=RelationshipSideEnum.DESTINATION),
+    ] = None
+
+
+class TenantToOneDestinationAdapter(NautobotAdapter):
+    """Adapter loading the destination-side to-one custom relationship model."""
+
+    top_level = ("tenant",)
+    tenant = TenantToOneDestinationModel
+
+
+class NautobotAdapterCustomRelationshipEdgeTests(TestCase):
+    """Cover the one-to-many DESTINATION and foreign-key custom-relationship edge branches."""
+
+    def setUp(self):
+        self.relationship = extras_models.Relationship.objects.create(
+            label="Test Relationship",
+            type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
+            source_type=ContentType.objects.get_for_model(circuits_models.Provider),
+            destination_type=ContentType.objects.get_for_model(tenancy_models.Tenant),
+        )
+        self.tenant = tenancy_models.Tenant.objects.create(name="Edge Tenant")
+
+    def _associate(self, provider_name):
+        provider = circuits_models.Provider.objects.create(name=provider_name)
+        extras_models.RelationshipAssociation.objects.create(
+            relationship=self.relationship, source=provider, destination=self.tenant
+        )
+        return provider
+
+    def test_to_one_destination_without_association_is_none(self):
+        """A destination-side to-one field with no association loads as None."""
+        adapter = TenantToOneDestinationAdapter(job=MagicMock())
+        adapter.load()
+        self.assertIsNone(adapter.get(TenantToOneDestinationModel, "Edge Tenant").provider)
+
+    def test_to_one_destination_single_association(self):
+        """A destination-side to-one field with one association loads as a single dict."""
+        self._associate("Edge Provider")
+        adapter = TenantToOneDestinationAdapter(job=MagicMock())
+        adapter.load()
+        self.assertEqual(adapter.get(TenantToOneDestinationModel, "Edge Tenant").provider, {"name": "Edge Provider"})
+
+    def test_to_one_destination_multiple_associations_raises(self):
+        """More than one association for a one-to-many destination raises ObjectCrudException."""
+        self._associate("Provider 1")
+        self._associate("Provider 2")
+        adapter = TenantToOneDestinationAdapter(job=MagicMock())
+        with self.assertRaises(ObjectCrudException):
+            adapter.load()
+
+    def test_foreign_key_custom_relationship_without_association_is_none(self):
+        """A foreign-key custom-relationship field with no association loads as None."""
+        adapter = CustomRelationShipTestAdapterSource(job=MagicMock())
+        adapter.load()
+        self.assertIsNone(adapter.get(TenantModelCustomRelationship, "Edge Tenant").provider__name)
+
+    def test_foreign_key_custom_relationship_multiple_associations_warns(self):
+        """More than one association for a foreign-key custom relationship logs a warning."""
+        self._associate("Provider 1")
+        self._associate("Provider 2")
+        adapter = CustomRelationShipTestAdapterSource(job=MagicMock())
+        adapter.load()
+        adapter.job.logger.warning.assert_called()
+        self.assertIsNotNone(adapter.get(TenantModelCustomRelationship, "Edge Tenant").provider__name)
+
+
+class _CoverageJobMeta:
+    data_source = "Coverage Source"
+
+
+class _CoverageJob:
+    """Minimal job stand-in exposing Meta.data_source for get_or_create_metadatatype."""
+
+    Meta = _CoverageJobMeta
+
+    def __init__(self):
+        self.logger = MagicMock()
+
+
+class NautobotAdapterMetadataTypeChildrenTest(TestCase):
+    """Cover the child-model loop in get_or_create_metadatatype."""
+
+    def test_children_models_included(self):
+        """get_or_create_metadatatype walks child models and records their scope fields."""
+        adapter = TestAdapter(job=_CoverageJob())
+        adapter.get_or_create_metadatatype()
+        self.assertIsNotNone(adapter.metadata_type)
+        # The top-level model and its child model both get scope fields recorded.
+        self.assertIn(NautobotTenantGroup, adapter.metadata_scope_fields)
+        self.assertIn(NautobotTenant, adapter.metadata_scope_fields)

--- a/nautobot_ssot/tests/test_contrib_object_metadata.py
+++ b/nautobot_ssot/tests/test_contrib_object_metadata.py
@@ -1,0 +1,212 @@
+"""Tests for the generic ObjectMetadataAnnotation contrib feature."""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional, get_args, get_type_hints
+from unittest.mock import MagicMock
+
+from diffsync.exceptions import ObjectCrudException
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from nautobot.apps.testing import TestCase
+from nautobot.dcim.models import Manufacturer
+from nautobot.extras.models.metadata import MetadataType, ObjectMetadata
+
+from nautobot_ssot.contrib import NautobotAdapter, NautobotModel, ObjectMetadataAnnotation
+from nautobot_ssot.contrib.types import CustomAnnotation
+
+METADATA_TYPE_NAME = "External System ID"
+
+
+class _ManufacturerWithExternalId(NautobotModel):
+    """Test DiffSync model: a Manufacturer with a metadata-backed external_id."""
+
+    _model = Manufacturer
+    _modelname = "manufacturer"
+    _identifiers = ("name",)
+    _attributes = ("external_id",)
+
+    name: str
+    external_id: Annotated[Optional[str], ObjectMetadataAnnotation(metadata_type_name=METADATA_TYPE_NAME)] = None
+
+
+class _ManufacturerAdapter(NautobotAdapter):
+    manufacturer = _ManufacturerWithExternalId
+    top_level = ("manufacturer",)
+
+
+class ObjectMetadataAnnotationTypeTests(TestCase):
+    """The annotation dataclass behaves like the other contrib annotations."""
+
+    def test_is_custom_annotation_subclass(self):
+        annotation = ObjectMetadataAnnotation(metadata_type_name="External System ID")
+        self.assertIsInstance(annotation, CustomAnnotation)
+
+    def test_default_data_type_is_text(self):
+        self.assertEqual(ObjectMetadataAnnotation(metadata_type_name="X").data_type, "text")
+
+    def test_data_type_override(self):
+        self.assertEqual(ObjectMetadataAnnotation(metadata_type_name="X", data_type="url").data_type, "url")
+
+    def test_detectable_via_typing(self):
+        class _Model:
+            external_id: Annotated[Optional[str], ObjectMetadataAnnotation(metadata_type_name="External System ID")] = (
+                None
+            )
+            name: str = ""
+
+        hints = get_type_hints(_Model, include_extras=True)
+        annotations = [a for a in get_args(hints["external_id"]) if isinstance(a, ObjectMetadataAnnotation)]
+        self.assertEqual(len(annotations), 1)
+        self.assertEqual(annotations[0].metadata_type_name, "External System ID")
+        self.assertEqual([a for a in get_args(hints.get("name", str)) if isinstance(a, ObjectMetadataAnnotation)], [])
+
+
+class ObjectMetadataReadTests(TestCase):
+    """Loading reads the annotated field from ObjectMetadata."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer_ct = ContentType.objects.get_for_model(Manufacturer)
+        cls.metadata_type = MetadataType.objects.create(name=METADATA_TYPE_NAME, data_type="text")
+        cls.metadata_type.content_types.add(cls.manufacturer_ct)
+
+    def _add_metadata(self, obj, value):
+        metadata = ObjectMetadata(metadata_type=self.metadata_type, assigned_object=obj, scoped_fields=[])
+        metadata.value = value
+        metadata.validated_save()
+
+    def test_loads_metadata_value_into_field(self):
+        manufacturer = Manufacturer.objects.create(name="Cisco")
+        self._add_metadata(manufacturer, "SN-123")
+
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        adapter.load()
+
+        loaded = adapter.get(_ManufacturerWithExternalId, "Cisco")
+        self.assertEqual(loaded.external_id, "SN-123")
+
+    def test_missing_metadata_row_loads_none(self):
+        Manufacturer.objects.create(name="Juniper")  # no metadata row
+
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        adapter.load()
+
+        self.assertIsNone(adapter.get(_ManufacturerWithExternalId, "Juniper").external_id)
+
+    def test_no_n_plus_one_queries(self):
+        # One manufacturer with metadata.
+        first = Manufacturer.objects.create(name="Vendor-1")
+        self._add_metadata(first, "SN-1")
+        # Warm up ContentType / app caches so the comparison isn't skewed by first-call lookups.
+        _ManufacturerAdapter(job=MagicMock()).load()
+        with CaptureQueriesContext(connection) as one_obj:
+            _ManufacturerAdapter(job=MagicMock()).load()
+
+        # Several more manufacturers with metadata.
+        for index in range(2, 6):
+            extra = Manufacturer.objects.create(name=f"Vendor-{index}")
+            self._add_metadata(extra, f"SN-{index}")
+        with CaptureQueriesContext(connection) as five_obj:
+            _ManufacturerAdapter(job=MagicMock()).load()
+
+        # Query count must not grow with the number of objects (prefetch, not per-row).
+        self.assertEqual(len(one_obj.captured_queries), len(five_obj.captured_queries))
+
+
+class ObjectMetadataWriteTests(TestCase):
+    """Create/update write the annotated field to ObjectMetadata."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer_ct = ContentType.objects.get_for_model(Manufacturer)
+        cls.metadata_type = MetadataType.objects.create(name=METADATA_TYPE_NAME, data_type="text")
+        cls.metadata_type.content_types.add(cls.manufacturer_ct)
+
+    def _metadata_value(self, obj):
+        metadata = obj.associated_object_metadata.filter(metadata_type=self.metadata_type).first()
+        return metadata.value if metadata else None
+
+    def test_create_writes_metadata(self):
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        _ManufacturerWithExternalId.create(adapter, {"name": "Cisco"}, {"external_id": "SN-123"})
+
+        manufacturer = Manufacturer.objects.get(name="Cisco")
+        self.assertEqual(self._metadata_value(manufacturer), "SN-123")
+        metadata = manufacturer.associated_object_metadata.get(metadata_type=self.metadata_type)
+        self.assertEqual(metadata.scoped_fields, [])
+
+    def test_update_changes_metadata_in_place(self):
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        _ManufacturerWithExternalId.create(adapter, {"name": "Cisco"}, {"external_id": "SN-123"})
+
+        load_adapter = _ManufacturerAdapter(job=MagicMock())
+        load_adapter.load()
+        loaded = load_adapter.get(_ManufacturerWithExternalId, "Cisco")
+        loaded.update({"external_id": "SN-999"})
+
+        manufacturer = Manufacturer.objects.get(name="Cisco")
+        self.assertEqual(self._metadata_value(manufacturer), "SN-999")
+        # Exactly one row of this type (updated in place, not duplicated).
+        self.assertEqual(manufacturer.associated_object_metadata.filter(metadata_type=self.metadata_type).count(), 1)
+
+    def test_none_value_is_noop(self):
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        _ManufacturerWithExternalId.create(adapter, {"name": "Aruba"}, {"external_id": None})
+
+        manufacturer = Manufacturer.objects.get(name="Aruba")
+        self.assertEqual(manufacturer.associated_object_metadata.filter(metadata_type=self.metadata_type).count(), 0)
+
+
+class ObjectMetadataWriteErrorTests(TestCase):
+    """Writes fail loudly when the backing MetadataType is missing or misconfigured."""
+
+    def test_missing_metadata_type_raises(self):
+        # No MetadataType named METADATA_TYPE_NAME exists.
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        with self.assertRaises(ObjectCrudException) as context:
+            _ManufacturerWithExternalId.create(adapter, {"name": "Cisco"}, {"external_id": "SN-1"})
+        self.assertIn(METADATA_TYPE_NAME, str(context.exception))
+
+    def test_content_type_not_attached_raises(self):
+        # MetadataType exists but the Manufacturer content type is NOT attached.
+        MetadataType.objects.create(name=METADATA_TYPE_NAME, data_type="text")
+        adapter = _ManufacturerAdapter(job=MagicMock())
+        with self.assertRaises(ObjectCrudException):
+            _ManufacturerWithExternalId.create(adapter, {"name": "Cisco"}, {"external_id": "SN-1"})
+
+
+class _FakeJobMeta:
+    data_source = "Test Source"
+
+
+class _FakeJob:
+    """Minimal stand-in for a Nautobot Job (avoids mutating MagicMock's shared class)."""
+
+    Meta = _FakeJobMeta
+
+    def __init__(self):
+        self.logger = MagicMock()
+
+
+class ObjectMetadataCoexistenceTests(TestCase):
+    """The annotation feature coexists with the adapter 'Last sync' metadata feature."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer_ct = ContentType.objects.get_for_model(Manufacturer)
+        cls.metadata_type = MetadataType.objects.create(name=METADATA_TYPE_NAME, data_type="text")
+        cls.metadata_type.content_types.add(cls.manufacturer_ct)
+
+    def test_annotation_and_last_sync_metadata_dont_collide(self):
+        adapter = _ManufacturerAdapter(job=_FakeJob())
+        adapter.get_or_create_metadatatype()  # enables the "Last sync from Test Source" feature
+
+        _ManufacturerWithExternalId.create(adapter, {"name": "Cisco"}, {"external_id": "SN-123"})
+
+        manufacturer = Manufacturer.objects.get(name="Cisco")
+        external = manufacturer.associated_object_metadata.get(metadata_type=self.metadata_type)
+        self.assertEqual(external.value, "SN-123")
+        last_sync = manufacturer.associated_object_metadata.get(metadata_type=adapter.metadata_type)
+        self.assertEqual(last_sync.metadata_type.name, "Last sync from Test Source")


### PR DESCRIPTION
# Closes: #1249

<!-- Test coverage and the incidental bug fix below are tracked under #791. -->
Related: #791

## What's Changed

Adds a generic `ObjectMetadataAnnotation` to `nautobot_ssot.contrib`, letting any DiffSync
model on the contrib `NautobotModel` base read and write a field's value to Nautobot
`ObjectMetadata`. It mirrors the existing `CustomFieldAnnotation` routing, so it is inert
for models that don't use it.

### Annotation type
- New `ObjectMetadataAnnotation(metadata_type_name, data_type="text")` in
  `nautobot_ssot/contrib/types.py`, exported from `nautobot_ssot.contrib`.

### Read path (`NautobotAdapter`)
- `_handle_single_parameter` now routes `ObjectMetadataAnnotation` fields, reading the
  value from the object's `ObjectMetadata` of the named `MetadataType`.
- `NautobotModel._get_queryset` prefetches `associated_object_metadata__metadata_type`
  when a model declares any annotated field, so loading N objects does **not** scale
  queries with N (covered by a query-count test).
- Reads are lenient: a missing `MetadataType` or absent row resolves to `None`.

### Write path (`NautobotModel`)
- Annotated values are written **after** `validated_save()` (they require a saved object),
  as a single whole-object (`scoped_fields=[]`) metadata row, idempotently (update in place,
  no duplicates).
- A `None` value is a no-op (existing metadata is left unchanged).
- Writes are strict: a missing `MetadataType`, or one without the object's content type
  attached, raises a clear `ObjectCrudException` naming the field and type. (The `MetadataType`
  is integration-owned — contrib does not create it, consistent with `CustomFieldAnnotation`
  and `CustomRelationshipAnnotation`.)

### Bonus Test coverage & bug fix (#791)
- Added unit tests bringing `nautobot_ssot/contrib/types.py` and
  `nautobot_ssot/contrib/adapter.py` to **100%** coverage 
- Fixed a latent bug uncovered by that work: the adapter's ">1 association" warning
  referenced `database_object.__name__` (which raises `AttributeError` on a model
  instance) — now `type(database_object).__name__`.

### Tests & docs
- New `nautobot_ssot/tests/test_contrib_object_metadata.py` (13 tests): annotation type,
  read + leniency + no-N+1, create/update/None, strict error paths, and coexistence with
  the existing "Last sync from <source>" adapter metadata feature.
- New contrib coverage tests in `nautobot_ssot/tests/test_contrib_adapter.py`.
- New developer docs page `docs/dev/contrib_object_metadata.md` (added to `mkdocs.yml`).

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example <!-- N/A: no UI or API payload changes -->
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

### Remaining work / constraints from design
- One value per `(MetadataType, object)` (whole-object scope); storing multiple distinct
  values under the same type for one object is intentionally unsupported.
- Clearing metadata by syncing `None` is intentionally not supported (it is a no-op).
