### PR TITLE
Correct Meraki Interface Descriptions

### DIFF
--- a/changes/1306.added
+++ b/changes/1306.added
@@ -1,0 +1,1 @@
+Added Interface description synchronization for Meraki MS switchports, sourced from the Meraki switchport name.

--- a/changes/1306.fixed
+++ b/changes/1306.fixed
@@ -1,0 +1,2 @@
+Fixed blank Interface descriptions when syncing SVIs from Meraki MX/MG/Z devices by sourcing the description from the Meraki VLAN name.
+Fixed the Meraki Port model silently discarding the description attribute by adding it to the model's tracked attributes.

--- a/docs/user/integrations/meraki.md
+++ b/docs/user/integrations/meraki.md
@@ -80,6 +80,20 @@ In addition, there are two methods provided to assign Roles to your imported Dev
 
 - Finally there is an option to specify a Tenant to be assigned to the imported Devices, Prefixes, and IPAddreses. This is handy for cases where you have multiple Meraki instances that are used by differing business units.
 
+## Interface Descriptions
+
+Imported Interfaces have their `description` field populated from the closest equivalent label in Meraki, as the Meraki Dashboard API has no dedicated interface description field:
+
+| Nautobot Interface        | Meraki source                                             |
+| ------------------------- | --------------------------------------------------------- |
+| SVIs on MX/MG/Z devices   | The VLAN `name` from `getNetworkApplianceVlans`           |
+| Switchports on MS devices | The port `name` from `getOrganizationSwitchPortsBySwitch` |
+
+SVIs are only imported when the `Sync Firewall LAN SVIs` toggle is enabled. When VLANs are disabled on an MX/MG/Z device, the single LAN interface is described as `Single LAN (VLANs disabled in Meraki)`.
+
+!!! warning
+    Meraki is authoritative for the Interface `description` field. Interface types that have no corresponding label in Meraki - WAN uplinks, management interfaces, and MX LAN ports - are synchronized with an empty description, and any description entered manually in Nautobot on a Meraki-managed Interface will be overwritten on the next sync.
+
 Running this Job will redirect you to a `Nautobot Job Result` view.
 
 ![JobResult View](../../images/meraki_jobresult.png)

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -210,6 +210,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     self.port,
                     ids={"name": port, "device": device.name},
                     attrs={
+                        "description": "",
                         "management": True,
                         "enabled": port_uplink_settings["enabled"],
                         "port_type": "1000base-t",
@@ -261,6 +262,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -305,6 +307,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 self.port,
                 ids={"name": str(port["number"]), "device": device.name},
                 attrs={
+                    "description": "",
                     "management": False,
                     "enabled": port["enabled"],
                     "port_type": "1000base-t",
@@ -329,6 +332,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 mgmt_port = self.port(
                     name=port,
                     device=device.name,
+                    description="",
                     management=True,
                     enabled=True,
                     port_type="1000base-t",
@@ -372,6 +376,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -411,6 +416,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -450,6 +456,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -489,6 +496,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -528,6 +536,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -567,6 +576,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     mgmt_port = self.port(
                         name=mgmt_port_name,
                         device=device.name,
+                        description="",
                         management=True,
                         enabled=True,
                         port_type="1000base-t",
@@ -599,6 +609,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 new_port = self.port(
                     name=port["portId"],
                     device=device.name,
+                    description=port.get("name") or "",
                     management=False,
                     enabled=port["enabled"],
                     port_type="1000base-t",
@@ -620,6 +631,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 new_port = self.port(
                     name=port,
                     device=device.name,
+                    description="",
                     management=True,
                     enabled=True,
                     port_type="1000base-t",
@@ -670,6 +682,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             self.port,
             ids={"name": port["interface"], "device": device.name},
             attrs={
+                "description": "",
                 "management": True,
                 "enabled": True,
                 "port_type": "1000base-t",
@@ -785,7 +798,8 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                     "vlan_id": vlan_id,
                     "subnet": subnet,
                     "appliance_ip": appliance_ip,
-                    "description": None,
+                    # The getNetworkApplianceVlans endpoint has no description field, so use the VLAN name instead.
+                    "description": vlan.get("name") or "",
                 }
                 self.load_lan_svi_record(device=device, network_id=network_id, svi=svi)
         elif appliance_vlans_settings.get("vlansEnabled") is False:
@@ -817,19 +831,19 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
         vlan_id = svi["vlan_id"]
         subnet = svi["subnet"]
         appliance_ip = svi["appliance_ip"]
-        description = svi.get("description")
+        description = svi.get("description") or ""
 
         port_name = f"Vlan{vlan_id}"
         new_port, loaded = self.get_or_instantiate(
             self.port,
             ids={"name": port_name, "device": device.name},
             attrs={
+                "description": description,
                 "management": False,
                 "enabled": True,
                 "port_type": "virtual",
                 "port_status": "Active",
                 "tagging": False,
-                "description": description,
                 "uuid": None,
             },
         )

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -167,6 +167,7 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                 new_port = self.port(
                     name=intf.name,
                     device=intf.device.name,
+                    description=intf.description,
                     management=intf.mgmt_only,
                     enabled=intf.enabled,
                     port_type=intf.type,

--- a/nautobot_ssot/integrations/meraki/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/base.py
@@ -84,11 +84,12 @@ class Port(DiffSyncModel):
 
     _modelname = "port"
     _identifiers = ("name", "device")
-    _attributes = ("management", "enabled", "port_type", "port_status", "tagging")
+    _attributes = ("description", "management", "enabled", "port_type", "port_status", "tagging")
     _children = {}
 
     name: str
     device: str
+    description: Optional[str] = None
     management: bool
     enabled: bool
     port_type: str

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -231,6 +231,7 @@ class NautobotPort(Port):
         new_port = Interface(
             name=ids["name"],
             device_id=adapter.device_map[ids["device"]],
+            description=attrs.get("description") or "",
             enabled=attrs["enabled"],
             mode="access" if not attrs["tagging"] else "tagged",
             mgmt_only=attrs["management"],
@@ -246,6 +247,9 @@ class NautobotPort(Port):
     def update(self, attrs):
         """Update Interface in Nautobot from NautobotDevice object."""
         port = Interface.objects.get(id=self.uuid)
+        if "description" in attrs:
+            # Interface.description is non-nullable, so coerce None to "" as the Port model allows a null description.
+            port.description = attrs["description"] or ""
         if "enabled" in attrs:
             port.enabled = attrs["enabled"]
         if "tagging" in attrs:

--- a/nautobot_ssot/tests/meraki/fixtures/get_org_switchports_recv.json
+++ b/nautobot_ssot/tests/meraki/fixtures/get_org_switchports_recv.json
@@ -371,7 +371,7 @@
             },
             {
                 "portId": "25",
-                "name": "",
+                "name": "Uplink to Core",
                 "tags": [],
                 "enabled": false,
                 "poeEnabled": false,

--- a/nautobot_ssot/tests/meraki/fixtures/get_org_switchports_sent.json
+++ b/nautobot_ssot/tests/meraki/fixtures/get_org_switchports_sent.json
@@ -371,7 +371,7 @@
             },
             {
                 "portId": "25",
-                "name": "",
+                "name": "Uplink to Core",
                 "tags": [],
                 "enabled": false,
                 "poeEnabled": false,

--- a/nautobot_ssot/tests/meraki/test_adapters_meraki.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_meraki.py
@@ -367,6 +367,9 @@ class TestMerakiAdapterTestCase(TestCase):
         ports = {port.get_unique_id() for port in self.meraki.get_all("port")}
         self.assertIn("Vlan1234__HQ01", ports)
 
+        svi = self.meraki.get("port", {"name": "Vlan1234", "device": "HQ01"})
+        self.assertEqual("My VLAN", svi.description)
+
         prefixes = {pf.get_unique_id() for pf in self.meraki.get_all("prefix")}
         self.assertIn("192.168.1.0/24__Global", prefixes)
 
@@ -406,6 +409,9 @@ class TestMerakiAdapterTestCase(TestCase):
         ports = {port.get_unique_id() for port in self.meraki.get_all("port")}
         self.assertIn("Vlan1__HQ01", ports)
 
+        svi = self.meraki.get("port", {"name": "Vlan1", "device": "HQ01"})
+        self.assertEqual("Single LAN (VLANs disabled in Meraki)", svi.description)
+
         prefixes = {pf.get_unique_id() for pf in self.meraki.get_all("prefix")}
         self.assertIn("192.168.50.0/24__Global", prefixes)
 
@@ -417,6 +423,54 @@ class TestMerakiAdapterTestCase(TestCase):
             {"address": "192.168.50.2", "device": "HQ01", "namespace": "Global", "port": "Vlan1"},
         )
         self.assertFalse(ipassignment.primary)
+
+    def test_load_firewall_ports_vlan_svi_without_name(self):
+        """SVI description falls back to an empty string when the Meraki VLAN has no name."""
+        mock_device = MagicMock()
+        mock_device.name = "HQ01"
+
+        self.job.sync_firewall_lan_ips = True
+        self.meraki.device_map = {"HQ01": fix.GET_ORG_DEVICES_FIXTURE[1]}
+
+        self.meraki_client.get_appliance_vlans_settings.return_value = fix.GET_APPLIANCE_VLANS_SETTINGS_TRUE_FIXTURE
+        self.meraki_client.get_appliance_vlans.return_value = [
+            {"id": "1234", "name": None, "subnet": "192.168.1.0/24", "applianceIp": "192.168.1.2"}
+        ]
+
+        self.meraki_client.get_management_ports.return_value = {}
+        self.meraki_client.get_uplink_settings.return_value = {}
+        self.meraki_client.get_appliance_switchports.return_value = []
+
+        self.meraki.load_firewall_ports(
+            device=mock_device,
+            serial="V4GD-ABDP-YVCK",
+            network_id="L_165471703274884707",
+            lan_ip=None,
+        )
+
+        svi = self.meraki.get("port", {"name": "Vlan1234", "device": "HQ01"})
+        self.assertEqual("", svi.description)
+
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"meraki_allow_dhcp_mgmt_ips": False}})
+    def test_load_switch_ports_description_from_port_name(self):
+        """Switchport descriptions are sourced from the Meraki port name, defaulting to an empty string."""
+        mock_device = MagicMock()
+        mock_device.name = "Lab Switch"
+
+        self.meraki.device_map = {"Lab Switch": fix.GET_ORG_DEVICES_FIXTURE[2]}
+        self.meraki_client.get_management_ports.return_value = {}
+
+        self.meraki.load_switch_ports(
+            device=mock_device,
+            org_switchports=fix.GET_ORG_SWITCHPORTS_RECV_FIXTURE,
+            serial="N0BA-AWBF-DCWP",
+            lan_ip=None,
+        )
+
+        # Port 25 carries a name in the fixture, port 1 has an empty name, and port 3 has a null name.
+        self.assertEqual("Uplink to Core", self.meraki.get("port", {"name": "25", "device": "Lab Switch"}).description)
+        self.assertEqual("", self.meraki.get("port", {"name": "1", "device": "Lab Switch"}).description)
+        self.assertEqual("", self.meraki.get("port", {"name": "3", "device": "Lab Switch"}).description)
 
     @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"meraki_allow_dhcp_mgmt_ips": True}})
     def test_load_switch_with_dhcp_mgmt_ip(self):

--- a/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
@@ -99,6 +99,7 @@ class NautobotDiffSyncTestCase(TestCase):
         lab01_mgmt = Interface.objects.create(
             name="wan1",
             device=lab01,
+            description="Primary WAN uplink",
             enabled=True,
             mode="access",
             mgmt_only=True,
@@ -143,6 +144,9 @@ class NautobotDiffSyncTestCase(TestCase):
             {dev.get_unique_id() for dev in self.nb_adapter.get_all("device")},
         )
         self.assertEqual({"wan1__Lab01"}, {port.get_unique_id() for port in self.nb_adapter.get_all("port")})
+        self.assertEqual(
+            "Primary WAN uplink", self.nb_adapter.get("port", {"name": "wan1", "device": "Lab01"}).description
+        )
         self.assertEqual(
             {f"{pf.prefix}__{pf.namespace.name}" for pf in Prefix.objects.all()},
             {pf.get_unique_id() for pf in self.nb_adapter.get_all("prefix")},

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -10,6 +10,7 @@ from nautobot.apps.testing import TestCase
 from nautobot.dcim.models import (
     Device,
     DeviceType,
+    Interface,
     Location,
     LocationType,
     Manufacturer,
@@ -24,6 +25,7 @@ from nautobot.tenancy.models import Tenant
 from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import (
     NautobotIPAddress,
     NautobotOSVersion,
+    NautobotPort,
     NautobotPrefix,
 )
 
@@ -318,3 +320,118 @@ class TestNautobotOSVersion(TestCase):  # pylint: disable=too-many-instance-attr
         self.adapter.job.logger.warning.assert_called_once_with(
             "SoftwareVersion 15.42 for Cisco Meraki is used with a ValidatedSoftware so won't be deleted."
         )
+
+
+@override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
+class TestNautobotPort(TestCase):  # pylint: disable=too-many-instance-attributes
+    """Test the NautobotPort class."""
+
+    databases = ("default", "job_logs")
+
+    @classmethod
+    def setUpTestData(cls):
+        """Configure common variables and objects for tests."""
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        site_lt = LocationType.objects.get_or_create(name="Site")[0]
+        site_lt.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[0]
+        manufacturer = Manufacturer.objects.get_or_create(name="Cisco Meraki")[0]
+        devicetype = DeviceType.objects.get_or_create(model="MX84", manufacturer=manufacturer)[0]
+        role = Role.objects.get_or_create(name="Firewall")[0]
+        role.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.device = Device.objects.create(
+            name="HQ01",
+            device_type=devicetype,
+            role=role,
+            location=cls.test_site,
+            status=cls.status_active,
+        )
+        cls.interface = Interface.objects.create(
+            name="Vlan1234",
+            device=cls.device,
+            description="Old description",
+            enabled=True,
+            mode="access",
+            mgmt_only=False,
+            type="virtual",
+            status=cls.status_active,
+        )
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.device_map = {"HQ01": cls.device.id}
+        cls.adapter.port_map = {"HQ01": {}}
+        cls.adapter.objects_to_create = {"ports": []}
+        cls.adapter.objects_to_delete = {"ports": []}
+
+    def test_create_with_description(self):
+        """Validate the NautobotPort create() method sets the Interface description."""
+        ids = {"name": "Vlan10", "device": "HQ01"}
+        attrs = {
+            "description": "My VLAN",
+            "management": False,
+            "enabled": True,
+            "port_type": "virtual",
+            "port_status": "Active",
+            "tagging": False,
+        }
+        result = NautobotPort.create(self.adapter, ids, attrs)
+        self.assertIsInstance(result, NautobotPort)
+        self.assertEqual(len(self.adapter.objects_to_create["ports"]), 1)
+        port = self.adapter.objects_to_create["ports"][0]
+        self.assertEqual(port.name, ids["name"])
+        self.assertEqual(port.description, attrs["description"])
+        self.assertEqual(self.adapter.port_map[ids["device"]][ids["name"]], port.id)
+
+    def test_create_without_description(self):
+        """Validate the NautobotPort create() method defaults a missing description to an empty string."""
+        ids = {"name": "Vlan20", "device": "HQ01"}
+        attrs = {
+            "description": None,
+            "management": False,
+            "enabled": True,
+            "port_type": "virtual",
+            "port_status": "Active",
+            "tagging": False,
+        }
+        NautobotPort.create(self.adapter, ids, attrs)
+        self.assertEqual(self.adapter.objects_to_create["ports"][0].description, "")
+
+    def test_update_description(self):
+        """Validate the NautobotPort update() method updates the Interface description."""
+        test_port = NautobotPort(
+            name="Vlan1234",
+            device="HQ01",
+            description="Old description",
+            management=False,
+            enabled=True,
+            port_type="virtual",
+            port_status="Active",
+            tagging=False,
+            uuid=self.interface.id,
+        )
+        test_port.adapter = self.adapter
+        actual = NautobotPort.update(self=test_port, attrs={"description": "My VLAN"})
+        self.interface.refresh_from_db()
+        self.assertEqual(self.interface.description, "My VLAN")
+        self.assertEqual(actual, test_port)
+
+    def test_update_description_to_empty(self):
+        """Validate the NautobotPort update() method clears the description when Meraki has no label."""
+        test_port = NautobotPort(
+            name="Vlan1234",
+            device="HQ01",
+            description="Old description",
+            management=False,
+            enabled=True,
+            port_type="virtual",
+            port_status="Active",
+            tagging=False,
+            uuid=self.interface.id,
+        )
+        test_port.adapter = self.adapter
+        NautobotPort.update(self=test_port, attrs={"description": None})
+        self.interface.refresh_from_db()
+        self.assertEqual(self.interface.description, "")


### PR DESCRIPTION
Closes: [#1306](https://github.com/nautobot/nautobot-app-ssot/issues/1306)

## What's Changed

This pull request implements robust synchronization of interface descriptions for Meraki devices, ensuring that interface descriptions in Nautobot are consistently sourced from the most appropriate Meraki API fields and accurately reflect the state of the Meraki environment. It fixes issues with blank descriptions, ensures descriptions are tracked and updated, and enhances test coverage and documentation to reflect the new behavior.

**Interface Description Synchronization Improvements:**

* Interface descriptions for Meraki MS switchports are now sourced from the Meraki port `name`, and SVI descriptions for MX/MG/Z devices are sourced from the VLAN `name`. Descriptions for interfaces without a corresponding Meraki label (e.g., WAN uplinks, management ports) are set to empty strings, with clear documentation and warnings added. [[1]](diffhunk://#diff-20e76ce6e29af2b206aea08424b2b0f3818d963a90a834173bbe8e5cec62c6c8R1) [[2]](diffhunk://#diff-09dd61a5a28213caaa6c28c568375eeaf1636cd4072d4451d87d78e6cce5443cR1-R2) [[3]](diffhunk://#diff-2a051c8366cd1690cdfe9d893e3fa5c3970d4050bcf466620346334e97cedb6cR83-R96)

* The `Port` DiffSync model now tracks the `description` attribute, ensuring that interface descriptions are no longer silently discarded during sync. [[1]](diffhunk://#diff-09dd61a5a28213caaa6c28c568375eeaf1636cd4072d4451d87d78e6cce5443cR1-R2) [[2]](diffhunk://#diff-804bf71af90679d04edc2658fd6313e25d60b985dedd57b749435d7549032e74L87-R92)

**Bug Fixes:**

* Fixed blank interface descriptions for SVIs by sourcing from the VLAN name, and ensured that switchport descriptions are correctly populated from the Meraki port name or set to empty if missing. [[1]](diffhunk://#diff-09dd61a5a28213caaa6c28c568375eeaf1636cd4072d4451d87d78e6cce5443cR1-R2) [[2]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570L788-R802) [[3]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R612) [[4]](diffhunk://#diff-6d80202c44819b7692d4ca8ba6eacda67a61f9a547a2b764567f6981393fdb15R427-R474)

* Ensured that interface descriptions are correctly propagated and updated in Nautobot, both on creation and update, and that they default to empty strings if missing. [[1]](diffhunk://#diff-0e08b892adb655cb71fd597c9d2cf73066e0e008375c9c5c8524a1f19ad81946R232) [[2]](diffhunk://#diff-0e08b892adb655cb71fd597c9d2cf73066e0e008375c9c5c8524a1f19ad81946R248-R249) [[3]](diffhunk://#diff-c98d84805028b662cd15255aa40fdfce78e30e7233bf474bece48204b41faf22R170)

**Test and Fixture Updates:**

* Added and updated tests to verify that interface descriptions are correctly set from Meraki data, including edge cases where names are missing or null. Updated fixtures to provide realistic port names. [[1]](diffhunk://#diff-6d80202c44819b7692d4ca8ba6eacda67a61f9a547a2b764567f6981393fdb15R370-R372) [[2]](diffhunk://#diff-6d80202c44819b7692d4ca8ba6eacda67a61f9a547a2b764567f6981393fdb15R427-R474) [[3]](diffhunk://#diff-6d80202c44819b7692d4ca8ba6eacda67a61f9a547a2b764567f6981393fdb15R412-R414) [[4]](diffhunk://#diff-fb959b8c5e538f85bc4a9db3bcce35de8a0b4b8b6fa7052d4357ba2095b92369R93) [[5]](diffhunk://#diff-fb959b8c5e538f85bc4a9db3bcce35de8a0b4b8b6fa7052d4357ba2095b92369R138-R140)

**Documentation:**

* Expanded the Meraki integration documentation to clearly explain how interface descriptions are mapped, including caveats and authoritative behavior warnings.

**Code Consistency:**

* Refactored all relevant adapter code to consistently set and pass the `description` attribute for all interface types, defaulting to empty strings where appropriate. [[1]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R213) [[2]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R265) [[3]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R310) [[4]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R335) [[5]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R379) [[6]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R419) [[7]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R459) [[8]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R499) [[9]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R539) [[10]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R579) [[11]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R612) [[12]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R634) [[13]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570R685) [[14]](diffhunk://#diff-3aca2721d4740031acc53f775d9232185cc6df9433082e15b72d35ca4851d570L820-L832)

These changes ensure that interface descriptions in Nautobot accurately reflect Meraki configuration and improve the reliability and clarity of Meraki SSoT integration.
