### PR TITLE
Fix LiberNMS Platform Unbound

### DIFF
--- a/changes/1153.fixed
+++ b/changes/1153.fixed
@@ -1,0 +1,1 @@
+Fixed LibreNMS device sync raising UnboundLocalError when updating a device's os_version without also updating its platform.

--- a/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
@@ -377,8 +377,8 @@ class NautobotDevice(Device):
             device.platform = _platform
         if "os_version" in attrs:
             _software_version = ensure_software_version(
-                platform=_platform,
-                manufacturer=self.manufacturer.name,
+                platform=device.platform,
+                manufacturer=self.manufacturer,
                 version=attrs["os_version"],
                 device_type=device.device_type,
             )

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -8,6 +8,7 @@ from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import Device as ORMDevice
 from nautobot.dcim.models import DeviceType, LocationType, Manufacturer
 from nautobot.dcim.models import Location as ORMLocation
+from nautobot.dcim.models import Platform as ORMPlatform
 from nautobot.extras.models import Role, Status
 
 from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice
@@ -105,3 +106,64 @@ class TestNautobotDeviceLocationSync(TestCase):
 
         new_orm_device = ORMDevice.objects.get(name="new-device")
         self.assertEqual(new_orm_device.location, self.catch_all)
+
+
+class TestNautobotDeviceUpdatePlatform(TestCase):
+    """Test that NautobotDevice.update() can update os_version without a platform change (issue #1153)."""
+
+    databases = ("default", "job_logs")
+
+    def setUp(self):
+        """Set up a Nautobot Device that already has a Platform assigned."""
+        super().setUp()
+        self.active_status, _ = Status.objects.get_or_create(name="Active")
+        self.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.site_type, _ = LocationType.objects.get_or_create(name="Site")
+        self.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.chicago = ORMLocation.objects.create(
+            name="Chicago", location_type=self.site_type, status=self.active_status
+        )
+
+        manufacturer, _ = Manufacturer.objects.get_or_create(name="Generic")
+        device_type, _ = DeviceType.objects.get_or_create(model="Test Device Type", manufacturer=manufacturer)
+        role, _ = Role.objects.get_or_create(name="Test Role")
+        role.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+        self.platform, _ = ORMPlatform.objects.get_or_create(name="linux", defaults={"manufacturer": manufacturer})
+
+        self.orm_device = ORMDevice.objects.create(
+            name="test-device",
+            device_type=device_type,
+            status=self.active_status,
+            role=role,
+            location=self.chicago,
+            platform=self.platform,
+        )
+
+        self.adapter = MagicMock(spec=Adapter)
+        self.adapter.job = MagicMock()
+        self.adapter.job.debug = False
+        self.adapter.job.sync_locations = False
+        self.adapter.tenant = None
+
+        self.diffsync_device = NautobotDevice(
+            name="test-device",
+            location="Chicago",
+            status="Active",
+            device_type="Test Device Type",
+            manufacturer="Generic",
+            system_of_record="LibreNMS",
+            uuid=self.orm_device.id,
+        )
+        self.diffsync_device.adapter = self.adapter
+
+    def test_update_os_version_without_platform_does_not_raise(self):
+        """Updating os_version alone must not raise UnboundLocalError for _platform."""
+        self.diffsync_device.update(attrs={"os_version": "2.0"})
+
+        self.orm_device.refresh_from_db()
+        software_version = self.orm_device.software_version
+        self.assertIsNotNone(software_version)
+        self.assertEqual(software_version.platform, self.platform)
+        self.assertEqual(software_version.version, "2.0")


### PR DESCRIPTION
# Closes: #1153 

## What's Changed

NautobotDevice.update() raised UnboundLocalError: cannot access local variable '_platform' where it is not associated with a value whenever LibreNMS reported an os_version change for a device without also reporting a platform change.

 _platform was only ever assigned inside the if "platform" in attrs: block, but was referenced unconditionally a few lines later inside the sibling if "os_version" in attrs: block used to build the device's SoftwareVersion. Since the two conditions aren't mutually inclusive, syncing an
  os_version-only change crashed the job.

Fixing that first exposed a second, previously-masked bug on the same line: manufacturer=self.manufacturer.name called .name on self.manufacturer, which is a plain str on the Device DiffSync model (see diffsync/models/base.py), not an ORM Manufacturer object — this would have raised
  AttributeError immediately after the first bug was fixed.

##Before/After
Before: Any device where LibreNMS syncs an OS version change without a platform change fails the whole job with: UnboundLocalError: cannot access local variable '_platform' where it is not associated with a value

After: ensure_software_version() is called with platform=device.platform (the device's current/just-updated platform) and manufacturer=self.manufacturer (the string manufacturer name, consistent with how it's used elsewhere in this method), so the update completes successfully regardless of whether platform is present in attrs.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
- [x] Outline Remaining Work, Constraints from Design
