### PR TITLE
Look up Cisco Meraki Platform by exact name in signals (fixes MultipleObjectsReturned on startup)

### DIFF
--- a/changes/1159.fixed
+++ b/changes/1159.fixed
@@ -1,0 +1,1 @@
+Fixed Meraki SSoT crashing Nautobot startup with `MultipleObjectsReturned` when more than one Platform name contains "Meraki", by looking up the canonical `Cisco Meraki` Platform by exact name instead of `name__icontains`.

--- a/nautobot_ssot/integrations/meraki/signals.py
+++ b/nautobot_ssot/integrations/meraki/signals.py
@@ -26,11 +26,10 @@ def nautobot_database_ready_callback(sender, *, apps, **kwargs):  # pylint: disa
 
     cisco_manu = Manufacturer.objects.get_or_create(name="Cisco Meraki")[0]
     plat_dict = {
-        "name": "Cisco Meraki",
         "manufacturer": cisco_manu,
         "network_driver": "cisco_meraki",
     }
-    Platform.objects.update_or_create(name__icontains="Meraki", defaults=plat_dict)
+    Platform.objects.update_or_create(name="Cisco Meraki", defaults=plat_dict)
 
     sysrecord_cf_dict = {
         "type": CustomFieldTypeChoices.TYPE_TEXT,

--- a/nautobot_ssot/tests/meraki/test_signals.py
+++ b/nautobot_ssot/tests/meraki/test_signals.py
@@ -1,0 +1,31 @@
+"""Regression tests for the Meraki SSoT post-migrate signal."""
+
+from django.apps import apps as global_apps
+from nautobot.apps.testing import TestCase
+from nautobot.dcim.models import Platform
+
+from nautobot_ssot.integrations.meraki.signals import nautobot_database_ready_callback
+
+
+class TestMerakiSignals(TestCase):
+    """Tests for the Meraki ``nautobot_database_ready_callback`` signal."""
+
+    databases = ("default", "job_logs")
+
+    def test_does_not_raise_with_multiple_meraki_platforms(self):
+        """Regression for #1159.
+
+        The callback previously looked up the canonical platform with
+        ``Platform.objects.update_or_create(name__icontains="Meraki", ...)``, which raised
+        ``Platform.MultipleObjectsReturned`` (crashing ``post_migrate``/startup) whenever more
+        than one Platform name contained "Meraki". It must now look the platform up by its exact
+        name and leave the others untouched.
+        """
+        Platform.objects.create(name="Meraki Dashboard")
+        Platform.objects.create(name="meraki-cloud-controller")
+
+        # Must not raise Platform.MultipleObjectsReturned.
+        nautobot_database_ready_callback(sender=None, apps=global_apps)
+
+        platform = Platform.objects.get(name="Cisco Meraki")
+        self.assertEqual(platform.network_driver, "cisco_meraki")


### PR DESCRIPTION
# Closes: #1159

## What's Changed

`nautobot_database_ready_callback` in the Meraki integration ensures a canonical `Cisco Meraki` Platform exists, but looked it up with `Platform.objects.update_or_create(name__icontains="Meraki", defaults=...)`. When an instance has more than one Platform whose name contains "Meraki", that `update_or_create` (which does a `.get()` under the hood) raises `Platform.MultipleObjectsReturned` from the `post_migrate` signal — crashing `nautobot-server post_upgrade` / startup.

This looks the Platform up by its exact canonical name (`name="Cisco Meraki"`) — matching the `Manufacturer.objects.get_or_create(name="Cisco Meraki")` immediately above and the `plat_dict` name — and drops the now-redundant `name` from `defaults`. The canonical platform is still created/updated; any other "Meraki"-named platforms are left untouched instead of crashing the lookup.

**Reproduction** (core ORM, Nautobot 3.1):

```
# 3 platforms whose name contains "Meraki"
Platform.objects.update_or_create(name__icontains="Meraki", defaults={...})
#   -> MultipleObjectsReturned: get() returned more than one Platform -- it returned 3!  (startup crash)

Platform.objects.update_or_create(name="Cisco Meraki", defaults={...})
#   -> created=False, updates the canonical "Cisco Meraki" platform, ignores the others. No crash.
```

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/1159.fixed`)
- [ ] Attached Screenshots, Payload Example — N/A
 - [x] Unit, Integration Tests — added regression test `nautobot_ssot/tests/meraki/test_signals.py` asserting the callback no longer raises `MultipleObjectsReturned` when multiple "Meraki"-named Platforms exist.
- [x] Outline Remaining Work, Constraints from Design
