### PR TITLE
Make Arista CloudVision NautobotIPAddress.create idempotent (existing IP no longer aborts sync)

### DIFF
--- a/changes/1261.fixed
+++ b/changes/1261.fixed
@@ -1,0 +1,1 @@
+Fixed Arista CloudVision SSoT sync aborting when CloudVision reports an `IPAddress` that already exists in Nautobot, by making `NautobotIPAddress.create()` idempotent with `get_or_create`.

--- a/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/models/nautobot.py
@@ -266,14 +266,13 @@ class NautobotIPAddress(IPAddress):
     @classmethod
     def create(cls, adapter, ids, attrs):
         """Create IPAddress in Nautobot."""
-        new_ip = OrmIPAddress(
+        OrmIPAddress.objects.get_or_create(
             address=ids["address"],
             parent=OrmPrefix.objects.get(
                 prefix=ids["prefix"], namespace=OrmNamespace.objects.get(name=ids["namespace"])
             ),
-            status=OrmStatus.objects.get(name="Active"),
+            defaults={"status": OrmStatus.objects.get(name="Active")},
         )
-        new_ip.validated_save()
         return super().create(ids=ids, adapter=adapter, attrs=attrs)
 
     def delete(self):


### PR DESCRIPTION
# Closes: #1261

## What's Changed

`NautobotIPAddress.create()` in the Arista CloudVision integration unconditionally instantiated a new `IPAddress` and called `validated_save()`. When CloudVision reported an address that already existed in Nautobot under the same parent, the uniqueness `ValidationError` ("IP address with this Parent and Host already exists") propagated uncaught and aborted the entire sync — the integration was not idempotent against pre-existing IPAM data.

This makes the create path idempotent with `get_or_create` (matching the codebase idiom — Citrix ADM uses `get_or_create`, and the sibling `NautobotIPAssignment.create()` already fetches existing objects). Same bug class as #940 (Citrix ADM).

**Reproduction** (core ORM, Nautobot 3.1, scrubbed RFC5737 IPs):

```
# pre-existing IPAddress 192.0.2.10/24, then the old create() path:
IPAddress(address="192.0.2.10/24", parent=..., status=Active).validated_save()
#   -> ValidationError: ['IP address with this Parent and Host already exists.']  (sync aborts)

# with the fix:
IPAddress.objects.get_or_create(address="192.0.2.10/24", parent=..., defaults={"status": Active})
#   existing -> created=False, reuses the existing row (no crash)
#   new IP   -> created=True (happy path unchanged)
```

## Possible follow-up (out of scope here)

On match, this reuses the existing `IPAddress` as-is rather than reconciling its attributes (e.g. status) to the CloudVision-reported values. Whether the source should overwrite existing Nautobot data is a precedence decision for maintainers — and these objects reach `create()` rather than `update()`, so they may not be on the attribute-reconciliation path. Flagged in #1261; intentionally not addressed here to keep the crash fix minimal.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1261.fixed`)
- [ ] Attached Screenshots, Payload Example — N/A (behavior change in create path)
- [ ] Unit, Integration Tests — `NautobotIPAddress.create()` has no existing unit coverage; happy to add if maintainers want it
- [x] Outline Remaining Work, Constraints from Design
