### PR TITLE
Release v3.12.5 - 2026-06-17

### DIFF
--- a/changes/1259.added
+++ b/changes/1259.added
@@ -1,1 +1,0 @@
-Added `skip_auto_component_creation` opt-in for SSoT jobs, suppressing Nautobot's automatic Device/Module component instantiation during sync via Nautobot core's `nautobot.apps.dcim.SkipAutoComponentCreation` extension point (nautobot/nautobot#9026).

--- a/docs/admin/release_notes/version_3.12.md
+++ b/docs/admin/release_notes/version_3.12.md
@@ -10,6 +10,12 @@ This document describes all new features and changes in the release. The format 
 <!-- towncrier release notes start -->
 
 
+## [v3.12.5 (2026-06-17)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.12.5)
+
+### Added
+
+- [#1259](https://github.com/nautobot/nautobot-app-ssot/issues/1259) - Added `skip_auto_component_creation` opt-in for SSoT jobs, suppressing Nautobot's automatic Device/Module component instantiation during sync via Nautobot core's `nautobot.apps.dcim.SkipAutoComponentCreation` extension point (nautobot/nautobot#9026).
+
 ## [v3.12.4 (2026-04-01)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.12.4)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot"
-version = "3.12.4"
+version = "3.12.5"
 description = "Nautobot Single Source of Truth"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v3.12.5 (2026-06-17)](https://github.com/nautobot/nautobot-app-ssot/releases/tag/v3.12.5)

### Added

- [#1259](https://github.com/nautobot/nautobot-app-ssot/issues/1259) - Added `skip_auto_component_creation` opt-in for SSoT jobs, suppressing Nautobot's automatic Device/Module component instantiation during sync via Nautobot core's `nautobot.apps.dcim.SkipAutoComponentCreation` extension point (nautobot/nautobot#9026).