### PR TITLE
[AristaCV] Fixed parsing interface attributes across split notifications

### DIFF
--- a/changes/1245.fixed
+++ b/changes/1245.fixed
@@ -1,0 +1,1 @@
+Fixed Arista CloudVision SSoT sync failing when attributes are streamed in multiple gRPC notification frames.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -511,30 +511,33 @@ def get_interfaces_chassis(client: CloudvisionApi, dId):
     dataset = dId
     query = get_query(client, dataset, pathElts)
     queryLC = unfreeze_frozen_dict(query).keys()
-    intfStatusChassis = []
 
-    # Go through each linecard and get the state of all interfaces
+    # Group notifications by the interface name from the path elements. CloudVision may stream an
+    # interface's attributes across multiple frames, and a frame carrying state may not contain intfId, so
+    # anchoring on the path element and merging keeps those frames from being lost. Interface names
+    # are unique across linecards, so a single accumulator spans all of them.
+    per_intf = {}
     for lc in queryLC:
         pathElts = ["Sysdb", "interface", "status", "eth", "phy", "slice", lc, "intfStatus", Wildcard()]
 
         for batch in clean_query_results(pathElts, client, dataset):
             for notif in batch["notifications"]:
+                intf_name = notif["path_elements"][-1]
+                entry = per_intf.setdefault(intf_name, {"interface": intf_name})
                 results = notif["updates"]
-                if not results.get("intfId"):
-                    continue
-                new_intf = {"interface": results["intfId"]}
+                if results.get("intfId"):
+                    entry["interface"] = results["intfId"]
                 if results.get("linkStatus"):
-                    new_intf["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
+                    entry["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
                 if results.get("operStatus"):
-                    new_intf["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
+                    entry["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
                 if results.get("enabledState"):
-                    new_intf["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
+                    entry["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
                 if results.get("burnedInAddr"):
-                    new_intf["mac_addr"] = results["burnedInAddr"]
+                    entry["mac_addr"] = results["burnedInAddr"]
                 if results.get("mtu"):
-                    new_intf["mtu"] = results["mtu"]
-                intfStatusChassis.append(new_intf)
-    return intfStatusChassis
+                    entry["mtu"] = results["mtu"]
+    return list(per_intf.values())
 
 
 def get_interfaces_fixed(client: CloudvisionApi, dId: str):
@@ -546,25 +549,28 @@ def get_interfaces_fixed(client: CloudvisionApi, dId: str):
     """
     pathElts = ["Sysdb", "interface", "status", "eth", "phy", "slice", "1", "intfStatus", Wildcard()]
 
-    intfStatusFixed = []
+    # Group notifications by the wildcarded interface name from the path. CloudVision may stream an
+    # interface's attributes across multiple frames, and a frame carrying state (e.g. enabledState)
+    # may not contain intfId, so anchoring on the path element and merging keeps those frames from being lost.
+    per_intf = {}
     for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
+            intf_name = notif["path_elements"][-1]
+            entry = per_intf.setdefault(intf_name, {"interface": intf_name})
             results = notif["updates"]
-            if not results.get("intfId"):
-                continue
-            new_intf = {"interface": results["intfId"]}
+            if results.get("intfId"):
+                entry["interface"] = results["intfId"]
             if results.get("enabledState"):
-                new_intf["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
+                entry["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
             if results.get("burnedInAddr"):
-                new_intf["mac_addr"] = results["burnedInAddr"]
+                entry["mac_addr"] = results["burnedInAddr"]
             if results.get("mtu"):
-                new_intf["mtu"] = results["mtu"]
+                entry["mtu"] = results["mtu"]
             if results.get("operStatus"):
-                new_intf["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
+                entry["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
             if results.get("linkStatus"):
-                new_intf["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
-            intfStatusFixed.append(new_intf)
-    return intfStatusFixed
+                entry["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
+    return list(per_intf.values())
 
 
 def clean_query_results(path_elements: List[str], client: CloudvisionApi, dataset: str):
@@ -593,11 +599,13 @@ def get_interfaces_port_channel(client: CloudvisionApi, dId: str):
     pc_interfaces = {}
     for batch in clean_query_results(status_path, client, dId):
         for notif in batch["notifications"]:
+            # Anchor on the wildcarded interface name from the path so frames that omit intfId
+            # (CloudVision may stream a Port-Channel's attributes across multiple frames) still merge.
+            intf_id = notif["path_elements"][-1]
             results = notif["updates"]
-            intf_id = results.get("intfId")
-            if not intf_id:
-                continue
             entry = pc_interfaces.setdefault(intf_id, {"interface": intf_id})
+            if results.get("intfId"):
+                entry["interface"] = results["intfId"]
             if results.get("linkStatus"):
                 entry["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
             if results.get("operStatus"):
@@ -613,10 +621,9 @@ def get_interfaces_port_channel(client: CloudvisionApi, dId: str):
 
     for batch in clean_query_results(config_path, client, dId):
         for notif in batch["notifications"]:
+            # Anchor on the wildcarded interface name from the path so frames that omit name still merge.
+            name = notif["path_elements"][-1]
             results = notif["updates"]
-            name = results.get("name")
-            if not name:
-                continue
             entry = pc_interfaces.setdefault(name, {"interface": name})
             if results.get("mtu") and not entry.get("mtu"):
                 entry["mtu"] = results["mtu"]

--- a/nautobot_ssot/tests/aristacv/fixtures/get_interfaces_chassis_client_query.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_interfaces_chassis_client_query.json
@@ -582,7 +582,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/36"
+                ]
             }
         ]
     },
@@ -1169,7 +1180,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/49/3"
+                ]
             }
         ]
     },
@@ -1756,7 +1778,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/27"
+                ]
             }
         ]
     },
@@ -2343,7 +2376,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/40"
+                ]
             }
         ]
     },
@@ -2930,7 +2974,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/37"
+                ]
             }
         ]
     },
@@ -3517,7 +3572,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/38"
+                ]
             }
         ]
     },
@@ -4104,7 +4170,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/50/1"
+                ]
             }
         ]
     },
@@ -4691,7 +4768,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/50/2"
+                ]
             }
         ]
     },
@@ -5278,7 +5366,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/45"
+                ]
             }
         ]
     },
@@ -5865,7 +5964,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/49/4"
+                ]
             }
         ]
     },
@@ -6452,7 +6562,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/41"
+                ]
             }
         ]
     },
@@ -7039,7 +7160,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/9"
+                ]
             }
         ]
     },
@@ -7626,7 +7758,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/8"
+                ]
             }
         ]
     },
@@ -8213,7 +8356,18 @@
                         "mode200GbpsFull8Lane": false,
                         "mode400GbpsFull8Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "Linecard1",
+                    "intfStatus",
+                    "Ethernet8/26"
+                ]
             }
         ]
     }

--- a/nautobot_ssot/tests/aristacv/fixtures/get_interfaces_fixed_client_query.json
+++ b/nautobot_ssot/tests/aristacv/fixtures/get_interfaces_fixed_client_query.json
@@ -475,7 +475,18 @@
                         "modeHg53GbpsFull2Lane": false,
                         "modeHg106GbpsFull4Lane": false
                     }
-                }
+                },
+                "path_elements": [
+                    "Sysdb",
+                    "interface",
+                    "status",
+                    "eth",
+                    "phy",
+                    "slice",
+                    "1",
+                    "intfStatus",
+                    "Ethernet1/1"
+                ]
             }
         ]
     }

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -282,6 +282,7 @@ class TestCloudvisionUtils(TestCase):
 
         def make_notif(intf_id):
             return {
+                "path_elements": ["Sysdb", "interface", "status", "eth", "phy", "slice", "1", "intfStatus", intf_id],
                 "updates": {
                     "intfId": intf_id,
                     "linkStatus": {"Name": "linkUp"},
@@ -289,7 +290,7 @@ class TestCloudvisionUtils(TestCase):
                     "enabledState": {"Name": "enabled"},
                     "burnedInAddr": "ab:cd:ef:00:00:01",
                     "mtu": 1500,
-                }
+                },
             }
 
         batches = [
@@ -302,6 +303,118 @@ class TestCloudvisionUtils(TestCase):
         self.assertEqual(
             [r["interface"] for r in results],
             ["Ethernet1", "Ethernet53/1", "Ethernet53/2", "Ethernet54/1"],
+        )
+
+    def test_get_interfaces_fixed_split_notifications(self):
+        """Test get_interfaces_fixed merges frames when state arrives without intfId.
+
+        Regression: CloudVision streams an interface's attributes across multiple frames. The
+        identity frame carries intfId while a later frame carries state (enabledState/operStatus/
+        linkStatus) and omits intfId, identifying the interface only via path_elements. The previous
+        guard dropped that frame, leaving the interface without an ``enabled`` key.
+        """
+        path = ["Sysdb", "interface", "status", "eth", "phy", "slice", "1", "intfStatus", "Ethernet1"]
+        batches = [
+            {
+                "notifications": [
+                    {"path_elements": path, "updates": {"intfId": "Ethernet1", "burnedInAddr": "ab:cd:ef:00:00:01"}},
+                    {
+                        "path_elements": path,
+                        "updates": {
+                            "enabledState": {"Name": "enabled"},
+                            "operStatus": {"Name": "intfOperUp"},
+                            "linkStatus": {"Name": "linkUp"},
+                        },
+                    },
+                ]
+            }
+        ]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(return_value=batches)
+            results = cloudvision.get_interfaces_fixed(client=self.client, dId="JPE12345678")
+        self.assertEqual(
+            results,
+            [
+                {
+                    "interface": "Ethernet1",
+                    "mac_addr": "ab:cd:ef:00:00:01",
+                    "enabled": True,
+                    "oper_status": "up",
+                    "link_status": "up",
+                }
+            ],
+        )
+
+    def test_get_interfaces_chassis_split_notifications(self):
+        """Test get_interfaces_chassis merges frames when state arrives without intfId."""
+        path = ["Sysdb", "interface", "status", "eth", "phy", "slice", "Linecard1", "intfStatus", "Ethernet1"]
+        batches = [
+            {
+                "notifications": [
+                    {"path_elements": path, "updates": {"intfId": "Ethernet1", "burnedInAddr": "ab:cd:ef:00:00:01"}},
+                    {
+                        "path_elements": path,
+                        "updates": {
+                            "enabledState": {"Name": "enabled"},
+                            "operStatus": {"Name": "intfOperUp"},
+                            "linkStatus": {"Name": "linkUp"},
+                        },
+                    },
+                ]
+            }
+        ]
+        mock_get_query = MagicMock(return_value={"Linecard1": None})
+        with patch("nautobot_ssot.integrations.aristacv.utils.cloudvision.get_query", mock_get_query):
+            self.client.get = MagicMock(return_value=batches)
+            results = cloudvision.get_interfaces_chassis(client=self.client, dId="JPE12345678")
+        self.assertEqual(
+            results,
+            [
+                {
+                    "interface": "Ethernet1",
+                    "mac_addr": "ab:cd:ef:00:00:01",
+                    "enabled": True,
+                    "oper_status": "up",
+                    "link_status": "up",
+                }
+            ],
+        )
+
+    def test_get_interfaces_port_channel_split_notifications(self):
+        """Test get_interfaces_port_channel attributes a frame missing intfId via path_elements."""
+        status_path = ["Sysdb", "lag", "input", "interface", "lag", "intfStatus", "Port-Channel1000"]
+        config_path = ["Sysdb", "interface", "config", "eth", "lag", "intfConfig", "Port-Channel1000"]
+        status_batches = [
+            {
+                "notifications": [
+                    # No intfId in updates; identity comes from path_elements only.
+                    {
+                        "path_elements": status_path,
+                        "updates": {
+                            "linkStatus": {"Name": "linkUp"},
+                            "operStatus": {"Name": "intfOperUp"},
+                            "addr": "fc:bd:67:0f:6f:04",
+                            "active": True,
+                        },
+                    }
+                ]
+            }
+        ]
+        config_batches = [{"notifications": [{"path_elements": config_path, "updates": {"mtu": 9214}}]}]
+        self.client.get = MagicMock(side_effect=[status_batches, config_batches])
+        results = cloudvision.get_interfaces_port_channel(client=self.client, dId="JPE12345678")
+        self.assertEqual(
+            results,
+            [
+                {
+                    "interface": "Port-Channel1000",
+                    "link_status": "up",
+                    "oper_status": "up",
+                    "mac_addr": "fc:bd:67:0f:6f:04",
+                    "enabled": True,
+                    "mtu": 9214,
+                }
+            ],
         )
 
     def test_get_interfaces_chassis(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1245

## What's Changed
This PR changes the `get_interfaces_chassis`, `get_interfaces_fixed` and `get_interfaces_port_channel` functions on how they parse interface attributes to match how we parse other objects when using path wildcards. Instead of assuming a name is always present in the attributes for all notifications, it now uses the wildcard element of the gRPC path elements as the key and collates the attributes across notifications before returning them.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-6027