### PR TITLE
Fixed token auth for on-prem Arista CV

### DIFF
--- a/changes/1235.fixed
+++ b/changes/1235.fixed
@@ -1,0 +1,1 @@
+Fixed token authentication against on-premise Arista CloudVision portals.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -249,20 +249,25 @@ class CloudvisionApi:  # pylint: disable=too-many-instance-attributes, too-many-
         if not parsed_url.hostname:
             raise ValueError(f"Invalid URL provided for CloudVision. {config.url}")
         try:
-            if config.token and not config.is_on_premise:
+            if config.token:
                 client.connect(
                     nodes=[parsed_url.hostname],
                     username="",
                     password="",
-                    is_cvaas=True,
+                    is_cvaas=not config.is_on_premise,
                     api_token=config.token,
                 )
-            else:
+            elif config.cvp_user and config.cvp_password:
                 client.connect(
                     nodes=[parsed_url.hostname],
                     username=config.cvp_user,
                     password=config.cvp_password,
                     is_cvaas=False,
+                )
+            else:
+                raise AuthFailure(
+                    error_code="Missing Credentials",
+                    message="Unable to authenticate due to missing credentials.",
                 )
         except CvpLoginError as err:
             raise AuthFailure(

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -48,6 +48,51 @@ class TestCloudvisionApi(TestCase):
         self.assertEqual(config.url, "https://www.arista.io:443")
         self.assertEqual(config.token, "1234567890abcdef")
 
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot": {
+                "aristacv_cvp_host": "localhost",
+                "aristacv_cvp_token": "1234567890abcdef",
+                "aristacv_verify": True,
+            },
+        },
+    )
+    def test_auth_on_premise_with_token(self):
+        """Test that on-premise authentication with a token passes the token to the REST client."""
+        config = get_config()
+        self.assertTrue(config.is_on_premise)
+        with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.CvpClient") as mock_cvp:
+            cloudvision.CloudvisionApi(config)
+            _, kwargs = mock_cvp.return_value.connect.call_args
+            self.assertEqual(kwargs["api_token"], "1234567890abcdef")
+            self.assertFalse(kwargs["is_cvaas"])
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot": {
+                "aristacv_cvp_host": "localhost",
+                "aristacv_cvp_user": "admin",
+                "aristacv_cvp_password": "password",  # noqa: S106
+                "aristacv_verify": True,
+            },
+        },
+    )
+    def test_auth_on_premise_with_user_password(self):
+        """Test that on-premise authentication with user/password passes credentials to the REST client."""
+        config = get_config()
+        self.assertTrue(config.is_on_premise)
+        with (
+            patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.CvpClient") as mock_cvp,
+            patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.requests.post") as mock_post,
+        ):
+            mock_post.return_value.json.return_value = {"sessionId": "session-token"}
+            cloudvision.CloudvisionApi(config)
+            _, kwargs = mock_cvp.return_value.connect.call_args
+            self.assertEqual(kwargs["username"], "admin")
+            self.assertEqual(kwargs["password"], "password")
+            self.assertFalse(kwargs["is_cvaas"])
+            self.assertNotIn("api_token", kwargs)
+
     @override_settings(PLUGINS_CONFIG=CVAAS_PLUGIN_CONFIG)
     def test_get_version_returns_version_from_response(self):
         """get_version returns the value of the 'version' key from get_cvp_info()."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1235

## What's Changed
This PR fixes a bug that was exposed via #1197 where we were only allowing either token auth for CVaaS or username/password for on-prem. Now, we accept token auth for on-prem Arista CV.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5983