### PR TITLE
Catch MultipleObjectsReturned in vSphere sync_complete primary IP assignment

### DIFF
--- a/changes/1250.fixed
+++ b/changes/1250.fixed
@@ -1,0 +1,1 @@
+Fixed vSphere SSoT sync crash when more than one `IPAddress` shares the primary IP host, by catching `MultipleObjectsReturned` during primary IP assignment.

--- a/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/vsphere/diffsync/adapters/adapter_nautobot.py
@@ -60,6 +60,10 @@ class NBAdapter(NautobotAdapter):
                         setattr(vm, ip, IPAddress.objects.get(host=info[ip]))
                     except IPAddress.DoesNotExist:
                         self.job.logger.warning(f"IPAddress {info[ip]} not found for {vm}, skipping {ip} assignment.")
+                    except IPAddress.MultipleObjectsReturned:
+                        self.job.logger.warning(
+                            f"Multiple IPAddresses found for host {info[ip]} on {vm}, skipping {ip} assignment."
+                        )
             try:
                 vm.validated_save()
             except ValidationError as err:


### PR DESCRIPTION
# Closes: #1250

## What's Changed

`NBAdapter.sync_complete()` in the vSphere integration assigns each VM's primary IP via `IPAddress.objects.get(host=info[ip])`. That lookup only caught `IPAddress.DoesNotExist`, so when more than one `IPAddress` shares the primary IP's host value (the same host present across multiple namespaces, or a NIC with multiple addresses), `get()` raised an uncaught `IPAddress.MultipleObjectsReturned` that propagated out of `sync_complete` and aborted the entire sync job.

This adds a `MultipleObjectsReturned` handler alongside the existing `DoesNotExist` one — log a warning and skip that primary IP assignment — matching the graceful-skip behavior already used for the missing-IP and missing-VM cases (the latter added in #1177).

**Reproduction** (core ORM behavior, Nautobot 3.1, scrubbed RFC5737 IPs):

```
# two IPAddresses sharing host 192.0.2.50 across two namespaces
IPAddress.objects.filter(host="192.0.2.50").count()   # -> 2
IPAddress.objects.get(host="192.0.2.50")              # -> MultipleObjectsReturned: returned 2!
```

Before: uncaught, sync aborts. After: caught, warning logged, sync continues.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1250.fixed`)
- [ ] Attached Screenshots, Payload Example — N/A (log-only behavior change)
- [ ] Unit, Integration Tests — `sync_complete` has no existing unit coverage; happy to add if maintainers want it
- [x] Outline Remaining Work, Constraints from Design
