### PR TITLE
Fix: LibreNMS device location overwritten regardless of sync_locations setting

### DIFF
--- a/changes/1292.fixed
+++ b/changes/1292.fixed
@@ -1,0 +1,1 @@
+Fixed LibreNMS device sync overwriting a device's location on every run regardless of the sync_locations setting.

--- a/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
@@ -356,7 +356,7 @@ class NautobotDevice(Device):
             device.status = Status.objects.get_or_create(name=attrs["status"])[0]
         if "role" in attrs:
             device.role = ensure_role(role_name=attrs["role"], content_type=ORMDevice)
-        if "location" in attrs:
+        if "location" in attrs and self.adapter.job.sync_locations:
             # Get location data from the device attributes
             location_name = attrs["location"]
             parent_location_name = attrs.get("parent_location")

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Nautobot-side LibreNMS DiffSync models (NautobotDevice)."""
+
+from unittest.mock import MagicMock
+
+from diffsync import Adapter
+from django.contrib.contenttypes.models import ContentType
+from nautobot.apps.testing import TestCase
+from nautobot.dcim.models import Device as ORMDevice
+from nautobot.dcim.models import DeviceType, LocationType, Manufacturer
+from nautobot.dcim.models import Location as ORMLocation
+from nautobot.extras.models import Role, Status
+
+from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice
+
+
+class TestNautobotDeviceLocationSync(TestCase):
+    """Test that NautobotDevice.update() honors the sync_locations job flag for the location field."""
+
+    databases = ("default", "job_logs")
+
+    def setUp(self):
+        """Set up a Nautobot Device already assigned to a real Location, plus a second candidate Location."""
+        super().setUp()
+        self.active_status, _ = Status.objects.get_or_create(name="Active")
+        self.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.site_type, _ = LocationType.objects.get_or_create(name="Site")
+        self.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.chicago = ORMLocation.objects.create(
+            name="Chicago", location_type=self.site_type, status=self.active_status
+        )
+        self.catch_all = ORMLocation.objects.create(
+            name="Catch-All", location_type=self.site_type, status=self.active_status
+        )
+
+        manufacturer, _ = Manufacturer.objects.get_or_create(name="Generic")
+        device_type, _ = DeviceType.objects.get_or_create(model="Test Device Type", manufacturer=manufacturer)
+        role, _ = Role.objects.get_or_create(name="Test Role")
+        role.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.orm_device = ORMDevice.objects.create(
+            name="test-device",
+            device_type=device_type,
+            status=self.active_status,
+            role=role,
+            location=self.chicago,
+        )
+
+        self.adapter = Adapter()
+        self.adapter.job = MagicMock()
+        self.adapter.job.location_type = self.site_type
+        self.adapter.job.debug = False
+        self.adapter.tenant = None
+
+        self.diffsync_device = NautobotDevice(
+            name="test-device",
+            location="Chicago",
+            status="Active",
+            device_type="Test Device Type",
+            manufacturer="Generic",
+            system_of_record="LibreNMS",
+            uuid=self.orm_device.id,
+        )
+        self.diffsync_device.adapter = self.adapter
+
+    def test_update_does_not_overwrite_location_when_sync_locations_false(self):
+        """Reparented devices must not be moved back by a later sync when sync_locations is False."""
+        self.adapter.job.sync_locations = False
+
+        self.diffsync_device.update(attrs={"location": "Catch-All", "parent_location": None})
+
+        self.orm_device.refresh_from_db()
+        self.assertEqual(self.orm_device.location, self.chicago)
+
+    def test_update_overwrites_location_when_sync_locations_true(self):
+        """With sync_locations True, per-device location updates still apply."""
+        self.adapter.job.sync_locations = True
+
+        self.diffsync_device.update(attrs={"location": "Catch-All", "parent_location": None})
+
+        self.orm_device.refresh_from_db()
+        self.assertEqual(self.orm_device.location, self.catch_all)
+
+    def test_create_assigns_location_regardless_of_sync_locations(self):
+        """A brand-new device must still get a location even when sync_locations is False."""
+        self.adapter.job.sync_locations = False
+
+        ids = {"name": "new-device"}
+        attrs = {
+            "location": "Catch-All",
+            "parent_location": None,
+            "status": "Active",
+            "device_type": "Test Device Type",
+            "manufacturer": "Linux",
+            "platform": "linux",
+            "role": "Test Role",
+            "serial_no": "SN123",
+            "os_version": "1.0",
+            "device_id": 1,
+            "system_of_record": "LibreNMS",
+        }
+
+        NautobotDevice.create(self.adapter, ids, attrs)
+
+        new_orm_device = ORMDevice.objects.get(name="new-device")
+        self.assertEqual(new_orm_device.location, self.catch_all)

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -47,7 +47,7 @@ class TestNautobotDeviceLocationSync(TestCase):
             location=self.chicago,
         )
 
-        self.adapter = Adapter()
+        self.adapter = MagicMock(spec=Adapter)
         self.adapter.job = MagicMock()
         self.adapter.job.location_type = self.site_type
         self.adapter.job.debug = False

--- a/nautobot_ssot/tests/test_utils.py
+++ b/nautobot_ssot/tests/test_utils.py
@@ -79,6 +79,18 @@ class TestSSoTUtils(unittest.TestCase):
         result = parse_hostname_for_location(location_map=location_map, device_hostname="sw01", device_location="HQ")
         self.assertEqual(result, {"name": "Switchville", "parent": "Region 1"})
 
+    def test_parse_hostname_for_location_dict_first_match_wins(self):
+        """When multiple dict patterns match, the first one (insertion order) wins, regardless of key order."""
+        location_map = {"^sw": {"Name": "Switchville", "Parent": "Region 1"}, ".*": {"Name": "Catch-All"}}
+        result = parse_hostname_for_location(location_map=location_map, device_hostname="sw01", device_location="HQ")
+        self.assertEqual(result, {"name": "Switchville", "parent": "Region 1"})
+
+        reversed_map = {".*": {"Name": "Catch-All"}, "^sw": {"Name": "Switchville", "Parent": "Region 1"}}
+        reversed_result = parse_hostname_for_location(
+            location_map=reversed_map, device_hostname="sw01", device_location="HQ"
+        )
+        self.assertEqual(reversed_result, {"name": "Catch-All", "parent": None})
+
     def test_parse_hostname_for_role_json_string(self):
         """A JSON-string hostname_map is decoded before matching."""
         result = parse_hostname_for_role(


### PR DESCRIPTION


# Closes: #1292 

## What's Changed
     
  Fixes #1292. NautobotDevice.update() (nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py) was overwriting a device's location on every sync regardless of the job's sync_locations setting.  location/parent_location are permanent Device._attributes (diffsync/models/base.py), so they're diffed for every device on every run; update() applied the LibreNMS-computed location whenever "location" was present in the diffed attrs, with no gate at all. sync_locations only ever gated the separate top-level Location-object sync, never this per-device attribute — so disabling it didn't protect device placement the way its help text implies, and any device manually reparented in Nautobot after onboarding got silently reverted on the next sync.

##  Fix

  One-line guard in NautobotDevice.update():
  -if "location" in attrs:
  +if "location" in attrs and self.adapter.job.sync_locations:

  NautobotDevice.create() is intentionally untouched: a new device always needs some location assigned (Device.location isn't nullable), so create-time assignment must keep working regardless of sync_locations.

##  Before/After

  - Before: onboard into a catch-all Location → manually reparent to the real Location → re-run sync with
  sync_locations=False → device is silently moved back.
  - After: same steps, but the Location is left alone (the diff still shows a cosmetic location mismatch in the job's change summary, but nothing is written).

##  To Do

  - [x] Explanation of Change(s)
  - [x] Added change log fragment(s) — changes/1292.fixed
  - [x] Unit, Integration Tests — new tests in test_nautobot_model.py + test_utils.py; full suite green
  (1518 tests)
  - [x] Outline Remaining Work, Constraints from Design — none, self-contained fix