### PR TITLE
ServiceNow: bulk update instead of per-item update

### DIFF
--- a/changes/1277.fixed
+++ b/changes/1277.fixed
@@ -1,0 +1,1 @@
+Fixed slow performance of the ServiceNow integration when tagging synced objects by replacing per-object saves in `tag_involved_objects()` with bulk database operations.

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
@@ -167,6 +167,7 @@ class NautobotDiffSync(Adapter):
             if synced_pks:
                 self.tag_objects(nautobot_model, synced_pks, tag, custom_field, today)
 
+    # pylint: disable=too-many-arguments
     def tag_objects(self, nautobot_model, pks, tag, custom_field, today):
         """Bulk-apply the given tag and custom field to many objects of a single Nautobot model.
 

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_nautobot.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from nautobot.core.choices import ColorChoices
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, Manufacturer
 from nautobot.extras.choices import CustomFieldTypeChoices
-from nautobot.extras.models import CustomField, Tag
+from nautobot.extras.models import CustomField, Tag, TaggedItem
 
 from . import models
 
@@ -143,44 +143,61 @@ class NautobotDiffSync(Adapter):
         for model in [Device, DeviceType, Interface, Manufacturer, Location]:
             custom_field.content_types.add(ContentType.objects.get_for_model(model))
 
-        for modelname in [
-            "company",
-            "device",
-            "interface",
-            "location",
-            "product_model",
-        ]:
+        today = datetime.date.today().isoformat()
+        # Map each DiffSync model name to its corresponding Nautobot model class.
+        nautobot_models = {
+            "company": Manufacturer,
+            "device": Device,
+            "interface": Interface,
+            "location": Location,
+            "product_model": DeviceType,
+        }
+        for modelname, nautobot_model in nautobot_models.items():
+            # Collect the PKs of all objects that now have a counterpart in the target DiffSync.
+            synced_pks = []
             for local_instance in self.get_all(modelname):
                 unique_id = local_instance.get_unique_id()
-                # Verify that the object now has a counterpart in the target DiffSync
                 try:
                     target.get(modelname, unique_id)
                 except ObjectNotFound:
                     continue
+                if local_instance.pk is not None:
+                    synced_pks.append(local_instance.pk)
 
-                self.tag_object(modelname, unique_id, tag, custom_field)
+            if synced_pks:
+                self.tag_objects(nautobot_model, synced_pks, tag, custom_field, today)
 
-    def tag_object(self, modelname, unique_id, tag, custom_field):
-        """Apply the given tag and custom field to the identified object."""
-        model_instance = self.get(modelname, unique_id)
-        today = datetime.date.today().isoformat()
+    def tag_objects(self, nautobot_model, pks, tag, custom_field, today):
+        """Bulk-apply the given tag and custom field to many objects of a single Nautobot model.
 
-        def _tag_object(nautobot_object):
-            """Apply custom field and tag to object, if applicable."""
-            if hasattr(nautobot_object, "tags"):
-                nautobot_object.tags.add(tag)
-            if hasattr(nautobot_object, "cf"):
+        This deliberately uses bulk database operations rather than a per-object
+        ``validated_save()``. Re-running each model's ``clean()`` and emitting a change-log
+        entry for every object makes tagging tens of thousands of objects take hours; the bulk
+        approach reduces this to minutes, at the cost of not change-logging the tag/custom-field
+        bookkeeping update.
+        """
+        content_type = ContentType.objects.get_for_model(nautobot_model)
+
+        # Apply the Tag through the TaggedItem table, skipping objects that already carry it.
+        if hasattr(nautobot_model, "tags"):
+            already_tagged = set(
+                TaggedItem.objects.filter(tag=tag, content_type=content_type, object_id__in=pks).values_list(
+                    "object_id", flat=True
+                )
+            )
+            TaggedItem.objects.bulk_create(
+                [
+                    TaggedItem(tag=tag, content_type=content_type, object_id=pk)
+                    for pk in pks
+                    if pk not in already_tagged
+                ],
+                batch_size=1000,
+                ignore_conflicts=True,
+            )
+
+        # Stamp the "last synced" date custom field, reading and writing _custom_field_data in bulk.
+        if hasattr(nautobot_model, "cf"):
+            objects_to_update = list(nautobot_model.objects.filter(pk__in=pks))
+            for nautobot_object in objects_to_update:
                 nautobot_object.cf[custom_field.key] = today
-            nautobot_object.validated_save()
-
-        if modelname == "company":
-            _tag_object(Manufacturer.objects.get(pk=model_instance.pk))
-        elif modelname == "device":
-            _tag_object(Device.objects.get(pk=model_instance.pk))
-        elif modelname == "interface":
-            _tag_object(Interface.objects.get(pk=model_instance.pk))
-        elif modelname == "location":
-            if model_instance.pk is not None:
-                _tag_object(Location.objects.get(pk=model_instance.pk))
-        elif modelname == "product_model":
-            _tag_object(DeviceType.objects.get(pk=model_instance.pk))
+            nautobot_model.objects.bulk_update(objects_to_update, ["_custom_field_data"], batch_size=1000)

--- a/nautobot_ssot/tests/servicenow/test_adapter_nautobot.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_nautobot.py
@@ -1,8 +1,10 @@
 """Unit tests for the Nautobot DiffSync adapter."""
 
+import datetime
+
 from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
-from nautobot.extras.models import JobResult, Role, Status
+from nautobot.extras.models import JobResult, Role, Status, Tag
 
 from nautobot_ssot.integrations.servicenow.diffsync.adapter_nautobot import NautobotDiffSync
 from nautobot_ssot.integrations.servicenow.jobs import ServiceNowDataTarget
@@ -75,3 +77,34 @@ class NautobotDiffSyncTestCase(TestCase):
             ["csr1__eth1", "csr1__eth2", "csr2__eth1", "csr2__eth2"],
             sorted(intf.get_unique_id() for intf in nds.get_all("interface")),
         )
+
+    def test_tag_involved_objects(self):
+        """Test that tag_involved_objects() bulk-applies the tag and custom field to synced objects."""
+        job = self.job_class()
+        job.job_result = JobResult.objects.create(name=job.class_path, task_name="fake task", worker="default")
+        Location.objects.filter(location_type__name="Site").exclude(name__contains="Site").delete()
+
+        source = NautobotDiffSync(job=job, sync=None)
+        source.load()
+        # A second adapter loaded from the same database stands in for a target where every object
+        # was successfully synced, so the target.get() existence check succeeds for all of them.
+        target = NautobotDiffSync(job=job, sync=None)
+        target.load()
+
+        source.tag_involved_objects(target=target)
+
+        tag = Tag.objects.get(name="SSoT Synced to ServiceNow")
+        today = datetime.date.today().isoformat()
+
+        # Taggable models receive both the tag and the "last synced" custom field stamp.
+        for device in Device.objects.all():
+            self.assertIn(tag, device.tags.all())
+            self.assertEqual(device.cf["ssot_synced_to_servicenow"], today)
+
+        # Manufacturer is not taggable, but should still receive the custom field stamp.
+        manufacturer = Manufacturer.objects.get(name="Cisco")
+        self.assertEqual(manufacturer.cf["ssot_synced_to_servicenow"], today)
+
+        # Re-running must be idempotent and not create duplicate tag assignments.
+        source.tag_involved_objects(target=target)
+        self.assertEqual(Device.objects.get(name="csr1").tags.count(), 1)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1277

## What's Changed
ServiceNow tag_object() is changed to tag_objects() to perform bulk tagging.
This allows skipping creating ChangeLogs and other checks, drastically reducing the time it takes to run the ServiceNow Job

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
