### PR TITLE
Only assign Meraki management IP from an Active uplink (fixes missing primary IP)

### DIFF
--- a/changes/1205.fixed
+++ b/changes/1205.fixed
@@ -1,0 +1,1 @@
+Fixed Meraki SSoT assigning the management/primary IP from a Not-Active uplink: an inactive static uplink no longer sets `mgmt_ip`, so it cannot shadow an Active uplink or suppress the DHCP management-IP fallback.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -230,12 +230,12 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                             location=self.resolve_location_name(network_id),
                         )
                         if port_uplink_settings["pppoe"]["enabled"]:
-                            mgmt_ip = port_svis["address"]
                             host_addr = port_svis["address"]
                             mask_length = "32"
                         else:
+                            host_addr, mask_length = port_svis["address"].split("/")
+                        if uplink_status == "Active":
                             mgmt_ip = port_svis["address"]
-                            host_addr, mask_length = mgmt_ip.split("/")
                         self.load_ipaddress(
                             host_addr=host_addr,
                             mask_length=mask_length,


### PR DESCRIPTION
# Closes: #1205

## What's Changed

In `load_firewall_ports`, a static uplink set `mgmt_ip = port_svis["address"]` regardless of its operational status. Because `mgmt_ip` both (a) gates the DHCP management-IP fallback (`if not mgmt_ip and meraki_allow_dhcp_mgmt_ips:`) and (b) is the "last-writer-wins" management address, a **Not-Active** uplink could shadow an Active one or suppress the fallback entirely.

Concretely, with a Not-Active static uplink + an Active dynamic/DHCP uplink: the inactive uplink set `mgmt_ip`, so the DHCP fallback was skipped and the Active uplink never received a primary IP — the device ended up with **no primary IP**.

This decouples the per-uplink address (`host_addr`, still loaded for every uplink as before) from `mgmt_ip`, and only sets `mgmt_ip` when `uplink_status == "Active"`. The `primary=` flag on `load_ipassignment` was already gated on Active and is unchanged.

**Reproduction** (control-flow of the method's mgmt_ip/uplink_status logic; Not-Active static `192.0.2.10/24` + Active DHCP uplink):

```
CURRENT:  inactive static sets mgmt_ip -> DHCP fallback skipped -> PRIMARY IP: none   (bug)
FIXED:    inactive static loads its IP (non-primary), mgmt_ip stays unset ->
          DHCP fallback runs -> PRIMARY IP: the Active uplink's address
```

The inactive uplink's own IP still loads (as non-primary) — no regression.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1205.fixed`)
- [ ] Attached Screenshots, Payload Example — N/A
- [ ] Unit, Integration Tests — `load_firewall_ports` is Meraki-API-coupled with no existing unit coverage for this path; verified here via control-flow reproduction. Happy to add an integration test with the maintainers' Meraki fixtures if wanted.
- [x] Outline Remaining Work, Constraints from Design
