### PR TITLE
Fix for Platform = None

### DIFF
--- a/changes/916.fixed
+++ b/changes/916.fixed
@@ -1,0 +1,1 @@
+Fixed LibreNMS SSoT crashing with `AttributeError: 'NoneType' object has no attribute 'name'` during Nautobot adapter load when a synced device has no Platform assigned, by skipping such devices with a warning instead.

--- a/nautobot_ssot/integrations/librenms/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/adapters/nautobot.py
@@ -76,6 +76,11 @@ class NautobotAdapter(Adapter):
         else:
             devices = OrmDevice.objects.all()
         for nb_device in devices:
+            if nb_device.platform is None:
+                self.job.logger.warning(
+                    f"Skipping device {nb_device.name}: no Platform assigned, cannot be synced with LibreNMS."
+                )
+                continue
             if self.job.debug:
                 self.job.logger.debug(f"Nautobot Adapter Loading Nautobot Device {nb_device}")
                 self.job.logger.debug(

--- a/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
@@ -95,6 +95,36 @@ class TestNautobotAdapterTestCase(TestCase):
             print(f"Loaded device type: {type(loaded_device)}")
             self.assertIsNotNone(loaded_device, f"Device {device['sysName']} not found in the adapter.")
 
+    def test_load_devices_skips_device_without_platform(self):
+        """Test that a device with no Platform assigned is skipped instead of crashing the load."""
+        location = ORMLocation.objects.get(name=DEVICE_FIXTURE[0]["location"])
+        manufacturer, _ = Manufacturer.objects.get_or_create(name=os_manufacturer_map[DEVICE_FIXTURE[0]["os"]])
+        role, _ = Role.objects.get_or_create(name=DEVICE_FIXTURE[0]["type"])
+        status, _ = Status.objects.get_or_create(name=librenms_status_map[DEVICE_FIXTURE[0]["status"]])
+        device_type, _ = DeviceType.objects.get_or_create(model="Passive Patch Panel", manufacturer=manufacturer)
+        ORMDevice.objects.create(
+            name="passive-patch-panel-01",
+            device_type=device_type,
+            role=role,
+            location=location,
+            status=status,
+            serial="PP-0001",
+            platform=None,
+        )
+
+        self.nautobot_adapter.job.logger.warning.reset_mock()
+        self.nautobot_adapter.load_device()
+
+        loaded_devices = {device.get_unique_id() for device in self.nautobot_adapter.get_all("device")}
+        self.assertNotIn(
+            "passive-patch-panel-01",
+            loaded_devices,
+            "Device without a Platform should not have been loaded.",
+        )
+        self.nautobot_adapter.job.logger.warning.assert_called_once_with(
+            "Skipping device passive-patch-panel-01: no Platform assigned, cannot be synced with LibreNMS."
+        )
+
     def test_load_locations(self):
         """Test that locations are correctly loaded from the Nautobot ORM."""
         self.nautobot_adapter.load_location()


### PR DESCRIPTION
# Closes: #916 

## What's Changed

Included a condition to skip sync for devices that don't have a platform

## Added

- [x] Explanation of Change(s)
- [x ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x ] Unit, Integration Tests

