### PR TITLE
[Meraki] Check if ip address is primary for the synced device only

### DIFF
--- a/changes/1304.fixed
+++ b/changes/1304.fixed
@@ -1,0 +1,1 @@
+[Meraki] Check if ip address is primary for the synced device only

--- a/changes/1304.fixed
+++ b/changes/1304.fixed
@@ -1,1 +1,1 @@
-[Meraki] Check if ip address is primary for the synced device only
+Fixed Meraki IP address sync incorrectly marking an address as primary when it was primary for a different device rather than the device being synced.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -258,11 +258,10 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     f"Loading IPAssignment {ipassignment.ip_address.host} on {ipassignment.interface.device.name} "
                     f"port {ipassignment.interface.name} in Namespace {ipassignment.ip_address.parent.namespace.name}"
                 )
-            primary=ipassignment.ip_address.primary_ip4_for.filter(
-                id=ipassignment.interface.device.id
-            ).exists() or ipassignment.ip_address.primary_ip6_for.filter(
-                id=ipassignment.interface.device.id
-            ).exists()
+            primary = (
+                ipassignment.ip_address.primary_ip4_for.filter(id=ipassignment.interface.device.id).exists()
+                or ipassignment.ip_address.primary_ip6_for.filter(id=ipassignment.interface.device.id).exists()
+            )
 
             new_map = self.ipassignment(
                 address=str(ipassignment.ip_address.host),

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -258,13 +258,18 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     f"Loading IPAssignment {ipassignment.ip_address.host} on {ipassignment.interface.device.name} "
                     f"port {ipassignment.interface.name} in Namespace {ipassignment.ip_address.parent.namespace.name}"
                 )
+            primary=ipassignment.ip_address.primary_ip4_for.filter(
+                id=ipassignment.interface.device.id
+            ).exists() or ipassignment.ip_address.primary_ip6_for.filter(
+                id=ipassignment.interface.device.id
+            ).exists()
+
             new_map = self.ipassignment(
                 address=str(ipassignment.ip_address.host),
                 namespace=ipassignment.ip_address.parent.namespace.name,
                 device=ipassignment.interface.device.name,
                 port=ipassignment.interface.name,
-                primary=len(ipassignment.ip_address.primary_ip4_for.all()) > 0
-                or len(ipassignment.ip_address.primary_ip6_for.all()) > 0,
+                primary=primary,
                 uuid=ipassignment.id,
             )
             if self.tenant:

--- a/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
@@ -146,3 +146,55 @@ class NautobotDiffSyncTestCase(TestCase):
             {"10.0.0.1__Lab01__Test__wan1"},
             {map.get_unique_id() for map in self.nb_adapter.get_all("ipassignment")},
         )
+
+    def test_ipassignment_primary_for_synced_device(self):
+        """Validate an IP marked primary for the synced device loads as primary."""
+        lab01 = Device.objects.get(name="Lab01")
+        lab01_mgmt_ip = IPAddress.objects.get(host="10.0.0.1")
+        lab01.primary_ip4 = lab01_mgmt_ip
+        lab01.validated_save()
+
+        self.nb_adapter.load()
+
+        assignment = self.nb_adapter.get("ipassignment", "10.0.0.1__Lab01__Test__wan1")
+        self.assertTrue(assignment.primary)
+
+    def test_ipassignment_primary_for_other_device(self):
+        """Validate an IP primary for a different device is not marked primary for the synced device."""
+        lab01_mgmt_ip = IPAddress.objects.get(host="10.0.0.1")
+        lab01 = Device.objects.get(name="Lab01")
+
+        # Assign the same IP to a second device and make it that device's primary.
+        lab02 = Device.objects.create(
+            name="Lab02",
+            serial="DEF-456-789",
+            status=self.status_active,
+            role=lab01.role,
+            device_type=lab01.device_type,
+            platform=lab01.platform,
+            location=lab01.location,
+        )
+        lab02.custom_field_data["system_of_record"] = "Meraki SSoT"
+        lab02.validated_save()
+        lab02_mgmt = Interface.objects.create(
+            name="wan1",
+            device=lab02,
+            enabled=True,
+            mode="access",
+            mgmt_only=True,
+            type="1000base-t",
+            status=self.status_active,
+        )
+        lab02_mgmt.custom_field_data["system_of_record"] = "Meraki SSoT"
+        lab02_mgmt.validated_save()
+        IPAddressToInterface.objects.create(ip_address=lab01_mgmt_ip, interface=lab02_mgmt)
+        lab02.primary_ip4 = lab01_mgmt_ip
+        lab02.validated_save()
+
+        self.nb_adapter.load()
+
+        # The IP is only primary for Lab02, so the Lab01 assignment must not be flagged primary.
+        lab01_assignment = self.nb_adapter.get("ipassignment", "10.0.0.1__Lab01__Test__wan1")
+        self.assertFalse(lab01_assignment.primary)
+        lab02_assignment = self.nb_adapter.get("ipassignment", "10.0.0.1__Lab02__Test__wan1")
+        self.assertTrue(lab02_assignment.primary)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1304

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Verify if the ip address is primary for just the device we're syncing, not whether it's primary at all

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
