### PR TITLE
Fix LibreNMS sync requiring a tenant to be selected

### DIFF
--- a/changes/1290.fixed
+++ b/changes/1290.fixed
@@ -1,3 +1,2 @@
 Fixed LibreNMS sync failing with an `AttributeError` when no Tenant Filter was selected; IP addresses are now placed in the Global namespace when no tenant is set.
-Fixed LibreNMS devices and locations reporting a tenant difference on every sync that could never be resolved; the tenant is now assigned only at creation time from the optional Tenant Filter.
 Fixed the Tenant Filter being silently ignored by the Nautobot to LibreNMS job.

--- a/changes/1290.fixed
+++ b/changes/1290.fixed
@@ -1,0 +1,3 @@
+Fixed LibreNMS sync failing with an `AttributeError` when no Tenant Filter was selected; IP addresses are now placed in the Global namespace when no tenant is set.
+Fixed LibreNMS devices and locations reporting a tenant difference on every sync that could never be resolved; the tenant is now assigned only at creation time from the optional Tenant Filter.
+Fixed the Tenant Filter being silently ignored by the Nautobot to LibreNMS job.

--- a/nautobot_ssot/integrations/librenms/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/base.py
@@ -11,11 +11,10 @@ class Location(DiffSyncModel):
 
     _modelname = "location"
     _identifiers = ("name",)
-    # "tenant" is intentionally not a synced attribute; it is assigned at create
-    # time from the job's optional Tenant Filter and must not generate diffs.
     _attributes = (
         "status",
         "location_type",
+        "tenant",
         "parent",
         "latitude",
         "longitude",
@@ -40,13 +39,12 @@ class Device(DiffSyncModel):
 
     _modelname = "device"
     _identifiers = ("name",)
-    # "tenant" is intentionally not a synced attribute; it is assigned at create
-    # time from the job's optional Tenant Filter and must not generate diffs.
     _attributes = (
         "device_id",
         "location",
         "parent_location",
         "snmp_location",
+        "tenant",
         "status",
         "device_type",
         "ip_address",

--- a/nautobot_ssot/integrations/librenms/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/base.py
@@ -11,10 +11,11 @@ class Location(DiffSyncModel):
 
     _modelname = "location"
     _identifiers = ("name",)
+    # "tenant" is intentionally not a synced attribute; it is assigned at create
+    # time from the job's optional Tenant Filter and must not generate diffs.
     _attributes = (
         "status",
         "location_type",
-        "tenant",
         "parent",
         "latitude",
         "longitude",
@@ -39,12 +40,13 @@ class Device(DiffSyncModel):
 
     _modelname = "device"
     _identifiers = ("name",)
+    # "tenant" is intentionally not a synced attribute; it is assigned at create
+    # time from the job's optional Tenant Filter and must not generate diffs.
     _attributes = (
         "device_id",
         "location",
         "parent_location",
         "snmp_location",
-        "tenant",
         "status",
         "device_type",
         "ip_address",

--- a/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
@@ -27,7 +27,9 @@ from nautobot_ssot.integrations.librenms.utils import check_sor_field
 
 def ensure_ip_address(ip_address: str, ip_prefix: str, adapter: object):
     """Safely returns an IPAddress."""
-    _namespace = Namespace.objects.get_or_create(name=adapter.job.tenant.name)[0]
+    # Tenant is optional; without one, IPs live in the default Global namespace.
+    _namespace_name = adapter.job.tenant.name if adapter.job.tenant else "Global"
+    _namespace = Namespace.objects.get_or_create(name=_namespace_name)[0]
     _namespace.validated_save()
     _prefix = Prefix.objects.get_or_create(
         prefix=ip_prefix, namespace=_namespace, status=Status.objects.get(name="Active")
@@ -341,10 +343,7 @@ class NautobotDevice(Device):
             new_device.primary_ip4 = _ipaddress
             new_device.validated_save()
 
-        # Remove tenant from attrs since we've already handled it
-        attrs_copy = attrs.copy()
-        attrs_copy.pop("tenant", None)
-        return super().create(adapter=adapter, ids=ids, attrs=attrs_copy)
+        return super().create(adapter=adapter, ids=ids, attrs=attrs)
 
     def update(self, attrs):
         """Update Device in Nautobot from NautobotDevice object."""

--- a/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
@@ -343,7 +343,10 @@ class NautobotDevice(Device):
             new_device.primary_ip4 = _ipaddress
             new_device.validated_save()
 
-        return super().create(adapter=adapter, ids=ids, attrs=attrs)
+        # Remove tenant from attrs since we've already handled it
+        attrs_copy = attrs.copy()
+        attrs_copy.pop("tenant", None)
+        return super().create(adapter=adapter, ids=ids, attrs=attrs_copy)
 
     def update(self, attrs):
         """Update Device in Nautobot from NautobotDevice object."""

--- a/nautobot_ssot/integrations/librenms/jobs.py
+++ b/nautobot_ssot/integrations/librenms/jobs.py
@@ -241,7 +241,7 @@ class LibrenmsDataTarget(DataTarget):  # pylint: disable=too-many-instance-attri
 
     def load_source_adapter(self):
         """Load data from Nautobot into DiffSync models."""
-        self.source_adapter = nautobot.NautobotAdapter(job=self, sync=self.sync)
+        self.source_adapter = nautobot.NautobotAdapter(job=self, sync=self.sync, tenant=self.tenant)
         self.source_adapter.load()
 
     def load_target_adapter(self):

--- a/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_adapter.py
@@ -9,6 +9,7 @@ from nautobot.dcim.models import Device as ORMDevice
 from nautobot.dcim.models import DeviceType, LocationType, Manufacturer, Platform
 from nautobot.dcim.models import Location as ORMLocation
 from nautobot.extras.models import JobResult, Role, Status
+from nautobot.tenancy.models import Tenant
 
 from nautobot_ssot.integrations.librenms.constants import (
     librenms_status_map,
@@ -123,6 +124,54 @@ class TestNautobotAdapterTestCase(TestCase):
         )
         self.nautobot_adapter.job.logger.warning.assert_called_once_with(
             "Skipping device passive-patch-panel-01: no Platform assigned, cannot be synced with LibreNMS."
+        )
+
+    def test_load_devices_with_tenant_filter(self):
+        """Test that a tenant filter loads only that tenant's devices, with the tenant populated."""
+        tenant = Tenant.objects.create(name="Filter Tenant")
+        device = ORMDevice.objects.get(name=DEVICE_FIXTURE[0]["sysName"])
+        device.tenant = tenant
+        device.validated_save()
+
+        # A second device outside the tenant that would otherwise load fine.
+        ORMDevice.objects.create(
+            name="untenanted-device",
+            device_type=device.device_type,
+            role=device.role,
+            location=device.location,
+            status=device.status,
+            platform=device.platform,
+        )
+
+        adapter = NautobotAdapter(job=self.job, sync=None, tenant=tenant)
+        adapter.load_device()
+
+        loaded_devices = {loaded.get_unique_id() for loaded in adapter.get_all("device")}
+        self.assertEqual(loaded_devices, {device.name}, "Only devices in the selected tenant should be loaded.")
+        self.assertEqual(adapter.get("device", {"name": device.name}).tenant, "Filter Tenant")
+
+    def test_load_devices_without_tenant_filter_loads_all(self):
+        """Test that omitting the tenant filter loads devices with and without a tenant."""
+        tenant = Tenant.objects.create(name="Some Tenant")
+        device = ORMDevice.objects.get(name=DEVICE_FIXTURE[0]["sysName"])
+        tenanted_device = ORMDevice.objects.create(
+            name="tenanted-device",
+            device_type=device.device_type,
+            role=device.role,
+            location=device.location,
+            status=device.status,
+            platform=device.platform,
+            tenant=tenant,
+        )
+
+        adapter = NautobotAdapter(job=self.job, sync=None)
+        adapter.load_device()
+
+        loaded_devices = {loaded.get_unique_id() for loaded in adapter.get_all("device")}
+        self.assertEqual(
+            loaded_devices,
+            {device.name, tenanted_device.name},
+            "Without a tenant filter, all devices should be loaded.",
         )
 
     def test_load_locations(self):

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -13,7 +13,6 @@ from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import Namespace
 from nautobot.tenancy.models import Tenant
 
-from nautobot_ssot.integrations.librenms.diffsync.models.base import Device, Location
 from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice, ensure_ip_address
 from nautobot_ssot.integrations.librenms.jobs import LibrenmsDataTarget
 
@@ -196,44 +195,6 @@ class TestEnsureIPAddress(TestCase):
 
         self.assertEqual(str(ip_address.address), "198.51.100.10/24")
         self.assertEqual(ip_address.parent.namespace.name, "Acme Corp")
-
-
-class StubAdapter(Adapter):
-    """Minimal adapter for diffing the base DiffSync models."""
-
-    location = Location
-    device = Device
-
-    top_level = ["location", "device"]
-
-
-class TestTenantNotSynced(TestCase):
-    """Tenant differences must not produce diffs; tenant is assigned only at create time."""
-
-    device_kwargs = {
-        "name": "device1",
-        "location": "Site A",
-        "status": "Active",
-        "device_type": "Model X",
-        "manufacturer": "Vendor",
-        "system_of_record": "LibreNMS",
-    }
-
-    def test_device_tenant_mismatch_produces_no_diff(self):
-        """A device with a tenant in Nautobot but none in LibreNMS must not show a perpetual diff."""
-        source = StubAdapter()
-        target = StubAdapter()
-        source.add(Device(**self.device_kwargs, tenant=None))
-        target.add(Device(**self.device_kwargs, tenant="Acme Corp"))
-
-        diff = source.diff_to(target)
-
-        self.assertFalse(diff.has_diffs(), f"Tenant mismatch must not generate a diff: {diff.str()}")
-
-    def test_tenant_not_in_synced_attributes(self):
-        """Tenant must not be declared as a synced attribute on any LibreNMS DiffSync model."""
-        self.assertNotIn("tenant", Device._attributes)  # pylint: disable=protected-access
-        self.assertNotIn("tenant", Location._attributes)  # pylint: disable=protected-access
 
 
 class TestLibrenmsDataTargetTenant(TestCase):

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -1,6 +1,6 @@
-"""Unit tests for the Nautobot-side LibreNMS DiffSync models (NautobotDevice)."""
+"""Unit tests for the Nautobot-side LibreNMS DiffSync models (NautobotDevice) and helpers."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
@@ -10,8 +10,12 @@ from nautobot.dcim.models import DeviceType, LocationType, Manufacturer
 from nautobot.dcim.models import Location as ORMLocation
 from nautobot.dcim.models import Platform as ORMPlatform
 from nautobot.extras.models import Role, Status
+from nautobot.ipam.models import Namespace
+from nautobot.tenancy.models import Tenant
 
-from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice
+from nautobot_ssot.integrations.librenms.diffsync.models.base import Device, Location
+from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice, ensure_ip_address
+from nautobot_ssot.integrations.librenms.jobs import LibrenmsDataTarget
 
 
 class TestNautobotDeviceLocationSync(TestCase):
@@ -167,3 +171,92 @@ class TestNautobotDeviceUpdatePlatform(TestCase):
         self.assertIsNotNone(software_version)
         self.assertEqual(software_version.platform, self.platform)
         self.assertEqual(software_version.version, "2.0")
+
+
+class TestEnsureIPAddress(TestCase):
+    """Test that ensure_ip_address works with and without a tenant selected on the job."""
+
+    def test_no_tenant_uses_global_namespace(self):
+        """A sync without a Tenant Filter must not crash and must use the Global namespace."""
+        adapter = MagicMock()
+        adapter.job.tenant = None
+
+        ip_address = ensure_ip_address(ip_address="192.0.2.10/24", ip_prefix="192.0.2.0/24", adapter=adapter)
+
+        self.assertEqual(str(ip_address.address), "192.0.2.10/24")
+        self.assertEqual(ip_address.parent.namespace, Namespace.objects.get(name="Global"))
+
+    def test_tenant_uses_tenant_named_namespace(self):
+        """A sync with a Tenant Filter places IPs in a namespace named after the tenant."""
+        tenant = Tenant.objects.create(name="Acme Corp")
+        adapter = MagicMock()
+        adapter.job.tenant = tenant
+
+        ip_address = ensure_ip_address(ip_address="198.51.100.10/24", ip_prefix="198.51.100.0/24", adapter=adapter)
+
+        self.assertEqual(str(ip_address.address), "198.51.100.10/24")
+        self.assertEqual(ip_address.parent.namespace.name, "Acme Corp")
+
+
+class StubAdapter(Adapter):
+    """Minimal adapter for diffing the base DiffSync models."""
+
+    location = Location
+    device = Device
+
+    top_level = ["location", "device"]
+
+
+class TestTenantNotSynced(TestCase):
+    """Tenant differences must not produce diffs; tenant is assigned only at create time."""
+
+    device_kwargs = {
+        "name": "device1",
+        "location": "Site A",
+        "status": "Active",
+        "device_type": "Model X",
+        "manufacturer": "Vendor",
+        "system_of_record": "LibreNMS",
+    }
+
+    def test_device_tenant_mismatch_produces_no_diff(self):
+        """A device with a tenant in Nautobot but none in LibreNMS must not show a perpetual diff."""
+        source = StubAdapter()
+        target = StubAdapter()
+        source.add(Device(**self.device_kwargs, tenant=None))
+        target.add(Device(**self.device_kwargs, tenant="Acme Corp"))
+
+        diff = source.diff_to(target)
+
+        self.assertFalse(diff.has_diffs(), f"Tenant mismatch must not generate a diff: {diff.str()}")
+
+    def test_tenant_not_in_synced_attributes(self):
+        """Tenant must not be declared as a synced attribute on any LibreNMS DiffSync model."""
+        self.assertNotIn("tenant", Device._attributes)  # pylint: disable=protected-access
+        self.assertNotIn("tenant", Location._attributes)  # pylint: disable=protected-access
+
+
+class TestLibrenmsDataTargetTenant(TestCase):
+    """Test tenant handling in the Nautobot to LibreNMS job."""
+
+    @patch("nautobot_ssot.integrations.librenms.diffsync.adapters.nautobot.NautobotAdapter")
+    def test_load_source_adapter_passes_tenant(self, mock_adapter):
+        """The optional Tenant Filter must be passed through to the Nautobot adapter."""
+        job = LibrenmsDataTarget()
+        job.sync = None
+        job.tenant = Tenant.objects.create(name="Acme Corp")
+
+        job.load_source_adapter()
+
+        mock_adapter.assert_called_once_with(job=job, sync=None, tenant=job.tenant)
+
+    @patch("nautobot_ssot.integrations.librenms.diffsync.adapters.nautobot.NautobotAdapter")
+    def test_load_source_adapter_without_tenant(self, mock_adapter):
+        """The job must load cleanly when no tenant is selected."""
+        job = LibrenmsDataTarget()
+        job.sync = None
+        job.tenant = None
+
+        job.load_source_adapter()
+
+        mock_adapter.assert_called_once_with(job=job, sync=None, tenant=None)


### PR DESCRIPTION
# Closes: #1290

## What's Changed

The LibreNMS jobs declare the `Tenant Filter` as optional (`required=False`), but in practice a sync without a tenant failed, forcing users who don't use tenancy in Nautobot to select one anyway.

### Sync no longer crashes without a tenant
`ensure_ip_address()` named the IPAM Namespace after the tenant with no fallback (`adapter.job.tenant.name`), raising `AttributeError: 'NoneType' object has no attribute 'name'` for every device with an IP address. It now falls back to Nautobot's built-in `Global` namespace when no tenant is selected.

### Tenant Filter now works on the DataTarget job
`LibrenmsDataTarget.load_source_adapter()` never passed `tenant=self.tenant` to the `NautobotAdapter`, so the filter was silently ignored in the Nautobot → LibreNMS direction. It is now passed through.

### Out of scope
Tenant remains a synced attribute on the Device and Location DiffSync models, and existing tenant sync behavior is unchanged.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design