### PR TITLE
fix: Meraki SSoT notes sync being non idempotent.

### DIFF
--- a/changes/1333.fixed
+++ b/changes/1333.fixed
@@ -1,0 +1,1 @@
+Fixed Meraki notes sync not being idempotent. A note removed from a Network or Device in Meraki is now deleted from Nautobot instead of being reported as a pending change on every sync.

--- a/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/adapters/meraki.py
@@ -146,7 +146,7 @@ class MerakiAdapter(Adapter):  # pylint: disable=too-many-instance-attributes
                             "controller_group": self.job.instance.controller_managed_device_groups.first().name
                             if self.job.instance.controller_managed_device_groups.count() != 0
                             else "",
-                            "notes": dev.get("notes", "").rstrip(),
+                            "notes": dev["notes"].rstrip() if dev.get("notes") else "",
                             "serial": dev["serial"],
                             "status": status,
                             "role": role,

--- a/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/diffsync/models/nautobot.py
@@ -20,6 +20,7 @@ from nautobot_ssot.integrations.meraki.diffsync.models.base import (
     Prefix,
     PrefixLocation,
 )
+from nautobot_ssot.integrations.meraki.utils.nautobot import update_note
 
 
 class NautobotNetwork(Network):
@@ -58,14 +59,13 @@ class NautobotNetwork(Network):
         site = Location.objects.get(id=self.uuid)
         if "timezone" in attrs:
             site.time_zone = attrs["timezone"]
-        if attrs.get("notes"):
-            new_note = Note(
+        if "notes" in attrs:
+            update_note(
+                nautobot_object=site,
                 note=attrs["notes"],
                 user=self.adapter.job.user,
-                assigned_object_type_id=self.adapter.contenttype_map["location"],
-                assigned_object_id=site.id,
+                contenttype_id=self.adapter.contenttype_map["location"],
             )
-            new_note.validated_save()
         if "tags" in attrs:
             site.tags.set(attrs["tags"])
             for tag in site.tags.all():
@@ -190,14 +190,13 @@ class NautobotDevice(Device):
             device.device_type_id = self.adapter.devicetype_map[attrs["model"]]
         if "network" in attrs:
             device.location = self.adapter.site_map[attrs["network"]]
-        if attrs.get("notes"):
-            new_note = Note(
+        if "notes" in attrs:
+            update_note(
+                nautobot_object=device,
                 note=attrs["notes"],
                 user=self.adapter.job.user,
-                assigned_object_type_id=self.adapter.contenttype_map["device"],
-                assigned_object_id=device.id,
+                contenttype_id=self.adapter.contenttype_map["device"],
             )
-            new_note.validated_save()
         if "tags" in attrs:
             device.tags.set(attrs["tags"])
             for tag in device.tags.all():

--- a/nautobot_ssot/integrations/meraki/utils/nautobot.py
+++ b/nautobot_ssot/integrations/meraki/utils/nautobot.py
@@ -2,6 +2,7 @@
 
 from typing import List
 
+from nautobot.extras.models import Note
 from taggit.managers import TaggableManager
 
 
@@ -20,3 +21,36 @@ def get_tag_strings(list_tags: TaggableManager) -> List[str]:
     if len(_strings) > 1:
         _strings.sort()
     return _strings
+
+
+def update_note(nautobot_object, note: str, user, contenttype_id):
+    """Make the Note on a Nautobot object match the note from Meraki.
+
+    The Nautobot adapter loads the most recent Note on an object, so that same Note is the one
+    updated in place here, or deleted when Meraki no longer has a note. Deleting is what makes the
+    sync idempotent: an empty note used to be skipped, leaving the stale Note in Nautobot to be
+    diffed again on every subsequent sync.
+
+    Args:
+        nautobot_object (Model): Nautobot object, such as a Device or Location, that the Note is assigned to.
+        note (str): Note text from Meraki. An empty value removes the Note from the object.
+        user (User): User to assign as the author of the Note.
+        contenttype_id (UUID): ID of the ContentType for the passed Nautobot object.
+    """
+    current_note = nautobot_object.notes.last()
+    if not note:
+        if current_note:
+            current_note.delete()
+        return
+    if current_note:
+        current_note.note = note
+        current_note.user = user
+        current_note.validated_save()
+        return
+    new_note = Note(
+        note=note,
+        user=user,
+        assigned_object_type_id=contenttype_id,
+        assigned_object_id=nautobot_object.id,
+    )
+    new_note.validated_save()

--- a/nautobot_ssot/tests/meraki/test_models_nautobot.py
+++ b/nautobot_ssot/tests/meraki/test_models_nautobot.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
 from diffsync import Adapter
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from nautobot.apps.testing import TestCase
@@ -17,12 +18,14 @@ from nautobot.dcim.models import (
     SoftwareVersion,
 )
 from nautobot.extras.management import populate_status_choices
-from nautobot.extras.models import Role, Status
+from nautobot.extras.models import Note, Role, Status
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
 
 from nautobot_ssot.integrations.meraki.diffsync.models.nautobot import (
+    NautobotDevice,
     NautobotIPAddress,
+    NautobotNetwork,
     NautobotOSVersion,
     NautobotPrefix,
 )
@@ -318,3 +321,145 @@ class TestNautobotOSVersion(TestCase):  # pylint: disable=too-many-instance-attr
         self.adapter.job.logger.warning.assert_called_once_with(
             "SoftwareVersion 15.42 for Cisco Meraki is used with a ValidatedSoftware so won't be deleted."
         )
+
+
+@override_settings(PLUGINS_CONFIG={"nautobot_ssot": {"enable_meraki": True}})
+class TestNotesSync(TestCase):  # pylint: disable=too-many-instance-attributes
+    """Test that Notes on Networks and Devices track the note in Meraki."""
+
+    databases = ("default", "job_logs")
+
+    @classmethod
+    def setUpTestData(cls):
+        """Configure common variables and objects for tests."""
+        super().setUpTestData()
+        populate_status_choices()
+        cls.status_active = Status.objects.get(name="Active")
+        cls.site_lt = LocationType.objects.get_or_create(name="Site")[0]
+        cls.site_lt.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.test_site = Location.objects.get_or_create(
+            name="Test", location_type=cls.site_lt, status=cls.status_active
+        )[0]
+        manufacturer = Manufacturer.objects.get_or_create(name="Cisco Meraki")[0]
+        Platform.objects.get_or_create(name="Cisco Meraki", manufacturer=manufacturer)
+        devicetype = DeviceType.objects.get_or_create(model="MX84", manufacturer=manufacturer)[0]
+        role = Role.objects.get_or_create(name="Firewall")[0]
+        role.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.device = Device.objects.create(
+            name="HQ01",
+            device_type=devicetype,
+            role=role,
+            location=cls.test_site,
+            status=cls.status_active,
+        )
+        cls.location_ct = ContentType.objects.get_for_model(Location)
+        cls.device_ct = ContentType.objects.get_for_model(Device)
+        cls.user = get_user_model().objects.create(username="testuser")
+        cls.adapter = Adapter()
+        cls.adapter.job = MagicMock()
+        cls.adapter.job.user = cls.user
+        cls.adapter.contenttype_map = {"location": cls.location_ct.id, "device": cls.device_ct.id}
+        cls.adapter.tenant_map = {}
+        cls.adapter.devicerole_map = {"Firewall": role.id}
+        cls.adapter.devicetype_map = {"MX84": devicetype.id}
+        cls.adapter.status_map = {"Active": cls.status_active.id}
+        cls.adapter.version_map = {}
+
+    def _add_note(self, nautobot_object, contenttype, note="Original note"):
+        """Attach a Note to the passed object the way a prior sync would have."""
+        new_note = Note(
+            note=note,
+            user=self.user,
+            assigned_object_type=contenttype,
+            assigned_object_id=nautobot_object.id,
+        )
+        new_note.validated_save()
+        return new_note
+
+    @staticmethod
+    def _note_texts(nautobot_object, contenttype):
+        """Return the text of every Note assigned to the passed object, oldest first."""
+        return [
+            note.note
+            for note in Note.objects.filter(
+                assigned_object_type=contenttype, assigned_object_id=nautobot_object.id
+            ).order_by("created")
+        ]
+
+    def _build_network(self):
+        """Build a NautobotNetwork for the test Location, bound to the test adapter."""
+        network = NautobotNetwork(
+            name="Test", parent=None, timezone=None, notes="Original note", uuid=self.test_site.id
+        )
+        network.adapter = self.adapter
+        return network
+
+    def _build_device(self):
+        """Build a NautobotDevice for the test Device, bound to the test adapter."""
+        device = NautobotDevice(
+            name="HQ01",
+            controller_group=None,
+            notes="Original note",
+            serial="",
+            status="Active",
+            role="Firewall",
+            model="MX84",
+            network="Test",
+            tenant=None,
+            version=None,
+            uuid=self.device.id,
+        )
+        device.adapter = self.adapter
+        return device
+
+    def test_network_update_removes_note_when_cleared_in_meraki(self):
+        """Validate a Network note deleted in Meraki is removed from Nautobot instead of being re-diffed forever."""
+        self._add_note(self.test_site, self.location_ct)
+
+        self._build_network().update(attrs={"notes": ""})
+
+        self.assertEqual([], self._note_texts(self.test_site, self.location_ct))
+
+    def test_device_update_removes_note_when_cleared_in_meraki(self):
+        """Validate a Device note deleted in Meraki is removed from Nautobot instead of being re-diffed forever."""
+        self._add_note(self.device, self.device_ct)
+
+        self._build_device().update(attrs={"notes": ""})
+
+        self.assertEqual([], self._note_texts(self.device, self.device_ct))
+
+    def test_network_update_changes_note_in_place(self):
+        """Validate a changed Network note updates the existing Note rather than stacking a second one."""
+        self._add_note(self.test_site, self.location_ct)
+
+        self._build_network().update(attrs={"notes": "Updated note"})
+
+        self.assertEqual(["Updated note"], self._note_texts(self.test_site, self.location_ct))
+
+    def test_device_update_changes_note_in_place(self):
+        """Validate a changed Device note updates the existing Note rather than stacking a second one."""
+        self._add_note(self.device, self.device_ct)
+
+        self._build_device().update(attrs={"notes": "Updated note"})
+
+        self.assertEqual(["Updated note"], self._note_texts(self.device, self.device_ct))
+
+    def test_network_update_adds_note_when_missing(self):
+        """Validate a Network note added in Meraki creates a Note when Nautobot has none."""
+        self._build_network().update(attrs={"notes": "Brand new note"})
+
+        self.assertEqual(["Brand new note"], self._note_texts(self.test_site, self.location_ct))
+
+    def test_device_update_adds_note_when_missing(self):
+        """Validate a Device note added in Meraki creates a Note when Nautobot has none."""
+        self._build_device().update(attrs={"notes": "Brand new note"})
+
+        self.assertEqual(["Brand new note"], self._note_texts(self.device, self.device_ct))
+
+    def test_update_without_notes_attr_leaves_note_alone(self):
+        """Validate a Device update that doesn't involve notes leaves the existing Note untouched."""
+        self._add_note(self.device, self.device_ct)
+
+        self._build_device().update(attrs={"serial": "XYZ-987"})
+
+        self.assertEqual(["Original note"], self._note_texts(self.device, self.device_ct))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1333 <ISSUE NUMBER GOES HERE>

## What's Changed
Added a function in utilities of Meraki SSoT integration to check for new notes, deleted notes, empty notes.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
