### PR TITLE
Backport #1315: Fix Arista CloudVision Python 3.12 import failure

### DIFF
--- a/changes/1332.fixed
+++ b/changes/1332.fixed
@@ -1,0 +1,1 @@
+Fixed Arista CloudVision SSoT failing to load on Python 3.12 when `setuptools` is not installed.

--- a/changes/1332.housekeeping
+++ b/changes/1332.housekeeping
@@ -1,0 +1,1 @@
+Fixed failing Device42 unit test caused by a dependence on Interface ordering.

--- a/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot/integrations/aristacv/diffsync/adapters/cloudvision.py
@@ -1,12 +1,12 @@
 """DiffSync adapter for Arista CloudVision."""
 
-import distutils
 import ipaddress
 import re
 
 import arista.tag.v2 as TAG
 from diffsync import Adapter
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
+from nautobot.core.settings_funcs import is_truthy
 from pydantic import ValidationError
 
 from nautobot_ssot.integrations.aristacv.diffsync.models.cloudvision import (
@@ -253,10 +253,10 @@ class CloudvisionAdapter(Adapter):
             if tag["label"] in ["hostname", "serialnumber", "Container", "vrf"]:
                 continue
             if tag["label"] == "mpls" or tag["label"] == "ztp":
-                tag["value"] = bool(distutils.util.strtobool(tag["value"]))
+                tag["value"] = is_truthy(tag["value"])
 
             if tag["value"] in ["true", "false"]:
-                tag["value"] = bool(distutils.util.strtobool(tag["value"]))
+                tag["value"] = is_truthy(tag["value"])
 
             try:
                 new_cf = self.cf(

--- a/nautobot_ssot/tests/device42/unit/test_models_nautobot_ipam.py
+++ b/nautobot_ssot/tests/device42/unit/test_models_nautobot_ipam.py
@@ -358,9 +358,7 @@ class TestNautobotIPAddress(TransactionTestCase):  # pylint: disable=too-many-in
         update_attrs = {"interface": "mgmt0"}
         result = self.mock_addr.update(attrs=update_attrs)
         self.assertIsInstance(result, ipam.NautobotIPAddress)
-        self.addr.refresh_from_db()
-        self.dev2_mgmt.refresh_from_db()
-        self.assertEqual(self.addr.interfaces.first(), self.dev2_mgmt)
+        self.assertEqual(self.addr.interfaces.get(device=self.test_dev2), self.dev2_mgmt)
 
     def test_update_changing_primary(self):
         """Validate the NautobotIPAddress.update() functionality with making an IPAddress primary."""


### PR DESCRIPTION
Backport of #1315 to `ltm-2.4`.

## What's Changed

Two of the three code changes from #1315 apply to `ltm-2.4`:

- **Arista CloudVision** — replaced `distutils.util.strtobool` with `nautobot.core.settings_funcs.is_truthy` and dropped `import distutils`. `distutils` was removed from the stdlib in Python 3.12 (PEP 632)
- **Device42 unit test** — `test_update_changing_interface` now asserts via `self.addr.interfaces.get(device=self.test_dev2)` instead of `self.addr.interfaces.first()`. The IPAddress under test ends up assigned to two interfaces on two different devices, so `.first()` depended on `Interface` ordering; the new assertion is order-independent.

## Not Backported

- **DNA Center** (`namespace=Namespace.objects.get(id=...)`) — this fixes a Nautobot 3.2 regression

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests <!-- covered by the existing suite; no new tests needed for a backport -->
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
