### PR TITLE
NAPPS-1454 | Fix contrib Cable GFK tests for Nautobot 3.2+ (fixes Upstream Monitor)

### DIFF
--- a/changes/1309.housekeeping
+++ b/changes/1309.housekeeping
@@ -1,1 +1,1 @@
-Fixed Nautobot Upstream Monitor test failures against Nautobot 3.2, where the `Cable.termination_a`/`termination_b` GenericForeignKeys were replaced by the `terminations` relation, by skipping the contrib Cable generic-foreign-key creation tests on affected versions and making the adapter cable test's interface selection deterministic.
+Fixed Nautobot Upstream Monitor test failures against Nautobot 3.2.

--- a/changes/1309.housekeeping
+++ b/changes/1309.housekeeping
@@ -1,0 +1,1 @@
+Fixed Nautobot Upstream Monitor test failures against Nautobot 3.2, where the `Cable.termination_a`/`termination_b` GenericForeignKeys were replaced by the `terminations` relation, by skipping the contrib Cable generic-foreign-key creation tests on affected versions and making the adapter cable test's interface selection deterministic.

--- a/nautobot_ssot/tests/contrib/adapter/test_adapter.py
+++ b/nautobot_ssot/tests/contrib/adapter/test_adapter.py
@@ -130,9 +130,12 @@ class NautobotAdapterGenericRelationTests(TestCaseWithDeviceData):
     """Testing the generic relation capability of the 'NautobotAdapter' class."""
 
     def setUp(self):
+        # Select the interfaces explicitly per device — Interface's default ordering is not
+        # name-deterministic on all Nautobot versions (3.2 orders by device_id, a UUID), so
+        # `.first()`/`.last()` would assign the cable ends to arbitrary devices.
         dcim_models.Cable.objects.create(
-            termination_a=dcim_models.Interface.objects.all().filter(name="Ethernet1").first(),
-            termination_b=dcim_models.Interface.objects.all().filter(name="Ethernet1").last(),
+            termination_a=dcim_models.Interface.objects.get(device__name="sw01", name="Ethernet1"),
+            termination_b=dcim_models.Interface.objects.get(device__name="sw02", name="Ethernet1"),
             status=extras_models.Status.objects.get(name="Active"),
         )
         super().setUp()

--- a/nautobot_ssot/tests/contrib/base.py
+++ b/nautobot_ssot/tests/contrib/base.py
@@ -1,6 +1,7 @@
 """Base classes for contrib testing."""
 
 from typing import Annotated, List, Optional
+from unittest import skipIf
 from unittest.mock import MagicMock
 
 import nautobot.circuits.models as circuits_models
@@ -19,6 +20,19 @@ from nautobot_ssot.contrib import (
     NautobotAdapter,
     NautobotModel,
     RelationshipSideEnum,
+)
+
+# Nautobot 3.2 replaced the Cable.termination_a/termination_b GenericForeignKeys with a
+# `terminations` to-many relation, so contrib models expressing terminations as generic
+# foreign keys (like NautobotCable below) can no longer be created against those versions:
+# NautobotModel.create() resolves each `foo__bar` field via Cable._meta.get_field("foo"),
+# which now raises FieldDoesNotExist. Only tests relying on that reflection are gated —
+# reading such fields and direct ORM writes (Cable.objects.create(termination_a=...)) still
+# work through Nautobot's backward-compat shims.
+CABLE_HAS_TERMINATION_GFKS = any(field.name == "termination_a" for field in dcim_models.Cable._meta.get_fields())
+SKIP_IF_NO_CABLE_TERMINATION_GFKS = skipIf(
+    not CABLE_HAS_TERMINATION_GFKS,
+    "Cable.termination_a/termination_b GenericForeignKeys were removed in Nautobot 3.2",
 )
 
 

--- a/nautobot_ssot/tests/contrib/nautobot_model/test_model.py
+++ b/nautobot_ssot/tests/contrib/nautobot_model/test_model.py
@@ -30,6 +30,7 @@ from nautobot_ssot.tests.contrib.adapter.test_adapter import (
     CustomRelationShipTestAdapterSource,
 )
 from nautobot_ssot.tests.contrib.base import (
+    SKIP_IF_NO_CABLE_TERMINATION_GFKS,
     MockNautobotAdapter,
     NautobotCable,
     NautobotTenant,
@@ -116,6 +117,7 @@ class BaseModelCustomRelationshipOneToManyTest(TestCase):
 class BaseModelCustomRelationshipTestWithDeviceData(TestCaseWithDeviceData):
     """Tests for NautobotModel with custom relationships and including device data."""
 
+    @SKIP_IF_NO_CABLE_TERMINATION_GFKS
     def test_create_with_custom_relationship(self):
         """Test that NautobotModel.create works as expected with custom relationships."""
 
@@ -490,6 +492,7 @@ class BaseModelCustomRelationshipBranchTests(TestCase):
 class BaseModelGenericForeignKeyBranchTests(TestCaseWithDeviceData):
     """Cover the generic-foreign-key bad-content-type branch via a Cable model."""
 
+    @SKIP_IF_NO_CABLE_TERMINATION_GFKS
     def test_generic_foreign_key_unknown_content_type_raises(self):
         """A generic FK pointing at a non-existent content type raises ObjectNotCreated.
 


### PR DESCRIPTION
# Closes: NAPPS-1454

## What's Changed

Fixes the [Nautobot Upstream Monitor failure](https://github.com/nautobot/nautobot-app-ssot/actions/runs/29676419521) against Nautobot `next` (3.2.0b2):

```
django.core.exceptions.FieldDoesNotExist: Cable has no field named 'termination_a'
```

### Validation

- Contrib suite vs `next` image (`INVOKE_NAUTOBOT_SSOT_NAUTOBOT_VER=next`): 5 consecutive runs, `106 tests, OK (skipped=5)` — the adapter GFK load test passes deterministically (it previously failed 3 of 5 runs due to the ordering flake).
- Full suite vs `next`: 1520 tests — all Cable failures resolved; one remaining failure is unrelated (`nautobot_ssot.tests.dna_center.test_jobs.DnaCenterMultiLevelLocationJobTest.test_job_success`, DNA Center job creates 0 of 3 expected devices on 3.2; needs its own ticket).
- On Nautobot < 3.2 the probed field exists, so the flag is true and all gated tests run exactly as before (regular CI on this PR will exercise that path).
- `ruff check` / `ruff format --check` pass.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates
- [ ] Outline Remaining Work