### PR TITLE
Allow `_children` mappings to reference model properties, not only concrete fields

### DIFF
--- a/changes/1281.fixed
+++ b/changes/1281.fixed
@@ -1,0 +1,1 @@
+Fixed `_children` mappings that reference a model property returning a queryset or manager (such as `Device.all_interfaces`) raising `AttributeError` during load. Properties returning other types are not yet supported.

--- a/nautobot_ssot/contrib/adapter.py
+++ b/nautobot_ssot/contrib/adapter.py
@@ -176,9 +176,12 @@ class NautobotAdapter(Adapter, BaseNautobotAdapter):  # pylint: disable=too-many
         """Recurse through all the children for this model."""
         available_fields = {field.name for field in diffsync_model._model._meta.get_fields()}
         for children_parameter, children_field in diffsync_model._children.items():
-            if children_field not in available_fields:
+            # `children_field` may be a concrete field/relation (present in `_meta.get_fields()`) or a
+            # class-level attribute such as a `@property` that returns a queryset/manager or a related
+            # object. Only raise when it is neither.
+            if children_field not in available_fields and not hasattr(diffsync_model._model, children_field):
                 raise AttributeError(
-                    f"'{diffsync_model._model.__name__}' has no field '{children_field}'. "
+                    f"'{diffsync_model._model.__name__}' has no field or attribute '{children_field}'. "
                     f"Check the '_children' mapping on '{diffsync_model.__class__.__name__}'."
                 )
             if not hasattr(database_object, children_field):  # covers OneToOneField with no related object

--- a/nautobot_ssot/tests/contrib/adapter/test_adapter.py
+++ b/nautobot_ssot/tests/contrib/adapter/test_adapter.py
@@ -30,6 +30,8 @@ from nautobot_ssot.tests.contrib.base import (
     NautobotDeviceBay,
     NautobotDeviceInvalidChildAttr,
     NautobotDeviceWithChildBay,
+    NautobotDeviceWithInterfaceProperty,
+    NautobotInterface,
     NautobotTenant,
     NautobotTenantGroup,
     ProviderModelCustomRelationship,
@@ -98,6 +100,30 @@ class NautobotAdapterOneToOneRelationTests(TestCaseWithDeviceData):
         adapter = Adapter(job=MagicMock())
         with self.assertRaises(AttributeError):
             adapter.load()
+
+    def test_property_children_returns_queryset(self):
+        """Test that a `_children` mapping pointing at a property returning a queryset loads children.
+
+        Regression test: `_children` targets are not required to be concrete model fields; a
+        `@property` that returns a queryset (e.g. `Device.all_interfaces`) must also load.
+        """
+
+        class Adapter(NautobotAdapter):
+            """Adapter loading interface children from the `all_interfaces` property."""
+
+            top_level = ("device",)
+            device = NautobotDeviceWithInterfaceProperty
+            interface = NautobotInterface
+
+        device = dcim_models.Device.objects.first()
+        adapter = Adapter(job=MagicMock())
+        adapter.load()
+
+        diffsync_device = adapter.get(NautobotDeviceWithInterfaceProperty, {"name": device.name})
+        loaded_children = diffsync_device.all_interfaces
+        self.assertEqual(len(loaded_children), device.all_interfaces.count())
+        for interface_name in device.all_interfaces.values_list("name", flat=True):
+            self.assertTrue(any(interface_name in child for child in loaded_children))
 
 
 class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):

--- a/nautobot_ssot/tests/contrib/base.py
+++ b/nautobot_ssot/tests/contrib/base.py
@@ -230,6 +230,22 @@ class NautobotInterface(NautobotModel):
     ip_addresses: List[IPAddressDict] = []
 
 
+class NautobotDeviceWithInterfaceProperty(NautobotModel):
+    """A Device model whose children are sourced from a property that returns a queryset.
+
+    `Device.all_interfaces` is a `@property` (not a concrete field), exercising support for
+    property-backed `_children` mappings.
+    """
+
+    _model = dcim_models.Device
+    _modelname = "device"
+    _identifiers = ("name",)
+    _children = {"interface": "all_interfaces"}
+
+    name: str
+    all_interfaces: List[NautobotInterface] = []
+
+
 class NautobotDevice(NautobotModel):
     """Device test model."""
 


### PR DESCRIPTION
Closes: #1281

### What's Changed

The field-existence guard added to `NautobotAdapter._handle_children` in 4.5.0 rejected any `_children` target not present in `_model._meta.get_fields()`. That set only contains concrete fields and relations — it excludes `@property` attributes. As a result, `_children` mappings that point at a property (e.g. a `Device`'s `all_interfaces`, which returns `Interface.objects.filter(...)`) raised:

```
AttributeError: 'Device' has no field 'all_interfaces'.
Check the '_children' mapping on '...'.
```

This is a regression — property-backed `_children` mappings worked in 4.0–4.4, and the very next lines in `_handle_children` (`getattr(...).all()`) handle a returned queryset correctly. The guard rejected the mapping before that handling ever ran.

### Fix

Widen the guard so it accepts attributes resolvable on the model **class** in addition to concrete fields:

```python
if children_field not in available_fields and not hasattr(diffsync_model._model, children_field):
    raise AttributeError(...)
```

- Concrete fields/relations → still pass (in `available_fields`).
- Properties / descriptors → now pass (`hasattr` on the class). Checking the class returns the descriptor without invoking the getter, so there are no side effects or DB queries.
- Genuinely invalid names (typos) → still raise, preserving the misconfiguration safety the guard was added for.

The OneToOneField handling also added in 4.5.0 is untouched.

### Scope / known limitation

This restores the ability to *reference* a property in `_children`. Properties that return a **queryset or manager** (the `all_interfaces` case) load correctly. Properties returning other types (e.g. a plain list or `None`) are still unsupported and may fail in the downstream handling — that broader robustness is intentionally deferred to a follow-up.

### Before / After

**Before (4.5.0):** loading any adapter with a property-backed `_children` mapping raises `AttributeError` immediately.
**After:** the same adapter loads the property's children successfully; invalid mapping names still raise.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design