### PR TITLE
fix: Missed methods accounting for split notification in Arista Cloudvision SSoT

### DIFF
--- a/changes/1245.fixed
+++ b/changes/1245.fixed
@@ -1,0 +1,1 @@
+Fixed the remaining methods in Arista CloudVision SSoT sync when attributes are streamed in multiple gRPC notification frames.

--- a/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/utils/cloudvision.py
@@ -854,10 +854,10 @@ def get_all_interface_descriptions(client: CloudvisionApi, dId: str) -> dict:
     for pathElts in paths:
         for batch in clean_query_results(pathElts, client, dId):
             for notif in batch["notifications"]:
-                updates = notif["updates"]
-                intf = updates.get("intfId")
-                description = updates.get("description")
-                if intf and description:
+                # Anchor on the wildcarded interface name from the path so frames that omit name still merge.
+                intf = notif["path_elements"][-1]
+                description = notif["updates"].get("description")
+                if description:
                     descriptions[intf] = description
     return descriptions
 
@@ -877,9 +877,11 @@ def get_routed_interface_description(client: CloudvisionApi, dId: str, interface
 
     for batch in clean_query_results(pathElts, client, dId):
         for notif in batch["notifications"]:
-            updates = notif["updates"]
-            if updates.get("intfId") == interface:
-                return updates.get("description") or ""
+            # Anchor on the wildcarded interface name from the path so frames that omit name still merge.
+            if notif["path_elements"][-1] == interface:
+                description = notif["updates"].get("description")
+                if description:
+                    return description
     return ""
 
 

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Tests of CloudVision utility methods."""
 
 from unittest.mock import MagicMock, patch

--- a/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
+++ b/nautobot_ssot/tests/aristacv/test_utils_cloudvision.py
@@ -733,6 +733,77 @@ class TestCloudvisionUtils(TestCase):
             )
         self.assertEqual(results, "")
 
+    def test_get_routed_interface_description_split_notifications(self):
+        """Test get_routed_interface_description merges frames when the description omits intfId.
+
+        Regression: CloudVision streams an interface's attributes across multiple frames. The
+        identity frame carries intfId while a later frame carries the description and omits intfId,
+        identifying the interface only via path_elements. Matching on updates["intfId"] dropped that
+        frame, so the description was never returned.
+        """
+        path = ["Sysdb", "interface", "config", "loopback", "intf", "intfConfig", "Loopback0"]
+        batches = [
+            {
+                "notifications": [
+                    {"path_elements": path, "updates": {"intfId": "Loopback0", "mtu": 1500}},
+                    {"path_elements": path, "updates": {"description": "router id"}},
+                ]
+            }
+        ]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(return_value=batches)
+            results = cloudvision.get_routed_interface_description(
+                client=self.client, dId="JPE12345678", interface="Loopback0"
+            )
+        self.assertEqual(results, "router id")
+
+    def test_get_all_interface_descriptions_split_notifications(self):
+        """Test get_all_interface_descriptions merges frames when the description omits intfId.
+
+        Regression: CloudVision streams an interface's attributes across multiple frames. A frame
+        carrying the description may omit intfId, identifying the interface only via path_elements.
+        Keying on updates["intfId"] dropped that frame, so the interface's description was lost.
+        """
+        physical_batch = [
+            {
+                "notifications": [
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "eth",
+                            "phy",
+                            "slice",
+                            "1",
+                            "intfConfig",
+                            "Ethernet1",
+                        ],
+                        "updates": {"intfId": "Ethernet1", "mtu": 1500},
+                    },
+                    {
+                        "path_elements": [
+                            "Sysdb",
+                            "interface",
+                            "config",
+                            "eth",
+                            "phy",
+                            "slice",
+                            "1",
+                            "intfConfig",
+                            "Ethernet1",
+                        ],
+                        "updates": {"description": "uplink to spine"},
+                    },
+                ]
+            }
+        ]
+        non_physical_batch = [{"notifications": []}]
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", MagicMock()):
+            self.client.get = MagicMock(side_effect=[physical_batch, non_physical_batch])
+            results = cloudvision.get_all_interface_descriptions(client=self.client, dId="JPE12345678")
+        self.assertEqual(results, {"Ethernet1": "uplink to spine"})
+
     def test_get_ip_interfaces(self):
         """Test the get_ip_interfaces method."""
         mock_query = MagicMock()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1245 <ISSUE NUMBER GOES HERE>

## What's Changed
Added split notification fix to get_all_interface_descriptions and get_routed_interface_description methods
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
