### PR TITLE
Fix ProtectedError When Deleteing SoftwareVersion in Meraki

### DIFF
--- a/changes/1310.fixed
+++ b/changes/1310.fixed
@@ -1,0 +1,1 @@
+Fixed a ProtectedError crash in the Meraki integration when a SoftwareVersion that was still assigned to a Device was deleted, by deferring SoftwareVersion deletion until after Devices have been updated.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/nautobot.py
@@ -292,6 +292,7 @@ class NautobotAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
             "ports",
             "devices",
             "devicetypes",
+            "osversions",
         ):
             for nautobot_object in self.objects_to_delete[grouping]:
                 try:

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -123,7 +123,9 @@ class NautobotOSVersion(OSVersion):
                     f"SoftwareVersion {osversion.version} for {osversion.platform.name} is used with a ValidatedSoftware so won't be deleted."
                 )
                 return self
-        osversion.delete()
+        # Deletion is deferred to sync_complete so Devices are repointed to their new SoftwareVersion first. Deleting
+        # here raises a ProtectedError because DiffSync processes osversion deletions before Device updates.
+        self.adapter.objects_to_delete["osversions"].append(osversion)
         return self
 
 

--- a/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_adapters_nautobot.py
@@ -5,7 +5,16 @@ from unittest.mock import MagicMock
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from nautobot.apps.testing import TestCase
-from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer, Platform
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    Interface,
+    Location,
+    LocationType,
+    Manufacturer,
+    Platform,
+    SoftwareVersion,
+)
 from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import JobResult, Note, Role, Status
 from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix
@@ -198,3 +207,60 @@ class NautobotDiffSyncTestCase(TestCase):
         self.assertFalse(lab01_assignment.primary)
         lab02_assignment = self.nb_adapter.get("ipassignment", "10.0.0.1__Lab02__Test__wan1")
         self.assertTrue(lab02_assignment.primary)
+
+    def test_sync_complete_deletes_deferred_osversion(self):
+        """Validate a deferred SoftwareVersion is deleted once the Device has moved to the new version."""
+        self.nb_adapter.job.debug = False
+        lab01 = Device.objects.get(name="Lab01")
+        old_version = SoftwareVersion.objects.create(
+            version="15.42", platform=lab01.platform, status=self.status_active
+        )
+        new_version = SoftwareVersion.objects.create(
+            version="16.00", platform=lab01.platform, status=self.status_active
+        )
+        lab01.software_version = old_version
+        lab01.validated_save()
+
+        # NautobotDevice.update() repoints the Device during the sync, before sync_complete runs.
+        lab01.software_version = new_version
+        lab01.validated_save()
+        self.nb_adapter.objects_to_delete["osversions"].append(old_version)
+
+        self.nb_adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+
+        self.assertFalse(SoftwareVersion.objects.filter(version="15.42").exists())
+        self.assertEqual([], self.nb_adapter.objects_to_delete["osversions"])
+
+    def test_sync_complete_warns_on_still_referenced_osversion(self):
+        """Validate a SoftwareVersion still in use logs a warning instead of raising ProtectedError."""
+        self.nb_adapter.job.debug = False
+        lab01 = Device.objects.get(name="Lab01")
+        old_version = SoftwareVersion.objects.create(
+            version="15.42", platform=lab01.platform, status=self.status_active
+        )
+        lab01.software_version = old_version
+        lab01.validated_save()
+        self.nb_adapter.objects_to_delete["osversions"].append(old_version)
+
+        self.nb_adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+
+        self.nb_adapter.job.logger.warning.assert_called_once_with(f"Deletion failed protected object: {old_version}")
+        self.assertTrue(SoftwareVersion.objects.filter(version="15.42").exists())
+
+    def test_sync_complete_deletes_device_before_osversion(self):
+        """Validate a Device queued for deletion is removed before its SoftwareVersion, releasing the protected FK."""
+        self.nb_adapter.job.debug = False
+        lab01 = Device.objects.get(name="Lab01")
+        old_version = SoftwareVersion.objects.create(
+            version="15.42", platform=lab01.platform, status=self.status_active
+        )
+        lab01.software_version = old_version
+        lab01.validated_save()
+        self.nb_adapter.objects_to_delete["devices"].append(lab01)
+        self.nb_adapter.objects_to_delete["osversions"].append(old_version)
+
+        self.nb_adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+
+        # Had the SoftwareVersion been processed before the Device, the protected FK would have blocked its deletion.
+        self.assertFalse(Device.objects.filter(name="Lab01").exists())
+        self.assertFalse(SoftwareVersion.objects.filter(version="15.42").exists())

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -1,18 +1,31 @@
 """Unit tests for Nautobot IPAM model CRUD functions."""
 
+from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from nautobot.apps.testing import TestCase
-from nautobot.dcim.models import Location, LocationType
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    Location,
+    LocationType,
+    Manufacturer,
+    Platform,
+    SoftwareVersion,
+)
 from nautobot.extras.management import populate_status_choices
-from nautobot.extras.models import Status
+from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
 
-from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import NautobotIPAddress, NautobotPrefix
+from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import (
+    NautobotIPAddress,
+    NautobotOSVersion,
+    NautobotPrefix,
+)
 
 
 @override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
@@ -235,3 +248,73 @@ class TestNautobotIPAddress(TestCase):  # pylint: disable=too-many-instance-attr
         actual = NautobotIPAddress.update(self=self.test_ip, attrs=update_attrs)
         self.assertIsNone(actual)
         self.adapter.job.logger.error.assert_called_once_with("Prefix 10.100.0.0/8 not found in Nautobot.")
+
+
+@override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
+class TestNautobotOSVersion(TestCase):  # pylint: disable=too-many-instance-attributes
+    """Test the NautobotOSVersion class."""
+
+    databases = ("default", "job_logs")
+
+    @classmethod
+    def setUpTestData(cls):
+        """Configure common variables and objects for tests."""
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        site_lt = LocationType.objects.get_or_create(name="Site")[0]
+        site_lt.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.test_site = Location.objects.get_or_create(name="Test", location_type=site_lt, status=cls.status_active)[0]
+        manufacturer = Manufacturer.objects.get_or_create(name="Cisco Meraki")[0]
+        cls.platform = Platform.objects.get_or_create(name="Cisco Meraki", manufacturer=manufacturer)[0]
+        devicetype = DeviceType.objects.get_or_create(model="MX84", manufacturer=manufacturer)[0]
+        role = Role.objects.get_or_create(name="Firewall")[0]
+        role.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.old_version = SoftwareVersion.objects.create(
+            version="15.42", platform=cls.platform, status=cls.status_active
+        )
+        # A Device still referencing the SoftwareVersion is what makes an immediate delete raise ProtectedError.
+        cls.device = Device.objects.create(
+            name="HQ01",
+            device_type=devicetype,
+            role=role,
+            location=cls.test_site,
+            status=cls.status_active,
+            software_version=cls.old_version,
+        )
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.objects_to_delete = defaultdict(list)
+
+    def _build_osversion(self):
+        """Build a NautobotOSVersion for the old SoftwareVersion, bound to the test adapter."""
+        osversion = NautobotOSVersion(version="15.42", uuid=self.old_version.id)
+        osversion.adapter = self.adapter
+        return osversion
+
+    def test_delete_defers_removal(self):
+        """Validate delete() queues the SoftwareVersion instead of removing it while a Device still references it."""
+        osversion = self._build_osversion()
+
+        actual = osversion.delete()
+
+        self.assertEqual(actual, osversion)
+        self.assertEqual([self.old_version.id], [ver.id for ver in self.adapter.objects_to_delete["osversions"]])
+        # Deleting inline here is what raised ProtectedError, so the record must survive the delete() call.
+        self.assertTrue(SoftwareVersion.objects.filter(id=self.old_version.id).exists())
+
+    @patch("nautobot_ssot.integrations.meraki.diffsync.models.nautobot.SoftwareVersion.objects.get")
+    def test_delete_skips_validated_software(self, mock_get):
+        """Validate delete() does not queue a SoftwareVersion that is used by a ValidatedSoftware."""
+        mock_version = MagicMock()
+        mock_version.version = "15.42"
+        mock_version.platform.name = "Cisco Meraki"
+        mock_version.validatedsoftwarelcm_set.count.return_value = 1
+        mock_get.return_value = mock_version
+
+        self._build_osversion().delete()
+
+        self.assertEqual([], self.adapter.objects_to_delete["osversions"])
+        self.adapter.job.logger.warning.assert_called_once_with(
+            "SoftwareVersion 15.42 for Cisco Meraki is used with a ValidatedSoftware so won't be deleted."
+        )


### PR DESCRIPTION
# Closes: #[1310](https://github.com/nautobot/nautobot-app-ssot/issues/1310)

## What's Changed

This pull request addresses a crash in the Meraki integration caused by attempting to delete a `SoftwareVersion` that is still assigned to a `Device`, which previously resulted in a `ProtectedError`. The solution defers the deletion of `SoftwareVersion` objects until after all referencing `Device` objects have been updated or deleted. The changes also add comprehensive tests to ensure correct deferred deletion behavior and to verify that warnings are logged when deletion is not possible due to ongoing references.

Key changes include:

**Bug Fixes and Core Logic:**

* Deletion of `SoftwareVersion` objects is now deferred until after all referencing `Device` objects have been updated, preventing `ProtectedError` crashes. This is achieved by queuing `SoftwareVersion` objects for deletion and processing them in the `sync_complete` method after device updates. [[1]](diffhunk://#diff-d726f60c8d736bc455782e7a2b531094f7230947e13bb049915da953d86e8f2cR1) [[2]](diffhunk://#diff-0e08b892adb655cb71fd597c9d2cf73066e0e008375c9c5c8524a1f19ad81946L126-R128) [[3]](diffhunk://#diff-c98d84805028b662cd15255aa40fdfce78e30e7233bf474bece48204b41faf22R295)

**Testing Improvements:**

* Added unit tests to verify that deferred deletion of `SoftwareVersion` works as intended, including scenarios where:
  - The version is deleted after device references are removed.
  - A warning is logged if the version is still referenced.
  - Devices are deleted before their associated `SoftwareVersion`, ensuring proper deletion order.
* Added tests for the `NautobotOSVersion` class to confirm that deletion is deferred and that versions referenced by `ValidatedSoftware` are not queued for deletion, with appropriate warnings logged.

**Test Setup and Imports:**

* Updated test imports to include `SoftwareVersion` and related models to support new test cases. [[1]](diffhunk://#diff-fb959b8c5e538f85bc4a9db3bcce35de8a0b4b8b6fa7052d4357ba2095b92369L8-R17) [[2]](diffhunk://#diff-e9a0a643675608324236f8536a5839781cb193829211f3d26d8f9ede2a0dbca1R3-R28)
