### PR TITLE
Fix upstream monitor failures against Nautobot next

### DIFF
--- a/changes/1307.fixed
+++ b/changes/1307.fixed
@@ -1,0 +1,1 @@
+Fixed `NautobotModel.create`/`update` raising `FieldDoesNotExist` for generic-foreign-key-style fields that are implemented as plain Python properties rather than model fields (e.g. `Cable.termination_a`/`termination_b` on Nautobot's `next` branch).

--- a/changes/1307.housekeeping
+++ b/changes/1307.housekeeping
@@ -1,0 +1,1 @@
+Fixed nondeterministic cable termination ordering in `NautobotAdapterGenericRelationTests` that caused intermittent failures against Nautobot's `next` branch.

--- a/nautobot_ssot/contrib/model.py
+++ b/nautobot_ssot/contrib/model.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from diffsync import DiffSyncModel
 from diffsync.exceptions import ObjectCrudException, ObjectNotCreated, ObjectNotDeleted, ObjectNotUpdated
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import MultipleObjectsReturned, ValidationError
+from django.core.exceptions import FieldDoesNotExist, MultipleObjectsReturned, ValidationError
 from django.db.models import ProtectedError, QuerySet
 from nautobot.extras.choices import RelationshipTypeChoices
 from nautobot.extras.models import Relationship, RelationshipAssociation
@@ -168,10 +168,19 @@ class NautobotModel(DiffSyncModel, DiffSyncModelUtilityMixin, BaseNautobotModel)
                 )
             # Normal foreign keys
             else:
-                django_field = cls._model._meta.get_field(related_model)
+                try:
+                    # For generic foreign keys (i.e. `GenericForeignKey` fields), `related_model` is `None` here;
+                    # the concrete model class is resolved from the `<field>__app_label` / `<field>__model` values
+                    # in `_lookup_and_set_foreign_keys` instead.
+                    related_model_class = cls._model._meta.get_field(related_model).related_model
+                except FieldDoesNotExist:
+                    # Some generic foreign keys are plain Python properties rather than `GenericForeignKey` fields
+                    # (e.g. `Cable.termination_a`/`termination_b` on Nautobot's `next` branch) and thus aren't
+                    # registered in the model's `_meta` at all. Treat them the same as generic foreign keys.
+                    related_model_class = None
                 relationship_fields["foreign_keys"][related_model][lookup] = value
                 # Add a special key to the dictionary to point to the related model's class
-                relationship_fields["foreign_keys"][related_model]["_model_class"] = django_field.related_model
+                relationship_fields["foreign_keys"][related_model]["_model_class"] = related_model_class
             return
 
         # Prepare handling of custom relationship many-to-many fields.

--- a/nautobot_ssot/tests/contrib/adapter/test_adapter.py
+++ b/nautobot_ssot/tests/contrib/adapter/test_adapter.py
@@ -130,9 +130,12 @@ class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):
     """Testing the generic relation capability of the 'NautobotAdapter' class."""
 
     def setUp(self):
+        # Look the interfaces up by device name explicitly - relying on `.first()`/`.last()` of the
+        # default queryset ordering is not deterministic across Nautobot versions (Nautobot's `next`
+        # branch orders Interfaces by raw `device_id` UUID rather than by device name).
         dcim_models.Cable.objects.create(
-            termination_a=dcim_models.Interface.objects.all().filter(name="Ethernet1").first(),
-            termination_b=dcim_models.Interface.objects.all().filter(name="Ethernet1").last(),
+            termination_a=dcim_models.Interface.objects.get(name="Ethernet1", device__name="sw01"),
+            termination_b=dcim_models.Interface.objects.get(name="Ethernet1", device__name="sw02"),
             status=extras_models.Status.objects.get(name="Active"),
         )
         super().setUp()


### PR DESCRIPTION
- Make cable termination setup in NautobotAdapterGenericRelationTests deterministic by looking interfaces up by device name instead of relying on default queryset ordering (Nautobot next orders Interfaces by raw device_id UUID, making .first()/.last() nondeterministic).
- Handle FieldDoesNotExist in NautobotModel._handle_single_field for generic-foreign-key-style fields implemented as plain properties (e.g. Cable.termination_a/termination_b on Nautobot next), falling back to the existing app_label/model content-type resolution.

<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
