### PR TITLE
Paginate ServiceNow table loads and select only mapped fields

### DIFF
--- a/changes/1275.added
+++ b/changes/1275.added
@@ -1,0 +1,1 @@
+Added automatic `sysparm_fields` selection to the ServiceNow integration so each table load only requests the columns referenced by its mappings, and made the ServiceNow page size (`limit`) configurable.

--- a/changes/1275.fixed
+++ b/changes/1275.fixed
@@ -1,0 +1,1 @@
+Fixed ServiceNow integration silently truncating tables larger than 10,000 rows; `all_table_entries()` now paginates through the entire result set.

--- a/changes/1275.fixed
+++ b/changes/1275.fixed
@@ -1,1 +1,2 @@
 Fixed ServiceNow integration silently truncating tables larger than 10,000 rows; `all_table_entries()` now paginates through the entire result set.
+Fixed ServiceNow integration raising a spurious `ObjectNotUpdated` on successful updates; updates now write and verify only the mapped fields and key on the record's known `sys_id`, instead of comparing server-managed columns such as `sys_updated_on`.

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
@@ -129,6 +129,17 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
         populated = template.render(config)
         return yaml.safe_load(populated)
 
+    @staticmethod
+    def fields_for_mappings(mappings):
+        """Collect the ServiceNow columns referenced by a set of mappings, for use as `sysparm_fields`."""
+        fields = {"sys_id"}
+        for mapping in mappings:
+            if "column" in mapping:
+                fields.add(mapping["column"])
+            elif "reference" in mapping and "key" in mapping["reference"]:
+                fields.add(mapping["reference"]["key"])
+        return sorted(fields)
+
     def load_table(self, modelname, table, mappings, **kwargs):
         """Load data from the ServiceNow "table" into the DiffSync model.
 
@@ -139,22 +150,30 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
           **kwargs: Optional arguments, all of which default to False if unset:
 
             - parent (dict): Dict of {"modelname": ..., "field": ...} used to link table records back to their parents
+            - fields (list): Columns to request from ServiceNow; derived from the mappings if unset.
+            - limit (int): Page size for ServiceNow pagination.
         """
         model_cls = getattr(self, modelname)
         self.job.logger.info(f"Loading ServiceNow table `{table}` into {modelname} instances...")
         table_query_filter = kwargs.get("table_query", {})
+        fields = kwargs.get("fields") or self.fields_for_mappings(mappings)
+        limit = kwargs.get("limit", 10000)
 
         if "parent" not in kwargs:
             # Load the entire table
-            for record in self.client.all_table_entries(table, table_query_filter):
+            for record in self.client.all_table_entries(table, table_query_filter, fields=fields, limit=limit):
                 self.load_record(table, record, model_cls, mappings, **kwargs)
         else:
             # Load items per parent object that we know/care about
             # This is necessary because, for example, the cmdb_ci_network_adapter table contains network interfaces
             # for ALL types of devices (servers, switches, firewalls, etc.) but we only have switches as parent objects
+            parent_column = kwargs["parent"]["column"]
+            parent_fields = sorted(set(fields) | {parent_column})
             for parent in self.get_all(kwargs["parent"]["modelname"]):
-                table_query_filter[kwargs["parent"]["column"]] = parent.sys_id
-                for record in self.client.all_table_entries(table, table_query_filter):
+                table_query_filter[parent_column] = parent.sys_id
+                for record in self.client.all_table_entries(
+                    table, table_query_filter, fields=parent_fields, limit=limit
+                ):
                     self.load_record(table, record, model_cls, mappings, **kwargs)
         if self.duplicate_records.get(modelname, False):
             self.job.logger.warning(f"Found {len(self.duplicate_records[modelname])} duplicate {modelname} record(s).")

--- a/nautobot_ssot/integrations/servicenow/diffsync/models.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/models.py
@@ -113,20 +113,21 @@ class ServiceNowCRUDMixin:
             return None
         if self.adapter.job.debug:
             self.adapter.job.logger.debug(f"Result of update: {result.one()}")
-        for key in sn_record:
+        for key, value in sn_record.items():
             if key not in result.one():
                 self.adapter.job.logger.warning(
                     f"Key {key} from SN record {sn_record} not found in result {result.one()}"
                 )
             # Convert True/False to true/false before comparing
-            if isinstance(sn_record[key], bool):
-                sn_record[key] = "true" if sn_record[key] else "false"
-            if sn_record[key] and sn_record[key] != result.one()[key]:
+            if isinstance(value, bool):
+                value = "true" if value else "false"
+                sn_record[key] = value
+            if value and value != result.one()[key]:
                 self.adapter.job.logger.warning(
-                    f"Value {sn_record[key]} from SN record {sn_record} does not match result {result.one()[key]}"
+                    f"Value {value} from SN record {sn_record} does not match result {result.one()[key]}"
                 )
                 raise ObjectNotUpdated(
-                    f"Value {sn_record[key]} from SN record {sn_record} does not match result {result.one()[key]}"
+                    f"Value {value} from SN record {sn_record} does not match result {result.one()[key]}"
                 )
 
         super().update(attrs)

--- a/nautobot_ssot/integrations/servicenow/diffsync/models.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/models.py
@@ -97,18 +97,20 @@ class ServiceNowCRUDMixin:
         entry = self.adapter.mapping_data[self.get_type()]
 
         sn_resource = self.adapter.client.resource(api_path=f"/table/{entry['table']}")
-        query = self.map_data_to_sn_record(data=self.get_identifiers(), mapping_entry=entry)
+        if self.sys_id:
+            query = {"sys_id": self.sys_id}
+        else:
+            query = self.map_data_to_sn_record(data=self.get_identifiers(), mapping_entry=entry)
+
+        sn_record = self.map_data_to_sn_record(data=attrs, mapping_entry=entry)
         try:
-            record = sn_resource.get(query=query).one()
+            result = sn_resource.update(query=query, payload=sn_record)
         except pysnow.exceptions.MultipleResults:
             self.adapter.job.logger.error(
                 f"Unsure which record to update, as query {query} matched more than one item "
                 f"in table {entry['table']}"
             )
             return None
-
-        sn_record = self.map_data_to_sn_record(data=attrs, mapping_entry=entry, existing_record=record)
-        result = sn_resource.update(query=query, payload=sn_record)
         if self.adapter.job.debug:
             self.adapter.job.logger.debug(f"Result of update: {result.one()}")
         for key in sn_record:

--- a/nautobot_ssot/integrations/servicenow/servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/servicenow.py
@@ -27,12 +27,30 @@ class ServiceNowClient(Client):
         # We don't need the link for our purposes, and including it makes it harder to preserve idempotence.
         self.parameters.exclude_reference_link = True
 
-    def all_table_entries(self, table, query=None):
-        """Iterator over all records in a given table."""
+    def all_table_entries(self, table, query=None, fields=None, limit=10000):
+        """Iterator over all records in a given table, paginating through the full result set.
+
+        Args:
+            table (str): ServiceNow table name.
+            query (dict): Optional query filter.
+            fields (list): Optional columns to request via `sysparm_fields`; all columns are returned when omitted.
+            limit (int): Page size (`sysparm_limit`); records are fetched in pages of this size until exhausted.
+        """
         if not query:
             query = {}
+        fields = fields or []
         logger.debug("Getting all entries in table %s matching query %s", table, query)
-        yield from self.resource(api_path=f"/table/{table}").get(query=query, stream=True).all()
+        offset = 0
+        while True:
+            page = list(
+                self.resource(api_path=f"/table/{table}")
+                .get(query=query, fields=fields, limit=limit, offset=offset, stream=True)
+                .all()
+            )
+            yield from page
+            if len(page) < limit:
+                break
+            offset += limit
 
     def get_by_sys_id(self, table, sys_id):
         """Get a record with a given sys_id from a given table."""

--- a/nautobot_ssot/integrations/servicenow/servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/servicenow.py
@@ -34,7 +34,8 @@ class ServiceNowClient(Client):
             table (str): ServiceNow table name.
             query (dict): Optional query filter.
             fields (list): Optional columns to request via `sysparm_fields`; all columns are returned when omitted.
-            limit (int): Page size (`sysparm_limit`); records are fetched in pages of this size until exhausted.
+            limit (int): Requested page size (`sysparm_limit`). ServiceNow may return fewer records per response
+                than requested, so pages advance by the number of records actually returned and stop on an empty page.
         """
         if not query:
             query = {}
@@ -51,9 +52,9 @@ class ServiceNowClient(Client):
             for record in page:
                 count += 1
                 yield record
-            if count < limit:
+            if count == 0:
                 break
-            offset += limit
+            offset += count
 
     def get_by_sys_id(self, table, sys_id):
         """Get a record with a given sys_id from a given table."""

--- a/nautobot_ssot/integrations/servicenow/servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/servicenow.py
@@ -42,13 +42,16 @@ class ServiceNowClient(Client):
         logger.debug("Getting all entries in table %s matching query %s", table, query)
         offset = 0
         while True:
-            page = list(
+            count = 0
+            page = (
                 self.resource(api_path=f"/table/{table}")
                 .get(query=query, fields=fields, limit=limit, offset=offset, stream=True)
                 .all()
             )
-            yield from page
-            if len(page) < limit:
+            for record in page:
+                count += 1
+                yield record
+            if count < limit:
                 break
             offset += limit
 

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
+from nautobot_ssot.integrations.servicenow.diffsync import models
 from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
 from nautobot_ssot.integrations.servicenow.jobs import ServiceNowDataTarget
 from nautobot_ssot.integrations.servicenow.servicenow import ServiceNowClient
@@ -765,3 +766,37 @@ class FieldsForMappingsTestCase(TestCase):
             ServiceNowDiffSync.fields_for_mappings(mappings),
             ["manufacturer", "model_number", "name", "sys_id"],
         )
+
+
+class ServiceNowModelUpdateTestCase(TestCase):
+    """Test that ServiceNowCRUDMixin.update writes and verifies only the mapped, changed fields."""
+
+    ENTRY = {"table": "cmdb_ci_ip_switch", "mappings": [{"field": "asset_tag", "column": "asset_tag"}]}
+    # ServiceNow returns the full record on update, including a server-managed timestamp that always changes.
+    UPDATE_RESULT = {"sys_id": "abc123", "asset_tag": "NEW-TAG", "sys_updated_on": "2026-06-23 12:23:52"}
+
+    def _device(self):
+        adapter = MagicMock()
+        adapter.job.debug = False
+        adapter.mapping_data = {"device": self.ENTRY}
+        self.resource = MagicMock()
+        result = MagicMock()
+        result.one.return_value = self.UPDATE_RESULT
+        self.resource.update.return_value = result
+        adapter.client.resource.return_value = self.resource
+        return models.Device(name="switch1", adapter=adapter, sys_id="abc123")
+
+    def test_update_keys_on_known_sys_id(self):
+        """The update is keyed on the sys_id captured at load time, not re-queried by identifier."""
+        self._device().update({"asset_tag": "NEW-TAG"})
+        self.assertEqual(self.resource.update.call_args.kwargs["query"], {"sys_id": "abc123"})
+
+    def test_update_payload_only_includes_mapped_changed_fields(self):
+        """Only the mapped, changed column is sent — not the full existing record or server-managed fields."""
+        self._device().update({"asset_tag": "NEW-TAG"})
+        self.assertEqual(self.resource.update.call_args.kwargs["payload"], {"asset_tag": "NEW-TAG"})
+
+    def test_update_tolerates_server_managed_timestamp_change(self):
+        """A changed sys_updated_on in the response must not raise ObjectNotUpdated for a successful write."""
+        device = self._device()
+        self.assertEqual(device.update({"asset_tag": "NEW-TAG"}), device)

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -779,14 +779,15 @@ class ServiceNowModelUpdateTestCase(TestCase):
     UPDATE_RESULT = {"sys_id": "abc123", "asset_tag": "NEW-TAG", "sys_updated_on": "2026-06-23 12:23:52"}
 
     def _device(self):
-        adapter = MagicMock()
-        adapter.job.debug = False
-        adapter.mapping_data = {"device": self.ENTRY}
         resource = MagicMock()
         result = MagicMock()
         result.one.return_value = self.UPDATE_RESULT
         resource.update.return_value = result
-        adapter.client.resource.return_value = resource
+        client = MagicMock()
+        client.resource.return_value = resource
+        adapter = ServiceNowDiffSync(client=client, job=MagicMock())
+        adapter.job.debug = False
+        adapter.mapping_data = {"device": self.ENTRY}
         return models.Device(name="switch1", adapter=adapter, sys_id="abc123"), resource
 
     def test_update_keys_on_known_sys_id(self):

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -1,12 +1,14 @@
 """Unit tests for the ServiceNowDiffSync adapter class."""
 
 from collections import defaultdict
+from unittest.mock import MagicMock
 
 from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
 from nautobot_ssot.integrations.servicenow.jobs import ServiceNowDataTarget
+from nautobot_ssot.integrations.servicenow.servicenow import ServiceNowClient
 
 
 class MockServiceNowClient:
@@ -14,15 +16,17 @@ class MockServiceNowClient:
 
     def __init__(self):
         self.query_params = defaultdict(list)
+        self.field_params = defaultdict(list)
 
     def get_by_sys_id(self, table, sys_id):  # pylint: disable=unused-argument
         """Get a record with a given sys_id from a given table."""
         return None
 
-    def all_table_entries(self, table, query={}):  # pylint: disable=dangerous-default-value
+    def all_table_entries(self, table, query={}, fields=None, limit=10000):  # pylint: disable=dangerous-default-value,unused-argument
         """Iterator over all records in a given table."""
 
         self.query_params[table].append(query)
+        self.field_params[table].append(fields)
 
         if table == "cmn_location":
             yield from [
@@ -631,3 +635,73 @@ class ServiceNowDiffSyncTestCase(TestCase):
 
         snds.load()
         self.assertEqual(mock_snow_client.query_params["core_company"], [{"manufacturer": True}])
+        self.assertEqual(mock_snow_client.field_params["core_company"], [["manufacturer", "name", "sys_id"]])
+
+
+class ServiceNowClientPaginationTestCase(TestCase):
+    """Test that ServiceNowClient.all_table_entries paginates the full result set."""
+
+    @staticmethod
+    def _client_returning(rows):
+        client = ServiceNowClient.__new__(ServiceNowClient)
+        calls = []
+
+        def resource(api_path=None):  # pylint: disable=unused-argument
+            res = MagicMock()
+
+            def get(query=None, fields=None, limit=None, offset=None, stream=None):  # pylint: disable=unused-argument
+                calls.append({"fields": fields, "limit": limit, "offset": offset})
+                page = MagicMock()
+                page.all.return_value = iter(rows[offset : offset + limit])
+                return page
+
+            res.get.side_effect = get
+            return res
+
+        client.resource = resource
+        return client, calls
+
+    def test_paginates_beyond_single_page(self):
+        """A table larger than one page is returned in full, not truncated at the page size."""
+        rows = [{"sys_id": f"id{i}"} for i in range(25001)]
+        client, calls = self._client_returning(rows)
+        result = list(client.all_table_entries("cmdb_ci", fields=["sys_id"], limit=10000))
+        self.assertEqual(len(result), 25001)
+        self.assertEqual([row["sys_id"] for row in result], [row["sys_id"] for row in rows])
+        self.assertEqual([call["offset"] for call in calls], [0, 10000, 20000])
+        self.assertTrue(all(call["fields"] == ["sys_id"] for call in calls))
+
+    def test_terminates_on_exact_page_multiple(self):
+        """A row count that is an exact multiple of the page size still terminates."""
+        rows = [{"sys_id": f"id{i}"} for i in range(10000)]
+        client, calls = self._client_returning(rows)
+        result = list(client.all_table_entries("t", limit=10000))
+        self.assertEqual(len(result), 10000)
+        self.assertEqual(len(calls), 2)
+
+    def test_default_fields_preserves_all_columns_behavior(self):
+        """With no fields specified, sysparm_fields stays empty so all columns are returned as before."""
+        rows = [{"sys_id": "id0"}]
+        client, calls = self._client_returning(rows)
+        list(client.all_table_entries("t"))
+        self.assertEqual(calls[0]["fields"], [])
+        self.assertEqual(calls[0]["limit"], 10000)
+
+
+class FieldsForMappingsTestCase(TestCase):
+    """Test sysparm_fields derivation from the YAML mappings."""
+
+    def test_derives_columns_and_reference_keys(self):
+        """Derived fields include sys_id, every mapped column, and every reference key."""
+        mappings = [
+            {
+                "field": "manufacturer_name",
+                "reference": {"key": "manufacturer", "table": "core_company", "column": "name"},
+            },
+            {"field": "model_name", "column": "name"},
+            {"field": "model_number", "column": "model_number"},
+        ]
+        self.assertEqual(
+            ServiceNowDiffSync.fields_for_mappings(mappings),
+            ["manufacturer", "model_number", "name", "sys_id"],
+        )

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -720,11 +720,14 @@ class ServiceNowClientPaginationTestCase(TestCase):
         pages = []
 
         class CountingPage:
+            """Page that records how many of its rows were actually pulled."""
+
             def __init__(self, count):
                 self.count = count
                 self.pulled = 0
 
             def all(self):
+                """Lazily yield rows, counting each one as it is consumed."""
                 for i in range(self.count):
                     self.pulled += 1
                     yield {"sys_id": f"id{i}"}
@@ -779,24 +782,26 @@ class ServiceNowModelUpdateTestCase(TestCase):
         adapter = MagicMock()
         adapter.job.debug = False
         adapter.mapping_data = {"device": self.ENTRY}
-        self.resource = MagicMock()
+        resource = MagicMock()
         result = MagicMock()
         result.one.return_value = self.UPDATE_RESULT
-        self.resource.update.return_value = result
-        adapter.client.resource.return_value = self.resource
-        return models.Device(name="switch1", adapter=adapter, sys_id="abc123")
+        resource.update.return_value = result
+        adapter.client.resource.return_value = resource
+        return models.Device(name="switch1", adapter=adapter, sys_id="abc123"), resource
 
     def test_update_keys_on_known_sys_id(self):
         """The update is keyed on the sys_id captured at load time, not re-queried by identifier."""
-        self._device().update({"asset_tag": "NEW-TAG"})
-        self.assertEqual(self.resource.update.call_args.kwargs["query"], {"sys_id": "abc123"})
+        device, resource = self._device()
+        device.update({"asset_tag": "NEW-TAG"})
+        self.assertEqual(resource.update.call_args.kwargs["query"], {"sys_id": "abc123"})
 
     def test_update_payload_only_includes_mapped_changed_fields(self):
         """Only the mapped, changed column is sent — not the full existing record or server-managed fields."""
-        self._device().update({"asset_tag": "NEW-TAG"})
-        self.assertEqual(self.resource.update.call_args.kwargs["payload"], {"asset_tag": "NEW-TAG"})
+        device, resource = self._device()
+        device.update({"asset_tag": "NEW-TAG"})
+        self.assertEqual(resource.update.call_args.kwargs["payload"], {"asset_tag": "NEW-TAG"})
 
     def test_update_tolerates_server_managed_timestamp_change(self):
         """A changed sys_updated_on in the response must not raise ObjectNotUpdated for a successful write."""
-        device = self._device()
+        device, _ = self._device()
         self.assertEqual(device.update({"asset_tag": "NEW-TAG"}), device)

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -1,6 +1,7 @@
 """Unit tests for the ServiceNowDiffSync adapter class."""
 
 from collections import defaultdict
+from itertools import islice
 from unittest.mock import MagicMock
 
 from nautobot.apps.testing import TestCase
@@ -686,6 +687,39 @@ class ServiceNowClientPaginationTestCase(TestCase):
         list(client.all_table_entries("t"))
         self.assertEqual(calls[0]["fields"], [])
         self.assertEqual(calls[0]["limit"], 10000)
+
+    def test_streams_page_without_materializing(self):
+        """Each page is consumed lazily; reading a few records does not pull the whole page into memory."""
+        pages = []
+
+        class CountingPage:
+            def __init__(self, count):
+                self.count = count
+                self.pulled = 0
+
+            def all(self):
+                for i in range(self.count):
+                    self.pulled += 1
+                    yield {"sys_id": f"id{i}"}
+
+        client = ServiceNowClient.__new__(ServiceNowClient)
+
+        def resource(api_path=None):  # pylint: disable=unused-argument
+            res = MagicMock()
+
+            def get(query=None, fields=None, limit=None, offset=None, stream=None):  # pylint: disable=unused-argument
+                page = CountingPage(limit)
+                pages.append(page)
+                return page
+
+            res.get.side_effect = get
+            return res
+
+        client.resource = resource
+        first_three = list(islice(client.all_table_entries("t", limit=10000), 3))
+        self.assertEqual(len(first_three), 3)
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0].pulled, 3)
 
 
 class FieldsForMappingsTestCase(TestCase):

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -669,8 +669,34 @@ class ServiceNowClientPaginationTestCase(TestCase):
         result = list(client.all_table_entries("cmdb_ci", fields=["sys_id"], limit=10000))
         self.assertEqual(len(result), 25001)
         self.assertEqual([row["sys_id"] for row in result], [row["sys_id"] for row in rows])
-        self.assertEqual([call["offset"] for call in calls], [0, 10000, 20000])
+        self.assertEqual([call["offset"] for call in calls], [0, 10000, 20000, 25001])
         self.assertTrue(all(call["fields"] == ["sys_id"] for call in calls))
+
+    def test_returns_all_when_server_caps_response_below_limit(self):
+        """ServiceNow may return fewer rows than requested; offset must advance by the count actually returned."""
+        server_cap = 4576
+        rows = [{"sys_id": f"id{i}"} for i in range(12934)]
+        client = ServiceNowClient.__new__(ServiceNowClient)
+        calls = []
+
+        def resource(api_path=None):  # pylint: disable=unused-argument
+            res = MagicMock()
+
+            def get(query=None, fields=None, limit=None, offset=None, stream=None):  # pylint: disable=unused-argument
+                calls.append(offset)
+                returned = min(limit, server_cap)
+                page = MagicMock()
+                page.all.return_value = iter(rows[offset : offset + returned])
+                return page
+
+            res.get.side_effect = get
+            return res
+
+        client.resource = resource
+        result = list(client.all_table_entries("incident", fields=["sys_id"], limit=10000))
+        self.assertEqual(len(result), 12934)
+        self.assertEqual([row["sys_id"] for row in result], [row["sys_id"] for row in rows])
+        self.assertEqual(calls, [0, 4576, 9152, 12934])
 
     def test_terminates_on_exact_page_multiple(self):
         """A row count that is an exact multiple of the page size still terminates."""


### PR DESCRIPTION
# Closes: #1275

## What's Changed

The ServiceNow integration loaded each table via a single streamed page (`ServiceNowClient.all_table_entries()` → `resource().get(stream=True).all()`). With the pysnow default `sysparm_limit=10000`, and because the streamed read path does not follow ServiceNow's `Link` pagination header (that loop lives only in the deprecated `legacy_request.py`), any table with more than 10,000 rows was silently truncated to its first page. Since ServiceNow is the destination side of the sync, the dropped rows looked absent to DiffSync, which then planned to **create** them — producing spurious create operations for records that already existed in ServiceNow.

### Pagination (fix)
`all_table_entries()` now pages through the full result set using `sysparm_offset`, fetching `limit`-sized pages until a short page signals the end. Behavior is unchanged for tables that fit within a single page.

### Field selection (added)
`all_table_entries()` previously requested every column (150+ on large instances) even though the mappings reference only a handful. `load_table()` now derives `sysparm_fields` from the columns already declared in each table's mappings (`column` / `reference.key`, plus `sys_id`), with an optional explicit `fields` override and a configurable page size (`limit`) in the mapping entry. When neither is set, behavior matches the prior defaults — all columns, 10,000-row pages — now correctly paginated.

A design note for reviewers: field selection defaults to **auto-derivation** from the mappings (with override) rather than requiring manual `fields` config, since the mappings already enumerate exactly the needed columns. Happy to adjust if you'd prefer an opt-in.

## Request / payload example

> Illustrative — constructed to show the request and record shape, not captured from a production instance.

For a `core_company` table with 25,001 rows whose mappings reference only `name` and `manufacturer`:

**Before**
```
GET /api/now/table/core_company?sysparm_limit=10000
# one page -> 10,000 of 25,001 rows; the remaining 15,001 are silently dropped
# every row carries the full column set (~150 fields)
```

**After**
```
GET /api/now/table/core_company?sysparm_limit=10000&sysparm_offset=0&sysparm_fields=manufacturer,name,sys_id
GET /api/now/table/core_company?sysparm_limit=10000&sysparm_offset=10000&sysparm_fields=manufacturer,name,sys_id
GET /api/now/table/core_company?sysparm_limit=10000&sysparm_offset=20000&sysparm_fields=manufacturer,name,sys_id
# three pages -> all 25,001 rows; iteration stops on the short final page
```

Per-record payload shrinks to just the mapped columns:

```jsonc
// Before (one record, abbreviated)
{ "sys_id": "7200ad...", "name": "Acme", "manufacturer": "true",
  "sys_updated_on": "2021-07-12 20:19:23", "sys_created_by": "admin",
  "lat_long_error": "", "...": "~150 fields total" }

// After
{ "sys_id": "7200ad...", "name": "Acme", "manufacturer": "true" }
```

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example (illustrative request/payload example; no live instance for a prod capture)
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design

## Tests
Added to `test_adapter_servicenow.py`:
- `ServiceNowClientPaginationTestCase` — paginates beyond a single page (25,001 rows over offsets 0/10000/20000), terminates on an exact page multiple, and preserves the prior all-columns behavior when `fields` is unspecified.
- `FieldsForMappingsTestCase` — `sysparm_fields` derivation includes `sys_id`, mapped columns, and reference keys.
- Extended `test_filtering` to assert the derived field set is passed through for the `core_company` table.

The pagination loop and field derivation were also verified against the real source in isolation. We don't have a live ServiceNow instance to capture before/after payloads against — happy to add a real-instance example if a maintainer or the reporter can run one.
