### PR TITLE
Fix contrib adapter to handle children with OneToOneField

### DIFF
--- a/changes/1258.fixed
+++ b/changes/1258.fixed
@@ -1,0 +1,1 @@
+Fixed handling children when child attribute is OneToOneField.

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -156,8 +156,14 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
 
     def _handle_children(self, database_object, diffsync_model: BaseNautobotModel):
         """Recurse through all the children for this model."""
+        available_fields = {field.name for field in diffsync_model._model._meta.get_fields()}
         for children_parameter, children_field in diffsync_model._children.items():
-            if not hasattr(database_object, children_field):  # covers OneToOneField
+            if children_field not in available_fields:
+                raise AttributeError(
+                    f"'{diffsync_model._model.__name__}' has no field '{children_field}'. "
+                    f"Check the '_children' mapping on '{diffsync_model.__class__.__name__}'."
+                )
+            if not hasattr(database_object, children_field):  # covers OneToOneField with no related object
                 continue
             _children = getattr(database_object, children_field)
             children = _children.all() if hasattr(_children, "all") else [_children]

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -157,7 +157,10 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
     def _handle_children(self, database_object, diffsync_model: BaseNautobotModel):
         """Recurse through all the children for this model."""
         for children_parameter, children_field in diffsync_model._children.items():
-            children = getattr(database_object, children_field).all()
+            if not hasattr(database_object, children_field):  # covers OneToOneField
+                continue
+            _children = getattr(database_object, children_field)
+            children = _children.all() if hasattr(_children, "all") else [_children]
             diffsync_model_child: BaseNautobotModel = self._get_diffsync_class(model_name=children_parameter)
             for child in children:
                 parameter_names = diffsync_model_child.get_synced_attributes()

--- a/nautobot_ssot/tests/contrib_base_classes.py
+++ b/nautobot_ssot/tests/contrib_base_classes.py
@@ -116,6 +116,31 @@ class NautobotTenantGroup(NautobotModel):
     tenants: List[NautobotTenant] = []
 
 
+class NautobotDeviceBay(NautobotModel):
+    """A Device may model for testing the `NautobotModel` base class."""
+
+    _model = dcim_models.DeviceBay
+    _modelname = "device_bay"
+    _identifiers = ("name", "device__name")
+    _attributes = ("installed_device__name",)
+
+    name: str
+    device__name: str
+    installed_device__name: str
+
+
+class NautobotDeviceWithChildBay(NautobotModel):
+    """A Device model with child OneToOne for testing the `NautobotModel` base class."""
+
+    _model = dcim_models.Device
+    _modelname = "device"
+    _identifiers = ("name",)
+    _children = {"device_bay": "parent_bay"}
+
+    name: str
+    parent_bay: List[NautobotDeviceBay] = []
+
+
 class ContentTypeDict(TypedDict):
     """Many-to-many relationship typed dict explaining which fields are interesting."""
 

--- a/nautobot_ssot/tests/contrib_base_classes.py
+++ b/nautobot_ssot/tests/contrib_base_classes.py
@@ -141,6 +141,18 @@ class NautobotDeviceWithChildBay(NautobotModel):
     parent_bay: List[NautobotDeviceBay] = []
 
 
+class NautobotDeviceInvalidChildAttr(NautobotModel):
+    """A Device model with invalid child attribute."""
+
+    _model = dcim_models.Device
+    _modelname = "device"
+    _identifiers = ("name",)
+    _children = {"device_bay": "invalid_attr"}
+
+    name: str
+    invalid_attr: List[NautobotDeviceBay] = []
+
+
 class ContentTypeDict(TypedDict):
     """Many-to-many relationship typed dict explaining which fields are interesting."""
 

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -22,6 +22,8 @@ from nautobot_ssot.contrib import CustomFieldAnnotation, NautobotAdapter, Nautob
 from nautobot_ssot.tests.contrib_base_classes import (
     NautobotCable,
     NautobotDevice,
+    NautobotDeviceBay,
+    NautobotDeviceWithChildBay,
     NautobotTenant,
     NautobotTenantGroup,
     ProviderModelCustomRelationship,
@@ -56,6 +58,25 @@ class NautobotAdapterOneToOneRelationTests(TestCaseWithDeviceData):
 
         self.assertEqual(self.ip_address_1.host, diffsync_device.primary_ip4__host)
         self.assertEqual(self.ip_address_1.mask_length, diffsync_device.primary_ip4__mask_length)
+
+    def test_one_to_one_relationship_children(self):
+        """Test that loading a one-to-one relationship works in children."""
+
+        class Adapter(NautobotAdapter):
+            """Adapter for loading one-to-one relationship fields on a device children."""
+
+            top_level = ("device",)
+            device = NautobotDeviceWithChildBay
+            device_bay = NautobotDeviceBay
+
+        device = dcim_models.Device.objects.first()
+        parent_device = dcim_models.Device.objects.last()
+        dcim_models.DeviceBay.objects.create(name="Slot0", device=parent_device, installed_device=device)
+
+        adapter = Adapter(job=MagicMock())
+        adapter.load()
+        diffsync_device = adapter.get(NautobotDeviceWithChildBay, {"name": device.name})
+        self.assertTrue(device.parent_bay.name in diffsync_device.parent_bay[0])
 
 
 class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):

--- a/nautobot_ssot/tests/test_contrib_adapter.py
+++ b/nautobot_ssot/tests/test_contrib_adapter.py
@@ -23,6 +23,7 @@ from nautobot_ssot.tests.contrib_base_classes import (
     NautobotCable,
     NautobotDevice,
     NautobotDeviceBay,
+    NautobotDeviceInvalidChildAttr,
     NautobotDeviceWithChildBay,
     NautobotTenant,
     NautobotTenantGroup,
@@ -77,6 +78,20 @@ class NautobotAdapterOneToOneRelationTests(TestCaseWithDeviceData):
         adapter.load()
         diffsync_device = adapter.get(NautobotDeviceWithChildBay, {"name": device.name})
         self.assertTrue(device.parent_bay.name in diffsync_device.parent_bay[0])
+
+    def test_invalid_children_attr_raises(self):
+        """Test that invalid attribute name in _children raises AttributeError."""
+
+        class Adapter(NautobotAdapter):
+            """Adapter with invalid children field."""
+
+            top_level = ("device",)
+            device = NautobotDeviceInvalidChildAttr
+            device_bay = NautobotDeviceBay
+
+        adapter = Adapter(job=MagicMock())
+        with self.assertRaises(AttributeError):
+            adapter.load()
 
 
 class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):


### PR DESCRIPTION
## What's Changed

In my use-case I have a custom model which is `OneToOneField` related to the `Device`.
When this custom model is referenced in a DiffSycModel `_children` then it raises `AttributeError`  `object has no attribute 'all'` as `_handle_children` only expects reverse FK as M2M manager with `.all()`.

This fixes the issue described above and allows to use `OneToOneField` under `_children`.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
