### PR TITLE
Fixed Secrets Group unset (#1328)

### DIFF
--- a/changes/1328.added
+++ b/changes/1328.added
@@ -1,0 +1,1 @@
+Added an optional Device Secrets Group field to the LibreNMS to Nautobot job, assigned to Devices it creates so credential-dependent jobs such as nautobot-device-onboarding's Sync Network Data From Network can resolve credentials for them.

--- a/docs/admin/integrations/librenms_setup.md
+++ b/docs/admin/integrations/librenms_setup.md
@@ -40,6 +40,16 @@ Once this is created, go into the Extensibility Menu and select `External Integr
 
 ![LibreNMS External Integration](../../images/librenms-external-integration.png)
 
+##### Device Secrets Group
+
+The `LibreNMS to Nautobot` job has a second, optional Secrets Group field, `Device Secrets Group`. This one is separate from the API token group above and serves a different purpose: it is assigned to each Device the job creates, and holds the credentials used to log in to the device itself.
+
+Devices need this because credential-dependent jobs read it off the Device. nautobot-device-onboarding's `Sync Network Data From Network`, for example, has no credentials field on its own form and resolves credentials only from `Device.secrets_group`; without it, the job fails with `A paramiko SSHException occurred during connection creation: No authentication methods available`.
+
+To build it, create Secrets for your network service account's username and password, then create a SecretsGroup and add both with the Access Type set to `Generic` and the Secret Types set to `Username` and `Password` respectively. That is the combination `nautobot-plugin-nornir` reads when resolving device credentials.
+
+Leaving the field blank is supported; Devices are then created without a Secrets Group, as before.
+
 #### LibreNMS as DataTarget
 NotYetImplemented
 

--- a/docs/user/integrations/librenms.md
+++ b/docs/user/integrations/librenms.md
@@ -44,6 +44,9 @@ The LibreNMS SSoT integration is built as part of the [Nautobot Single Source of
 #### Job Specific Options
 
 - load_type: Whether to load data from a local fixture file or from the External Integration API. File is only used for testing or trying out the integration without a connection to a LibreNMS instance.
+- device_secrets_group: Optional Secrets Group assigned to Devices created by this job. This is the Secrets Group holding the credentials used to connect to the device itself, not the LibreNMS API token on the External Integration. Devices need it for credential-dependent jobs such as nautobot-device-onboarding's `Sync Network Data From Network`, which has no credentials field of its own and reads them only from the Device's Secrets Group. See [the setup guide](../../admin/integrations/librenms_setup.md) for how to build it.
+
+    A Device that already has a Secrets Group is never overwritten, so a group assigned by hand or by another job survives later syncs. This also means Devices created before this field existed are only backfilled when the sync updates them for some other reason; to fix them all at once, filter the Devices list view and use the bulk edit button to set Secrets Group.
 
 From LibreNMS into Nautobot, the app synchronizes devices, and Locations. Here is a table showing the data mappings when syncing from LibreNMS to Nautobot.
 

--- a/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/librenms/diffsync/models/nautobot.py
@@ -299,6 +299,7 @@ class NautobotDevice(Device):
             adapter.job.logger.debug(f'Device Location {attrs["location"]}')
 
         _tenant = adapter.tenant
+        _secrets_group = getattr(adapter.job, "device_secrets_group", None)
 
         try:
             new_device = ORMDevice(
@@ -307,6 +308,7 @@ class NautobotDevice(Device):
                 status=Status.objects.get(name=attrs["status"]),
                 role=ensure_role(role_name=attrs["role"], content_type=ORMDevice),
                 tenant=_tenant,
+                secrets_group=_secrets_group,
                 location=_location,
                 platform=_platform,
                 serial=attrs["serial_no"],
@@ -395,6 +397,13 @@ class NautobotDevice(Device):
                 ip_address=_ipaddress, interface=_interface, defaults={"vm_interface": None}
             )
             device.primary_ip4 = _ipaddress
+
+        # Only backfill the Secrets Group, never overwrite one assigned by hand or by another job.
+        if not device.secrets_group:
+            _secrets_group = getattr(self.adapter.job, "device_secrets_group", None)
+            if _secrets_group:
+                device.secrets_group = _secrets_group
+
         custom_fields = {"last_synced_from_sor": datetime.today().date().isoformat()}
         if not check_sor_field(device):
             custom_fields["system_of_record"] = os.getenv("NAUTOBOT_SSOT_LIBRENMS_SYSTEM_OF_RECORD", "LibreNMS")

--- a/nautobot_ssot/integrations/librenms/jobs.py
+++ b/nautobot_ssot/integrations/librenms/jobs.py
@@ -12,7 +12,7 @@ from nautobot.extras.choices import (
     SecretsGroupAccessTypeChoices,
     SecretsGroupSecretTypeChoices,
 )
-from nautobot.extras.models import ExternalIntegration, Role
+from nautobot.extras.models import ExternalIntegration, Role, SecretsGroup
 from nautobot.tenancy.models import Tenant
 
 from nautobot_ssot.integrations.librenms.diffsync.adapters import librenms, nautobot
@@ -61,6 +61,14 @@ class LibrenmsDataSource(DataSource):  # pylint: disable=too-many-instance-attri
         required=False,
         label="Default Role",
         description="Default Role to use for devices that do not have a role in the hostname map.",
+        default=None,
+    )
+    device_secrets_group = ObjectVar(
+        model=SecretsGroup,
+        display_field="display",
+        required=False,
+        label="Device Secrets Group",
+        description="Secrets Group to assign to Devices created from LibreNMS. Existing Device Secrets Group assignments are never overwritten.",
         default=None,
     )
     unpermitted_values = StringVar(
@@ -162,9 +170,10 @@ class LibrenmsDataSource(DataSource):  # pylint: disable=too-many-instance-attri
         default_role,
         unpermitted_values,
         tenant,
+        device_secrets_group=None,
         *args,
         **kwargs,
-    ):  # pylint: disable=arguments-differ
+    ):  # pylint: disable=arguments-differ, keyword-arg-before-vararg
         """Perform data synchronization."""
         self.librenms_server = librenms_server
         self.hostname_field = hostname_field
@@ -177,6 +186,7 @@ class LibrenmsDataSource(DataSource):  # pylint: disable=too-many-instance-attri
         self.location_map = location_map
         self.hostname_map = hostname_map
         self.default_role = default_role
+        self.device_secrets_group = device_secrets_group
         self.unpermitted_values = literal_eval(unpermitted_values)
         super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)
 

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -175,6 +175,22 @@ class TestNautobotDeviceUpdatePlatform(TestCase):
         self.assertEqual(software_version.version, "2.0")
 
 
+DEVICE_CREATE_IDS = {"name": "new-device"}
+DEVICE_CREATE_ATTRS = {
+    "location": "Chicago",
+    "parent_location": None,
+    "status": "Active",
+    "device_type": "Test Device Type",
+    "manufacturer": "Linux",
+    "platform": "linux",
+    "role": "Test Role",
+    "serial_no": "SN123",
+    "os_version": "1.0",
+    "device_id": 1,
+    "system_of_record": "LibreNMS",
+}
+
+
 class TestNautobotDeviceSecretsGroup(TestCase):
     """Test that NautobotDevice assigns the device_secrets_group job var without clobbering existing groups."""
 
@@ -183,15 +199,13 @@ class TestNautobotDeviceSecretsGroup(TestCase):
     def setUp(self):
         """Set up a Nautobot Device with no Secrets Group, plus two Secrets Groups to assign."""
         super().setUp()
-        self.active_status, _ = Status.objects.get_or_create(name="Active")
-        self.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+        active_status, _ = Status.objects.get_or_create(name="Active")
+        active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
 
-        self.site_type, _ = LocationType.objects.get_or_create(name="Site")
-        self.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+        site_type, _ = LocationType.objects.get_or_create(name="Site")
+        site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
 
-        self.chicago = ORMLocation.objects.create(
-            name="Chicago", location_type=self.site_type, status=self.active_status
-        )
+        chicago = ORMLocation.objects.create(name="Chicago", location_type=site_type, status=active_status)
 
         manufacturer, _ = Manufacturer.objects.get_or_create(name="Generic")
         device_type, _ = DeviceType.objects.get_or_create(model="Test Device Type", manufacturer=manufacturer)
@@ -204,14 +218,14 @@ class TestNautobotDeviceSecretsGroup(TestCase):
         self.orm_device = ORMDevice.objects.create(
             name="test-device",
             device_type=device_type,
-            status=self.active_status,
+            status=active_status,
             role=role,
-            location=self.chicago,
+            location=chicago,
         )
 
         self.adapter = MagicMock(spec=Adapter)
         self.adapter.job = MagicMock()
-        self.adapter.job.location_type = self.site_type
+        self.adapter.job.location_type = site_type
         self.adapter.job.debug = False
         self.adapter.job.sync_locations = False
         self.adapter.job.device_secrets_group = None
@@ -228,26 +242,11 @@ class TestNautobotDeviceSecretsGroup(TestCase):
         )
         self.diffsync_device.adapter = self.adapter
 
-        self.create_ids = {"name": "new-device"}
-        self.create_attrs = {
-            "location": "Chicago",
-            "parent_location": None,
-            "status": "Active",
-            "device_type": "Test Device Type",
-            "manufacturer": "Linux",
-            "platform": "linux",
-            "role": "Test Role",
-            "serial_no": "SN123",
-            "os_version": "1.0",
-            "device_id": 1,
-            "system_of_record": "LibreNMS",
-        }
-
     def test_create_assigns_secrets_group(self):
         """A created Device gets the Secrets Group selected on the job form."""
         self.adapter.job.device_secrets_group = self.job_secrets_group
 
-        NautobotDevice.create(self.adapter, self.create_ids, self.create_attrs)
+        NautobotDevice.create(self.adapter, DEVICE_CREATE_IDS.copy(), DEVICE_CREATE_ATTRS.copy())
 
         new_orm_device = ORMDevice.objects.get(name="new-device")
         self.assertEqual(new_orm_device.secrets_group, self.job_secrets_group)
@@ -256,7 +255,7 @@ class TestNautobotDeviceSecretsGroup(TestCase):
         """Leaving the Secrets Group field blank must still create the Device."""
         self.adapter.job.device_secrets_group = None
 
-        NautobotDevice.create(self.adapter, self.create_ids, self.create_attrs)
+        NautobotDevice.create(self.adapter, DEVICE_CREATE_IDS.copy(), DEVICE_CREATE_ATTRS.copy())
 
         new_orm_device = ORMDevice.objects.get(name="new-device")
         self.assertIsNone(new_orm_device.secrets_group)

--- a/nautobot_ssot/tests/librenms/test_nautobot_model.py
+++ b/nautobot_ssot/tests/librenms/test_nautobot_model.py
@@ -1,5 +1,6 @@
 """Unit tests for the Nautobot-side LibreNMS DiffSync models (NautobotDevice) and helpers."""
 
+from inspect import signature
 from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
@@ -9,12 +10,12 @@ from nautobot.dcim.models import Device as ORMDevice
 from nautobot.dcim.models import DeviceType, LocationType, Manufacturer
 from nautobot.dcim.models import Location as ORMLocation
 from nautobot.dcim.models import Platform as ORMPlatform
-from nautobot.extras.models import Role, Status
+from nautobot.extras.models import Role, SecretsGroup, Status
 from nautobot.ipam.models import Namespace
 from nautobot.tenancy.models import Tenant
 
 from nautobot_ssot.integrations.librenms.diffsync.models.nautobot import NautobotDevice, ensure_ip_address
-from nautobot_ssot.integrations.librenms.jobs import LibrenmsDataTarget
+from nautobot_ssot.integrations.librenms.jobs import LibrenmsDataSource, LibrenmsDataTarget
 
 
 class TestNautobotDeviceLocationSync(TestCase):
@@ -55,6 +56,7 @@ class TestNautobotDeviceLocationSync(TestCase):
         self.adapter.job = MagicMock()
         self.adapter.job.location_type = self.site_type
         self.adapter.job.debug = False
+        self.adapter.job.device_secrets_group = None
         self.adapter.tenant = None
 
         self.diffsync_device = NautobotDevice(
@@ -148,6 +150,7 @@ class TestNautobotDeviceUpdatePlatform(TestCase):
         self.adapter.job = MagicMock()
         self.adapter.job.debug = False
         self.adapter.job.sync_locations = False
+        self.adapter.job.device_secrets_group = None
         self.adapter.tenant = None
 
         self.diffsync_device = NautobotDevice(
@@ -170,6 +173,144 @@ class TestNautobotDeviceUpdatePlatform(TestCase):
         self.assertIsNotNone(software_version)
         self.assertEqual(software_version.platform, self.platform)
         self.assertEqual(software_version.version, "2.0")
+
+
+class TestNautobotDeviceSecretsGroup(TestCase):
+    """Test that NautobotDevice assigns the device_secrets_group job var without clobbering existing groups."""
+
+    databases = ("default", "job_logs")
+
+    def setUp(self):
+        """Set up a Nautobot Device with no Secrets Group, plus two Secrets Groups to assign."""
+        super().setUp()
+        self.active_status, _ = Status.objects.get_or_create(name="Active")
+        self.active_status.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.site_type, _ = LocationType.objects.get_or_create(name="Site")
+        self.site_type.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.chicago = ORMLocation.objects.create(
+            name="Chicago", location_type=self.site_type, status=self.active_status
+        )
+
+        manufacturer, _ = Manufacturer.objects.get_or_create(name="Generic")
+        device_type, _ = DeviceType.objects.get_or_create(model="Test Device Type", manufacturer=manufacturer)
+        role, _ = Role.objects.get_or_create(name="Test Role")
+        role.content_types.add(ContentType.objects.get_for_model(ORMDevice))
+
+        self.job_secrets_group = SecretsGroup.objects.create(name="Device Credentials")
+        self.existing_secrets_group = SecretsGroup.objects.create(name="Pre-Existing Credentials")
+
+        self.orm_device = ORMDevice.objects.create(
+            name="test-device",
+            device_type=device_type,
+            status=self.active_status,
+            role=role,
+            location=self.chicago,
+        )
+
+        self.adapter = MagicMock(spec=Adapter)
+        self.adapter.job = MagicMock()
+        self.adapter.job.location_type = self.site_type
+        self.adapter.job.debug = False
+        self.adapter.job.sync_locations = False
+        self.adapter.job.device_secrets_group = None
+        self.adapter.tenant = None
+
+        self.diffsync_device = NautobotDevice(
+            name="test-device",
+            location="Chicago",
+            status="Active",
+            device_type="Test Device Type",
+            manufacturer="Generic",
+            system_of_record="LibreNMS",
+            uuid=self.orm_device.id,
+        )
+        self.diffsync_device.adapter = self.adapter
+
+        self.create_ids = {"name": "new-device"}
+        self.create_attrs = {
+            "location": "Chicago",
+            "parent_location": None,
+            "status": "Active",
+            "device_type": "Test Device Type",
+            "manufacturer": "Linux",
+            "platform": "linux",
+            "role": "Test Role",
+            "serial_no": "SN123",
+            "os_version": "1.0",
+            "device_id": 1,
+            "system_of_record": "LibreNMS",
+        }
+
+    def test_create_assigns_secrets_group(self):
+        """A created Device gets the Secrets Group selected on the job form."""
+        self.adapter.job.device_secrets_group = self.job_secrets_group
+
+        NautobotDevice.create(self.adapter, self.create_ids, self.create_attrs)
+
+        new_orm_device = ORMDevice.objects.get(name="new-device")
+        self.assertEqual(new_orm_device.secrets_group, self.job_secrets_group)
+
+    def test_create_without_secrets_group(self):
+        """Leaving the Secrets Group field blank must still create the Device."""
+        self.adapter.job.device_secrets_group = None
+
+        NautobotDevice.create(self.adapter, self.create_ids, self.create_attrs)
+
+        new_orm_device = ORMDevice.objects.get(name="new-device")
+        self.assertIsNone(new_orm_device.secrets_group)
+
+    def test_update_backfills_secrets_group_when_unset(self):
+        """A Device with no Secrets Group picks one up on update."""
+        self.adapter.job.device_secrets_group = self.job_secrets_group
+
+        self.diffsync_device.update(attrs={"serial_no": "SN999"})
+
+        self.orm_device.refresh_from_db()
+        self.assertEqual(self.orm_device.secrets_group, self.job_secrets_group)
+
+    def test_update_does_not_clobber_existing_secrets_group(self):
+        """A hand-assigned or onboarding-assigned Secrets Group survives later syncs."""
+        self.orm_device.secrets_group = self.existing_secrets_group
+        self.orm_device.validated_save()
+        self.adapter.job.device_secrets_group = self.job_secrets_group
+
+        self.diffsync_device.update(attrs={"serial_no": "SN999"})
+
+        self.orm_device.refresh_from_db()
+        self.assertEqual(self.orm_device.secrets_group, self.existing_secrets_group)
+
+    def test_update_without_secrets_group_leaves_none(self):
+        """An update with the form field blank must not raise and must leave the Device unchanged."""
+        self.adapter.job.device_secrets_group = None
+
+        self.diffsync_device.update(attrs={"serial_no": "SN999"})
+
+        self.orm_device.refresh_from_db()
+        self.assertIsNone(self.orm_device.secrets_group)
+        self.assertEqual(self.orm_device.serial, "SN999")
+
+
+class TestLibrenmsDataSourceSecretsGroupVar(TestCase):
+    """Test the device_secrets_group job var stays optional and backwards compatible."""
+
+    def test_device_secrets_group_var_is_optional(self):
+        """The field must not be required, so existing scheduled jobs keep validating."""
+        job_vars = LibrenmsDataSource._get_vars()  # pylint: disable=protected-access
+
+        self.assertIn("device_secrets_group", job_vars)
+        self.assertFalse(job_vars["device_secrets_group"].field_attrs.get("required"))
+
+    def test_run_defaults_device_secrets_group_to_none(self):
+        """Nautobot's deserialize_data only passes stored kwargs, so run() needs its own default.
+
+        Without it, every ScheduledJob created before this field existed would raise
+        TypeError: run() missing 1 required positional argument.
+        """
+        parameter = signature(LibrenmsDataSource.run).parameters["device_secrets_group"]
+
+        self.assertIsNone(parameter.default)
 
 
 class TestEnsureIPAddress(TestCase):


### PR DESCRIPTION
# Closes: #1328 

## What's Changed

The LibreNMS to Nautobot job creates Devices but never writes Device.secrets_group. This adds an optional Device Secrets Group field to the job form and assigns it to Devices the sync creates, without ever overwriting a group that is already set.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
