### PR TITLE
Fix bootstrap scheduled_job create/update failure

### DIFF
--- a/changes/1294.fixed
+++ b/changes/1294.fixed
@@ -1,0 +1,1 @@
+Fixed Bootstrap `ScheduledJob` create/update failing on Nautobot v3.

--- a/nautobot_ssot/integrations/bootstrap/constants.py
+++ b/nautobot_ssot/integrations/bootstrap/constants.py
@@ -116,7 +116,6 @@ SCOPED_FIELDS_MAPPING = {
         "crontab",
         "job_vars",
         "profile",
-        "approval_required",
         "enabled",
         "kwargs",
         "celery_kwargs",

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/bootstrap.py
@@ -974,7 +974,6 @@ class BootstrapAdapter(Adapter, LabelMixin):
                 crontab=crontab,
                 job_vars=job_vars,
                 profile=scheduled_job.get("profile", False),
-                approval_required=scheduled_job.get("approval_required", False),
                 task_queue=scheduled_job.get("task_queue"),
                 enabled=scheduled_job.get("enabled", True),
             )

--- a/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/adapters/nautobot.py
@@ -1175,7 +1175,6 @@ class NautobotAdapter(Adapter):
                     start_time=start_time,
                     crontab=job.crontab,
                     job_vars=job.kwargs,
-                    approval_required=job.approval_required,
                     profile=job.celery_kwargs.get("nautobot_job_profile", False),
                     task_queue=job.celery_kwargs.get("queue"),
                     enabled=job.enabled,

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/base.py
@@ -778,7 +778,6 @@ class ScheduledJob(DiffSyncModel):
         "crontab",
         "job_vars",
         "profile",
-        "approval_required",
         "task_queue",
         "enabled",
     )
@@ -792,7 +791,6 @@ class ScheduledJob(DiffSyncModel):
     crontab: str
     job_vars: dict
     profile: bool = False
-    approval_required: bool = False
     task_queue: Optional[str] = None
     enabled: Optional[bool] = True
 

--- a/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/bootstrap/diffsync/models/nautobot.py
@@ -2567,7 +2567,6 @@ class NautobotScheduledJob(ScheduledJob):
             interval=attrs.get("interval"),
             start_time=attrs.get("start_time"),
             crontab=attrs.get("crontab"),
-            approval_required=attrs.get("approval_required"),
             kwargs=job_kwargs,
             celery_kwargs=celery_kwargs,
             enabled=attrs.get("enabled"),
@@ -2614,8 +2613,6 @@ class NautobotScheduledJob(ScheduledJob):
             job.kwargs = attrs["job_vars"]
         if "profile" in attrs:
             job.celery_kwargs["nautobot_job_profile"] = attrs["profile"]
-        if "approval_required" in attrs:
-            job.approval_required = attrs["approval_required"]
         if "task_queue" in attrs:
             job.celery_kwargs["queue"] = attrs["task_queue"]
         if "enabled" in attrs:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1294 

## What's Changed

Fixed Bootstrap `ScheduledJob` create/update failing on Nautobot v3.
Removed all references to approval_required, if user data still includes it, it will be ignored.
( In Nautobot v3, ScheduledJob.approval_required became a read-only property
(derived from state); Bootstrap still assigned it until this update.)
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


