### PR TITLE
Fixed SNOW Integration to better handle duplicate names

### DIFF
--- a/changes/1323.fixed
+++ b/changes/1323.fixed
@@ -1,0 +1,1 @@
+Fixed ServiceNow integration to log and report errors for unresolved or ambiguous references, mark affected objects as failed, and resolve device model references by both manufacturer and model name to prevent name collisions.

--- a/docs/user/integrations/servicenow.md
+++ b/docs/user/integrations/servicenow.md
@@ -12,6 +12,20 @@ This integration provides the ability to synchronize basic data from Nautobot in
 
 Once the integration is installed and configured, from the Nautobot SSoT dashboard view (`/plugins/ssot/`), ServiceNow will be shown as a Data Target. You can click the **Sync** button to access a form view from which you can run the Nautobot-to-ServiceNow synchronization Job. Running the job will redirect you to a Nautobot **Job Result** view, from which you can access the **SSoT Sync Details** view to see detailed information about the outcome of the sync Job.
 
+## Reference resolution and duplicate ServiceNow records
+
+Several of the synchronized fields are ServiceNow reference (foreign key) columns: a Device's `model_id` points at a record in `cmdb_hardware_product_model`, its `location` at a record in `cmn_location`, and so on. To write one, the sync has to identify exactly one record in the referenced table.
+
+Where a single column cannot do that on its own, the mapping narrows the lookup by additional columns. A model name, for example, is only unique within its manufacturer, so `model_id` is resolved by name *and* manufacturer.
+
+When a lookup still matches more than one record, or matches none, the sync no longer writes the record with that field left unset. Instead it:
+
+- logs an error naming the record, the field, the value, the ServiceNow table, and the `sys_id` of every record that collided;
+- marks that object as failed in the **SSoT Sync Details** view, while the rest of the sync continues;
+- attaches an `unresolved_references.txt` report to the Job Result and logs a summary error, so a run with skipped fields is not mistaken for a clean one.
+
+The usual cause is duplicate records in the referenced ServiceNow table; the stock developer instance ships with duplicate `cmn_location` entries, for instance. De-duplicating them in ServiceNow resolves it. Duplicates that a reference cannot tell apart are also reported as warnings while data is loaded, so a **Dry run** surfaces them before any write is attempted.
+
 ## Screenshots
 
 ![Detail View](../../images/servicenow-detail-view.png)

--- a/nautobot_ssot/integrations/servicenow/data/mappings.yaml
+++ b/nautobot_ssot/integrations/servicenow/data/mappings.yaml
@@ -67,6 +67,16 @@ device:
         key: "model_id"
         table: "cmdb_hardware_product_model"
         column: "name"
+        # Several manufacturers can share a model name, so `name` alone does not identify a product model.
+        # Narrow the lookup by manufacturer, reusing the sys_id resolved by the mapping above where available
+        # and falling back to resolving `manufacturer_name` when it is not part of the data being written.
+        match:
+          - column: "manufacturer"
+            key: "manufacturer"
+            field: "manufacturer_name"
+            reference:
+              table: "core_company"
+              column: "name"
     - field: "serial"
       column: "serial_number"
 interface:

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
@@ -134,7 +134,7 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
                     tuple(models.normalize_sn_value(record.get(column)) for column in columns) for record in records
                 )
                 for values, count in counts.items():
-                    if count == 1:
+                    if count == 1 or not values[0]:
                         continue
                     described = ", ".join(f"{column}={value}" for column, value in zip(columns, values))
                     self.job.logger.warning(
@@ -230,6 +230,17 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
     def register_sn_record(self, table, record):
         """Remember a ServiceNow record so that references to it can be resolved without a query."""
         self.sys_ids.setdefault(table, {})[record["sys_id"]] = record
+
+    def table_query_for(self, table):
+        """The `table_query` filter this table is loaded with, if any.
+
+        Reference lookups apply it too, so that a record the load deliberately excluded is not resolved by
+        a fallback query instead.
+        """
+        for entry in self.mapping_data.values():
+            if entry["table"] == table:
+                return entry.get("table_query") or {}
+        return {}
 
     def load_record(self, table, record, model_cls, mappings, **kwargs):
         """Helper method to load_table()."""

--- a/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/adapter_servicenow.py
@@ -4,15 +4,16 @@
 import json
 import os
 from base64 import b64encode
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 import yaml
 from diffsync import Adapter
-from diffsync.enum import DiffSyncFlags
+from diffsync.enum import DiffSyncFlags, DiffSyncStatus
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
 from jinja2 import Environment, FileSystemLoader
 
 from nautobot_ssot.contrib.model import DiffSyncModel
+from nautobot_ssot.integrations.servicenow.exceptions import ServiceNowReferenceError
 
 from . import models
 
@@ -44,10 +45,10 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
         self.job = job
         self.sync = sync
         self.site_filter = site_filter
+        # Dict of table -> sys_id -> record. Every record pulled during load, plus any fetched later.
+        # Reference (foreign key) fields are resolved against this, so the write path needs no extra queries.
         self.sys_ids = {}
         self.mapping_data = []
-        # Dict of table -> column_name -> value -> sys_id.
-        self.sys_ids_cache = defaultdict(dict)  # Cache for sys_ids to avoid redundant queries
 
         # Since a device may contain dozens or hundreds of interfaces,
         # to improve performance when a device is created, we use ServiceNow's bulk/batch API to
@@ -55,6 +56,9 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
         self.interfaces_to_create_per_device = {}
 
         self.duplicate_records = defaultdict(list)  # Store duplicate records for user notification
+
+        # Reference fields that could not be resolved, so that the run does not look clean afterwards.
+        self.unresolved_references = []
 
     def load(self):
         """Load data via pysnow."""
@@ -110,6 +114,34 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
 
         for modelname, duplicate_uids in self.duplicate_records.items():
             self.job.create_file(f"duplicate_{modelname}.txt", "\n".join(duplicate_uids))
+
+        self.warn_about_ambiguous_references()
+
+    def warn_about_ambiguous_references(self):
+        """Warn about loaded records that a reference to their table will not be able to tell apart.
+
+        A dry run never writes, and so never resolves a reference. Without this, a duplicate that is going
+        to fail the next real sync stays invisible until that sync runs.
+        """
+        for modelname, entry in self.mapping_data.items():
+            for mapping in entry["mappings"]:
+                reference = mapping.get("reference")
+                if not reference or "column" not in reference:
+                    continue
+                records = self.sys_ids.get(reference["table"], {}).values()
+                columns = [reference["column"]] + [match["column"] for match in reference.get("match", [])]
+                counts = Counter(
+                    tuple(models.normalize_sn_value(record.get(column)) for column in columns) for record in records
+                )
+                for values, count in counts.items():
+                    if count == 1:
+                        continue
+                    described = ", ".join(f"{column}={value}" for column, value in zip(columns, values))
+                    self.job.logger.warning(
+                        f"Table `{reference['table']}` has {count} records with {described}; "
+                        f"`{modelname}.{mapping['field']}` references it by those columns and will not be "
+                        "able to tell them apart."
+                    )
 
     @classmethod
     def load_yaml_datafile(cls, filename, config=None):
@@ -190,9 +222,18 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
             self.duplicate_records[model_name] = [",".join(model_identifiers)]
         self.duplicate_records[model_name].append(",".join([getattr(model_cls, attr) for attr in model_identifiers]))
 
+    def record_unresolved_reference(self, error):
+        """Report a reference field that could not be resolved, and remember it for the run summary."""
+        self.job.logger.error(str(error))
+        self.unresolved_references.append(error)
+
+    def register_sn_record(self, table, record):
+        """Remember a ServiceNow record so that references to it can be resolved without a query."""
+        self.sys_ids.setdefault(table, {})[record["sys_id"]] = record
+
     def load_record(self, table, record, model_cls, mappings, **kwargs):
         """Helper method to load_table()."""
-        self.sys_ids.setdefault(table, {})[record["sys_id"]] = record
+        self.register_sn_record(table, record)
 
         ids_attrs = self.map_record_to_attrs(record, mappings)
         model = model_cls(**ids_attrs)
@@ -250,7 +291,7 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
                                 f"references sys_id `{sys_id}`, but that was not found in table `{table}`"
                             )
                         else:
-                            self.sys_ids.setdefault(table, {})[sys_id] = referenced_record
+                            self.register_sn_record(table, referenced_record)
 
                     if sys_id in self.sys_ids.get(table, {}):
                         value = self.sys_ids[table][sys_id][mapping["reference"]["column"]]
@@ -283,10 +324,17 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
             }
 
             for inner_request_id, interface in enumerate(self.interfaces_to_create_per_device[device_name]):
-                inner_request_payload = interface.map_data_to_sn_record(
-                    data={**interface.get_identifiers(), **interface.get_attrs()},
-                    mapping_entry=sn_mapping_entry,
-                )
+                try:
+                    inner_request_payload = interface.map_data_to_sn_record(
+                        data={**interface.get_identifiers(), **interface.get_attrs()},
+                        mapping_entry=sn_mapping_entry,
+                    )
+                except ServiceNowReferenceError as error:
+                    # Sending the batch anyway would create interfaces attached to nothing. Drop just this
+                    # one: the rest of the device's interfaces, and every other device, still go through.
+                    self.record_unresolved_reference(error)
+                    interface.set_status(DiffSyncStatus.FAILURE, str(error))
+                    continue
                 inner_request_body = b64encode(json.dumps(inner_request_payload).encode("utf-8")).decode("utf-8")
                 inner_request_data = {
                     "id": str(inner_request_id),
@@ -301,10 +349,17 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
                 }
                 request_data["rest_requests"].append(inner_request_data)
 
-            self.job.logger.debug(
-                f'Sending bulk API request to ServiceNow to create interfaces for device "{device_name}":'
-                f"\n```\n{json.dumps(request_data, indent=4)}\n```"
-            )
+            if not request_data["rest_requests"]:
+                self.job.logger.warning(
+                    f'No interfaces could be prepared for device "{device_name}"; skipping its bulk request.'
+                )
+                continue
+
+            if self.job.debug:
+                self.job.logger.debug(
+                    f'Sending bulk API request to ServiceNow to create interfaces for device "{device_name}":'
+                    f"\n```\n{json.dumps(request_data, indent=4)}\n```"
+                )
 
             sn_response = sn_resource.request(
                 "POST",
@@ -327,9 +382,10 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
                     f"were not serviced:\n```\n{json.dumps(response_data['unserviced_requests'], indent=4)}\n```",
                 )
             else:
-                self.job.logger.debug(
-                    f"ServiceNow response: {response.status_code}\n```\n{json.dumps(response_data, indent=4)}\n```"
-                )
+                if self.job.debug:
+                    self.job.logger.debug(
+                        f"ServiceNow response: {response.status_code}\n```\n{json.dumps(response_data, indent=4)}\n```"
+                    )
                 self.job.logger.info("Interfaces successfully bulk-created.")
 
         self.job.logger.info("Bulk creation of interfaces completed.")
@@ -363,3 +419,22 @@ class ServiceNowDiffSync(Adapter):  # pylint: disable=too-many-instance-attribut
                 for sn_object in self.objects_to_delete[grouping]:
                     sn_object.delete()
                 self.objects_to_delete[grouping] = []
+
+        self.report_unresolved_references()
+
+    def report_unresolved_references(self):
+        """Summarize any reference fields that could not be written, so the run does not look clean."""
+        if not self.unresolved_references:
+            return
+
+        self.job.logger.error(
+            f"{len(self.unresolved_references)} reference field(s) could not be resolved; the affected "
+            "records were not fully written to ServiceNow. See unresolved_references.txt."
+        )
+        lines = [ServiceNowReferenceError.csv_header()] + [error.as_csv_row() for error in self.unresolved_references]
+        try:
+            self.job.create_file("unresolved_references.txt", "\n".join(lines))
+        except Exception as error:  # pylint: disable=broad-except
+            # The errors themselves are already in the job log; losing the whole sync over the attachment
+            # (which enforces a size limit and a unique filename) would be a poor trade.
+            self.job.logger.warning(f"Unable to attach the unresolved reference report: {error}")

--- a/nautobot_ssot/integrations/servicenow/diffsync/models.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/models.py
@@ -5,52 +5,152 @@ from typing import List, Optional, Union
 
 from diffsync import DiffSyncModel
 from diffsync.enum import DiffSyncStatus
-from diffsync.exceptions import ObjectNotCreated, ObjectNotUpdated
+from diffsync.exceptions import ObjectNotCreated, ObjectNotDeleted, ObjectNotUpdated
+
+from nautobot_ssot.integrations.servicenow.exceptions import (
+    AmbiguousReferenceError,
+    MissingReferenceError,
+    ServiceNowReferenceError,
+)
 
 # import pysnow
 from nautobot_ssot.integrations.servicenow.third_party import pysnow
 
 
+def normalize_sn_value(value):
+    """Render a value the way ServiceNow reports it, for comparison against a fetched record.
+
+    ServiceNow returns every column as a string, using an empty string for an unset reference.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def record_matches(record, criteria):
+    """Whether a fetched ServiceNow record satisfies every column/value pair in `criteria`."""
+    return all(
+        normalize_sn_value(record.get(column)) == normalize_sn_value(expected) for column, expected in criteria.items()
+    )
+
+
 class ServiceNowCRUDMixin:
     """Mixin class for all ServiceNow models, to support CRUD operations based on mappings.yaml."""
 
-    def map_data_to_sn_record(self, data, mapping_entry, existing_record=None, clear_cache=False):
-        """Map create/update data from DiffSync to a corresponding ServiceNow data record."""
+    def map_data_to_sn_record(self, data, mapping_entry, existing_record=None, context=None):
+        """Map create/update data from DiffSync to a corresponding ServiceNow data record.
+
+        Args:
+            data (dict): Field values to write. Also decides *which* columns appear in the returned record,
+                so an update payload stays limited to the changed fields.
+            mapping_entry (dict): The mappings.yaml entry for this model.
+            existing_record (dict): Record to populate in place, if any.
+            context (dict): Additional field values used only to resolve and disambiguate references.
+                Never written to ServiceNow. Needed on the update path, where `data` holds only the
+                changed attributes and so may be missing the sibling fields a lookup needs.
+
+        Raises:
+            ServiceNowReferenceError: If a non-null reference value did not resolve to exactly one
+                ServiceNow record. Returning a null column instead would silently drop the field while
+                the sync went on to report success.
+        """
         record = existing_record or {}
+        context = {**(context or {}), **data}
         for mapping in mapping_entry.get("mappings", []):
             if mapping["field"] not in data:
                 continue
-            value = data[mapping["field"]]
             if "column" in mapping:
-                record[mapping["column"]] = value
+                record[mapping["column"]] = data[mapping["field"]]
             elif "reference" in mapping:
-                tablename = mapping["reference"]["table"]
-                sys_id = None
                 if "column" not in mapping["reference"]:
                     raise NotImplementedError
-                column_name = mapping["reference"]["column"]
-                if value is not None:
-                    # if clear_cache is set to True then clear the cache for the object
-                    if clear_cache:
-                        self.adapter.sys_ids_cache.setdefault(tablename, {}).setdefault(column_name, {})[value] = {}
-                    # Look in the cache first
-                    sys_id = self.adapter.sys_ids_cache.get(tablename, {}).get(column_name, {}).get(value, None)
-                    if not sys_id:
-                        target = self.adapter.client.get_by_query(tablename, {mapping["reference"]["column"]: value})
-                        if target is None:
-                            self.adapter.job.logger.warning(f"Unable to find reference target in {tablename}")
-                        else:
-                            sys_id = target["sys_id"]
-                            self.adapter.sys_ids_cache.setdefault(tablename, {}).setdefault(column_name, {})[value] = (
-                                sys_id
-                            )
-
-                record[mapping["reference"]["key"]] = sys_id
+                record[mapping["reference"]["key"]] = self._resolve_reference(mapping, context, record)
             else:
                 raise NotImplementedError
 
-        self.adapter.job.logger.debug(f"Mapped data {data} to record {record}")
+        if self.adapter.job.debug:
+            self.adapter.job.logger.debug(f"Mapped data {data} to record {record}")
         return record
+
+    def _find_sn_records(self, table, criteria):
+        """Records in `table` matching every column/value pair in `criteria`.
+
+        The records pulled during load are consulted first: they already contain every candidate, so the
+        happy path costs no API call. Only when the loaded set has nothing (because a `table_query` or
+        `site_filter` narrowed the load) is ServiceNow queried, and a single hit joins the loaded set so
+        an identical lookup later does not query again.
+        """
+        loaded = [record for record in self.adapter.sys_ids.get(table, {}).values() if record_matches(record, criteria)]
+        if loaded:
+            return loaded
+        fetched = self.adapter.client.get_all_by_query(table, criteria)
+        if len(fetched) == 1:
+            self.adapter.register_sn_record(table, fetched[0])
+        return fetched
+
+    def _match_criteria(self, reference, context, record):
+        """Build the extra column/value pairs that narrow an otherwise ambiguous reference lookup.
+
+        Returns:
+            tuple: (criteria, unapplied), where `unapplied` names the match fields whose value was not
+            available, so that an ambiguity error can report why it could not be narrowed.
+        """
+        criteria = {}
+        unapplied = []
+        for entry in reference.get("match", []):
+            # Prefer a sys_id already resolved for an earlier mapping in this same record: it is free.
+            if entry.get("key") in record:
+                criteria[entry["column"]] = record[entry["key"]]
+                continue
+            # Otherwise fall back to the DiffSync value, which on the update path is all we have.
+            value = context.get(entry.get("field"))
+            if value is not None and "reference" in entry:
+                nested = entry["reference"]
+                found = self._find_sn_records(nested["table"], {nested["column"]: value})
+                value = found[0]["sys_id"] if len(found) == 1 else None
+            if value is None:
+                unapplied.append(entry.get("field") or entry["column"])
+            else:
+                criteria[entry["column"]] = value
+        return criteria, unapplied
+
+    def _resolve_reference(self, mapping, context, record):
+        """Resolve a `reference` mapping to exactly one ServiceNow sys_id.
+
+        Returns None only when the source value is itself None, i.e. the reference is being cleared.
+
+        Raises:
+            AmbiguousReferenceError: If more than one record matched.
+            MissingReferenceError: If no record matched.
+        """
+        reference = mapping["reference"]
+        table = reference["table"]
+        column = reference["column"]
+        value = context.get(mapping["field"])
+        if value is None:
+            return None
+
+        criteria = {column: value}
+        match_criteria, unapplied = self._match_criteria(reference, context, record)
+        criteria.update(match_criteria)
+
+        candidates = self._find_sn_records(table, criteria)
+        if len(candidates) == 1:
+            return candidates[0]["sys_id"]
+
+        error_class = AmbiguousReferenceError if candidates else MissingReferenceError
+        raise error_class(
+            table=table,
+            column=column,
+            value=value,
+            modelname=self.get_type(),
+            unique_id=self.get_unique_id(),
+            field=mapping["field"],
+            candidates=[candidate["sys_id"] for candidate in candidates],
+            unapplied=unapplied,
+        )
 
     @classmethod
     def create(cls, adapter, ids, attrs):
@@ -62,7 +162,11 @@ class ServiceNowCRUDMixin:
         model = super().create(adapter, ids=ids, attrs=attrs)
 
         sn_resource = adapter.client.resource(api_path=f"/table/{entry['table']}")
-        sn_record = model.map_data_to_sn_record(data={**ids, **attrs}, mapping_entry=entry)
+        try:
+            sn_record = model.map_data_to_sn_record(data={**ids, **attrs}, mapping_entry=entry)
+        except ServiceNowReferenceError as error:
+            adapter.record_unresolved_reference(error)
+            raise ObjectNotCreated(str(error)) from error
         result = sn_resource.create(payload=sn_record)
         object_id = result.one().get("sys_id")
         if not object_id:
@@ -70,6 +174,12 @@ class ServiceNowCRUDMixin:
                 f"Failed to create {cls.get_type()} with identifiers {ids} and attributes {attrs}"
             )
             raise ObjectNotCreated(f"Failed to create {cls.get_type()} with identifiers {ids} and attributes {attrs}")
+
+        # Remember the new record so that objects created later in this same run can reference it
+        # without querying ServiceNow for something we just wrote.
+        model.sys_id = object_id
+        adapter.register_sn_record(entry["table"], result.one())
+
         for key in sn_record:
             if key not in result.one():
                 adapter.job.logger.warning(f"Key {key} from SN record {sn_record} not found in result {result.one()}")
@@ -97,20 +207,28 @@ class ServiceNowCRUDMixin:
         entry = self.adapter.mapping_data[self.get_type()]
 
         sn_resource = self.adapter.client.resource(api_path=f"/table/{entry['table']}")
-        if self.sys_id:
-            query = {"sys_id": self.sys_id}
-        else:
-            query = self.map_data_to_sn_record(data=self.get_identifiers(), mapping_entry=entry)
+        # `attrs` holds only the changed attributes, so reference lookups that need a sibling field
+        # (such as resolving a model name within its manufacturer) have to read it from the current state.
+        context = {**self.get_identifiers(), **self.get_attrs(), **attrs}
+        try:
+            if self.sys_id:
+                query = {"sys_id": self.sys_id}
+            else:
+                query = self.map_data_to_sn_record(data=self.get_identifiers(), mapping_entry=entry, context=context)
+            sn_record = self.map_data_to_sn_record(data=attrs, mapping_entry=entry, context=context)
+        except ServiceNowReferenceError as error:
+            self.adapter.record_unresolved_reference(error)
+            raise ObjectNotUpdated(str(error)) from error
 
-        sn_record = self.map_data_to_sn_record(data=attrs, mapping_entry=entry)
         try:
             result = sn_resource.update(query=query, payload=sn_record)
-        except pysnow.exceptions.MultipleResults:
-            self.adapter.job.logger.error(
+        except pysnow.exceptions.MultipleResults as error:
+            message = (
                 f"Unsure which record to update, as query {query} matched more than one item "
                 f"in table {entry['table']}"
             )
-            return None
+            self.adapter.job.logger.error(message)
+            raise ObjectNotUpdated(message) from error
         if self.adapter.job.debug:
             self.adapter.job.logger.debug(f"Result of update: {result.one()}")
         for key, value in sn_record.items():
@@ -137,21 +255,29 @@ class ServiceNowCRUDMixin:
         """Delete an existing instance in ServiceNow if it does not exist in Nautobot. This code adds the ServiceNow object to the objects_to_delete dict of lists. The actual delete occurs in the post-run method of adapter_servicenow.py."""
         entry = self.adapter.mapping_data[self.get_type()]
         sn_resource = self.adapter.client.resource(api_path=f"/table/{entry['table']}")
-        query = self.map_data_to_sn_record(data=self.get_identifiers(), mapping_entry=entry)
         try:
-            sn_resource.get(query=query).one()
-        except pysnow.exceptions.MultipleResults:
-            self.adapter.job.logger.error(
-                f"Unsure which record to update, as query {query} matched more than one item "
+            query = self.map_data_to_sn_record(
+                data=self.get_identifiers(),
+                mapping_entry=entry,
+                context={**self.get_identifiers(), **self.get_attrs()},
+            )
+        except ServiceNowReferenceError as error:
+            # An unresolved reference would leave the query matching the wrong records, or none at all.
+            self.adapter.record_unresolved_reference(error)
+            raise ObjectNotDeleted(str(error)) from error
+
+        _object = sn_resource.get(query=query)
+        try:
+            _object.one()
+        except pysnow.exceptions.MultipleResults as error:
+            message = (
+                f"Unsure which record to delete, as query {query} matched more than one item "
                 f"in table {entry['table']}"
             )
-            return None
+            self.adapter.job.logger.error(message)
+            raise ObjectNotDeleted(message) from error
         self.adapter.job.logger.warning(f"{self._modelname} {self.get_identifiers()} will be deleted.")
-        _object = sn_resource.get(query=query)
         self.adapter.objects_to_delete[self._modelname].append(_object)
-        self.map_data_to_sn_record(
-            data=self.get_identifiers(), mapping_entry=entry, clear_cache=True
-        )  # remove device cache
         super().delete()
         return self
 
@@ -260,7 +386,10 @@ class Device(ServiceNowCRUDMixin, DiffSyncModel):
         """Create a new Device instance, and set things up for eventual bulk-creation of its child Interfaces."""
         model = super().create(adapter, ids=ids, attrs=attrs)
 
-        adapter.job.logger.debug(f'New Device "{ids["name"]}" is being created, will bulk-create its interfaces later.')
+        if adapter.job.debug:
+            adapter.job.logger.debug(
+                f'New Device "{ids["name"]}" is being created, will bulk-create its interfaces later.'
+            )
         adapter.interfaces_to_create_per_device[ids["name"]] = []
 
         return model
@@ -307,9 +436,10 @@ class Interface(ServiceNowCRUDMixin, DiffSyncModel):
     def create(cls, adapter, ids, attrs):
         """Create an interface in isolation, or if the parent Device is new as well, defer for later bulk-creation."""
         if ids["device_name"] in adapter.interfaces_to_create_per_device:
-            adapter.job.logger.debug(
-                f'Device "{ids["device_name"]}" was just created; deferring creation of interface "{ids["name"]}"'
-            )
+            if adapter.job.debug:
+                adapter.job.logger.debug(
+                    f'Device "{ids["device_name"]}" was just created; deferring creation of interface "{ids["name"]}"'
+                )
             # copy-paste of DiffSyncModel's create() classmethod;
             # we don't want to call super().create() here as that would be ServiceNowCRUDMixin.create(),
             # which is what we're trying to avoid here!

--- a/nautobot_ssot/integrations/servicenow/diffsync/models.py
+++ b/nautobot_ssot/integrations/servicenow/diffsync/models.py
@@ -85,7 +85,8 @@ class ServiceNowCRUDMixin:
         loaded = [record for record in self.adapter.sys_ids.get(table, {}).values() if record_matches(record, criteria)]
         if loaded:
             return loaded
-        fetched = self.adapter.client.get_all_by_query(table, criteria)
+        query = {**self.adapter.table_query_for(table), **criteria}
+        fetched = self.adapter.client.get_all_by_query(table, query)
         if len(fetched) == 1:
             self.adapter.register_sn_record(table, fetched[0])
         return fetched

--- a/nautobot_ssot/integrations/servicenow/exceptions.py
+++ b/nautobot_ssot/integrations/servicenow/exceptions.py
@@ -10,6 +10,7 @@ class ServiceNowReferenceError(Exception):  # pylint: disable=too-many-instance-
 
     cause = "could not be resolved"
     remedy = ""
+    remedy_unapplied = ""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -62,8 +63,9 @@ class ServiceNowReferenceError(Exception):  # pylint: disable=too-many-instance-
                 f"; could not narrow the lookup by {', '.join(self.unapplied)} "
                 "because those values were not available"
             )
-        if self.remedy:
-            message += f". {self.remedy}"
+        remedy = self.remedy_unapplied if self.unapplied else self.remedy
+        if remedy:
+            message += f". {remedy}"
         return message
 
     def as_csv_row(self):
@@ -91,6 +93,10 @@ class AmbiguousReferenceError(ServiceNowReferenceError):
 
     cause = "matched more than one record"
     remedy = "Add a `match` clause to this reference in mappings.yaml, or de-duplicate the ServiceNow records"
+    remedy_unapplied = (
+        "Populate those fields on the record being synced so the `match` clause can be applied, or "
+        "de-duplicate the ServiceNow records"
+    )
 
 
 class MissingReferenceError(ServiceNowReferenceError):

--- a/nautobot_ssot/integrations/servicenow/exceptions.py
+++ b/nautobot_ssot/integrations/servicenow/exceptions.py
@@ -1,0 +1,100 @@
+"""Exceptions specific to the ServiceNow SSoT integration."""
+
+
+class ServiceNowReferenceError(Exception):  # pylint: disable=too-many-instance-attributes
+    """A ServiceNow reference (foreign key) field could not be resolved to exactly one record.
+
+    Raising rather than returning None is deliberate: a swallowed lookup failure used to leave the
+    reference column unwritten while the sync still reported success.
+    """
+
+    cause = "could not be resolved"
+    remedy = ""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        *,
+        table,
+        column,
+        value,
+        modelname=None,
+        unique_id=None,
+        field=None,
+        candidates=None,
+        unapplied=None,
+    ):
+        """Record everything needed to tell the user which write was skipped and why.
+
+        Args:
+            table (str): ServiceNow table that was queried.
+            column (str): Column of `table` used as the lookup key.
+            value: Value that was looked up in `column`.
+            modelname (str): DiffSync model name of the record being written, if known.
+            unique_id (str): DiffSync unique ID of the record being written, if known.
+            field (str): DiffSync field whose value could not be resolved, if known.
+            candidates (list): sys_ids of the records that matched, when more than one did.
+            unapplied (list): Disambiguating fields that were unavailable, and so were not applied.
+        """
+        self.table = table
+        self.column = column
+        self.value = value
+        self.modelname = modelname
+        self.unique_id = unique_id
+        self.field = field
+        self.candidates = list(candidates or [])
+        self.unapplied = list(unapplied or [])
+        super().__init__(self._describe())
+
+    def _describe(self):
+        """Render the single-line diagnostic used for log messages."""
+        subject = "Reference lookup"
+        if self.modelname:
+            subject = self.modelname
+            if self.unique_id:
+                subject += f' "{self.unique_id}"'
+            if self.field:
+                subject += f' field "{self.field}"'
+        message = f'{subject}: {self.cause} in ServiceNow table "{self.table}" for {self.column}="{self.value}"'
+        if self.candidates:
+            message += f" (candidate sys_ids: {', '.join(self.candidates)})"
+        if self.unapplied:
+            message += (
+                f"; could not narrow the lookup by {', '.join(self.unapplied)} "
+                "because those values were not available"
+            )
+        if self.remedy:
+            message += f". {self.remedy}"
+        return message
+
+    def as_csv_row(self):
+        """Render as a row for the `unresolved_references.txt` job artifact."""
+        fields = [
+            self.modelname or "",
+            self.unique_id or "",
+            self.field or "",
+            str(self.value),
+            self.table,
+            self.column,
+            self.cause,
+            " ".join(self.candidates),
+        ]
+        return ",".join(f'"{field}"' for field in fields)
+
+    @staticmethod
+    def csv_header():
+        """Header row matching `as_csv_row`."""
+        return "modelname,unique_id,field,value,table,column,cause,candidate_sys_ids"
+
+
+class AmbiguousReferenceError(ServiceNowReferenceError):
+    """More than one record in the referenced ServiceNow table matched the lookup."""
+
+    cause = "matched more than one record"
+    remedy = "Add a `match` clause to this reference in mappings.yaml, or de-duplicate the ServiceNow records"
+
+
+class MissingReferenceError(ServiceNowReferenceError):
+    """No record in the referenced ServiceNow table matched the lookup."""
+
+    cause = "matched no record"
+    remedy = "Create the referenced record in ServiceNow, or sync it before the record that references it"

--- a/nautobot_ssot/integrations/servicenow/servicenow.py
+++ b/nautobot_ssot/integrations/servicenow/servicenow.py
@@ -4,6 +4,8 @@ import logging
 
 import requests  # pylint: disable=wrong-import-order
 
+from nautobot_ssot.integrations.servicenow.exceptions import AmbiguousReferenceError
+
 # from pysnow import Client
 from nautobot_ssot.integrations.servicenow.third_party.pysnow import Client
 
@@ -27,6 +29,11 @@ class ServiceNowClient(Client):
         # We don't need the link for our purposes, and including it makes it harder to preserve idempotence.
         self.parameters.exclude_reference_link = True
 
+    @property
+    def logger(self):
+        """Prefer the Job logger when a Job is attached; fallback to the module logger."""
+        return self.worker.logger if self.worker is not None else logger
+
     def all_table_entries(self, table, query=None, fields=None, limit=10000):
         """Iterator over all records in a given table, paginating through the full result set.
 
@@ -40,7 +47,8 @@ class ServiceNowClient(Client):
         if not query:
             query = {}
         fields = fields or []
-        logger.debug("Getting all entries in table %s matching query %s", table, query)
+        if self.worker and self.worker.debug:
+            self.logger.debug("Getting all entries in table %s matching query %s", table, query)
         offset = 0
         while True:
             count = 0
@@ -61,18 +69,44 @@ class ServiceNowClient(Client):
         return self.get_by_query(table, {"sys_id": sys_id})
 
     def get_by_query(self, table, query):
-        """Get a specific record from a given table."""
-        logger.debug("Querying table %s with query %s", table, query)
+        """Get a specific record from a given table.
+
+        Returns None if the query matched nothing, or if ServiceNow rejected the request.
+
+        Raises:
+            AmbiguousReferenceError: If more than one record matched. Callers that write a reference field
+                must not silently skip the field, so ambiguity is surfaced rather than collapsed to None.
+        """
+        if self.worker and self.worker.debug:
+            self.logger.debug("Querying table %s with query %s", table, query)
         try:
             result = self.resource(api_path=f"/table/{table}").get(query=query).one_or_none()
         except requests.exceptions.HTTPError as exc:
             # Raised if for example we get a 400 response because we're querying a nonexistent table
-            logger.error("HTTP error encountered: %s", exc)
+            self.logger.error("HTTP error encountered: %s", exc)
             return None
-        except MultipleResults:
-            logger.error('Multiple results unexpectedly returned when querying table "%s" with "%s"', table, query)
-            return None
+        except MultipleResults as exc:
+            column, value = next(iter(query.items())) if len(query) == 1 else (str(sorted(query)), query)
+            raise AmbiguousReferenceError(table=table, column=column, value=value) from exc
 
         if not result:
-            logger.warning("Query %s did not match an object in table %s", query, table)
+            self.logger.warning("Query %s did not match an object in table %s", query, table)
         return result
+
+    def get_all_by_query(self, table, query, limit=100):
+        """Get every record matching a query in a given table.
+
+        Unlike `get_by_query`, this never raises on ambiguity: it is used by the write path, which needs to
+        report *which* records collided. The limit is intentionally small; callers only need to distinguish
+        zero from one from many, and to name a handful of candidates in an error message.
+
+        Returns:
+            list: Matching records, or an empty list if ServiceNow rejected the request.
+        """
+        if self.worker and self.worker.debug:
+            self.logger.debug("Querying table %s for all records matching query %s", table, query)
+        try:
+            return list(self.resource(api_path=f"/table/{table}").get(query=query, limit=limit).all())
+        except requests.exceptions.HTTPError as exc:
+            self.logger.error("HTTP error encountered: %s", exc)
+            return []

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -880,6 +880,29 @@ class AmbiguousReferenceWarningTestCase(TestCase):
         adapter.warn_about_ambiguous_references()
         adapter.job.logger.warning.assert_not_called()
 
+    def test_records_with_an_empty_lookup_value_are_not_reported(self):
+        """A null source value never triggers a lookup, so these records can never collide."""
+        adapter = self._adapter(
+            [
+                {"sys_id": "m1", "name": "", "manufacturer": ""},
+                {"sys_id": "m2", "name": "", "manufacturer": ""},
+                {"sys_id": "m3", "name": "", "manufacturer": "c1"},
+            ]
+        )
+        adapter.warn_about_ambiguous_references()
+        adapter.job.logger.warning.assert_not_called()
+
+    def test_an_empty_match_column_still_reports_a_name_collision(self):
+        """Only the lookup column itself being empty makes a record unreachable, not a match column."""
+        adapter = self._adapter(
+            [
+                {"sys_id": "m1", "name": "Unknown", "manufacturer": ""},
+                {"sys_id": "m2", "name": "Unknown", "manufacturer": ""},
+            ]
+        )
+        adapter.warn_about_ambiguous_references()
+        self.assertIn("Unknown", str(adapter.job.logger.warning.call_args))
+
 
 class ServiceNowModelUpdateTestCase(TestCase):
     """Test that ServiceNowCRUDMixin.update writes and verifies only the mapped, changed fields."""

--- a/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_adapter_servicenow.py
@@ -4,13 +4,16 @@ from collections import defaultdict
 from itertools import islice
 from unittest.mock import MagicMock
 
+import requests
 from nautobot.apps.testing import TestCase
 from nautobot.extras.models import JobResult
 
 from nautobot_ssot.integrations.servicenow.diffsync import models
 from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
+from nautobot_ssot.integrations.servicenow.exceptions import AmbiguousReferenceError
 from nautobot_ssot.integrations.servicenow.jobs import ServiceNowDataTarget
 from nautobot_ssot.integrations.servicenow.servicenow import ServiceNowClient
+from nautobot_ssot.integrations.servicenow.third_party.pysnow.exceptions import MultipleResults
 
 
 class MockServiceNowClient:
@@ -646,6 +649,7 @@ class ServiceNowClientPaginationTestCase(TestCase):
     @staticmethod
     def _client_returning(rows):
         client = ServiceNowClient.__new__(ServiceNowClient)
+        client.worker = None
         calls = []
 
         def resource(api_path=None):  # pylint: disable=unused-argument
@@ -678,6 +682,7 @@ class ServiceNowClientPaginationTestCase(TestCase):
         server_cap = 4576
         rows = [{"sys_id": f"id{i}"} for i in range(12934)]
         client = ServiceNowClient.__new__(ServiceNowClient)
+        client.worker = None
         calls = []
 
         def resource(api_path=None):  # pylint: disable=unused-argument
@@ -733,6 +738,7 @@ class ServiceNowClientPaginationTestCase(TestCase):
                     yield {"sys_id": f"id{i}"}
 
         client = ServiceNowClient.__new__(ServiceNowClient)
+        client.worker = None
 
         def resource(api_path=None):  # pylint: disable=unused-argument
             res = MagicMock()
@@ -752,6 +758,74 @@ class ServiceNowClientPaginationTestCase(TestCase):
         self.assertEqual(pages[0].pulled, 3)
 
 
+class ServiceNowClientReferenceTestCase(TestCase):
+    """Test that reference lookups distinguish "no match" from "multiple matches"."""
+
+    TABLE = "cmdb_hardware_product_model"
+    QUERY = {"name": "C9300-48P"}
+
+    @staticmethod
+    def _client(response=None, get_error=None):
+        """Build a client whose resource().get() returns `response`, or raises `get_error`."""
+        client = ServiceNowClient.__new__(ServiceNowClient)
+        client.worker = None
+        resource = MagicMock()
+        if get_error is not None:
+            resource.get.side_effect = get_error
+        else:
+            resource.get.return_value = response
+        client.resource = MagicMock(return_value=resource)
+        return client, resource
+
+    @staticmethod
+    def _response(one_or_none=None, error=None, rows=None):
+        response = MagicMock()
+        if error is not None:
+            response.one_or_none.side_effect = error
+        else:
+            response.one_or_none.return_value = one_or_none
+        response.all.return_value = iter(rows or [])
+        return response
+
+    def test_get_by_query_raises_on_multiple_results(self):
+        """Ambiguity must be raised, not collapsed to None, so callers cannot silently skip the field."""
+        client, _ = self._client(self._response(error=MultipleResults("Expected single-record result")))
+        with self.assertRaises(AmbiguousReferenceError) as context:
+            client.get_by_query(self.TABLE, self.QUERY)
+        self.assertEqual(context.exception.table, self.TABLE)
+        self.assertEqual(context.exception.column, "name")
+        self.assertEqual(context.exception.value, "C9300-48P")
+
+    def test_get_by_query_returns_none_on_http_error(self):
+        """An HTTP error (e.g. a nonexistent table) is still tolerated by the load path."""
+        client, _ = self._client(get_error=requests.exceptions.HTTPError("400 Client Error"))
+        self.assertIsNone(client.get_by_query(self.TABLE, self.QUERY))
+
+    def test_get_by_query_returns_none_when_no_match(self):
+        """A genuine miss is still None; only ambiguity changes behavior."""
+        client, _ = self._client(self._response(one_or_none=None))
+        self.assertIsNone(client.get_by_query(self.TABLE, self.QUERY))
+
+    def test_get_all_by_query_returns_every_candidate(self):
+        """The write path needs all candidates so it can report which records collided."""
+        rows = [{"sys_id": "aaa", "name": "C9300-48P"}, {"sys_id": "bbb", "name": "C9300-48P"}]
+        client, resource = self._client(self._response(rows=rows))
+        self.assertEqual(client.get_all_by_query(self.TABLE, self.QUERY), rows)
+        self.assertEqual(resource.get.call_args.kwargs["query"], self.QUERY)
+        self.assertEqual(resource.get.call_args.kwargs["limit"], 100)
+
+    def test_get_all_by_query_returns_empty_list_on_http_error(self):
+        client, _ = self._client(get_error=requests.exceptions.HTTPError("400 Client Error"))
+        self.assertEqual(client.get_all_by_query(self.TABLE, self.QUERY), [])
+
+    def test_diagnostics_reach_the_job_log(self):
+        """Client-side diagnostics must reach the Job Result, not only the module logger."""
+        client, _ = self._client(self._response(one_or_none=None))
+        client.worker = MagicMock()
+        client.get_by_query(self.TABLE, self.QUERY)
+        client.worker.logger.warning.assert_called_once()
+
+
 class FieldsForMappingsTestCase(TestCase):
     """Test sysparm_fields derivation from the YAML mappings."""
 
@@ -769,6 +843,42 @@ class FieldsForMappingsTestCase(TestCase):
             ServiceNowDiffSync.fields_for_mappings(mappings),
             ["manufacturer", "model_number", "name", "sys_id"],
         )
+
+
+class AmbiguousReferenceWarningTestCase(TestCase):
+    """Test that duplicates which will break the next sync are surfaced during load, dry run included."""
+
+    @staticmethod
+    def _adapter(product_models):
+        adapter = ServiceNowDiffSync(client=MagicMock(), job=MagicMock())
+        adapter.mapping_data = ServiceNowDiffSync.load_yaml_datafile("mappings.yaml")
+        adapter.sys_ids = {"cmdb_hardware_product_model": {record["sys_id"]: record for record in product_models}}
+        return adapter
+
+    def test_indistinguishable_records_are_reported(self):
+        """A dry run never writes, so it never resolves a reference; the collision must surface at load."""
+        adapter = self._adapter(
+            [
+                {"sys_id": "m1", "name": "C9300-48P", "manufacturer": "c1"},
+                {"sys_id": "m2", "name": "C9300-48P", "manufacturer": "c1"},
+            ]
+        )
+        adapter.warn_about_ambiguous_references()
+        warning = str(adapter.job.logger.warning.call_args)
+        self.assertIn("cmdb_hardware_product_model", warning)
+        self.assertIn("C9300-48P", warning)
+        self.assertIn("model_name", warning)
+
+    def test_records_separated_by_the_match_column_are_not_reported(self):
+        """Same model name under different manufacturers is exactly what the `match` clause resolves."""
+        adapter = self._adapter(
+            [
+                {"sys_id": "m1", "name": "C9300-48P", "manufacturer": "c1"},
+                {"sys_id": "m2", "name": "C9300-48P", "manufacturer": "c2"},
+            ]
+        )
+        adapter.warn_about_ambiguous_references()
+        adapter.job.logger.warning.assert_not_called()
 
 
 class ServiceNowModelUpdateTestCase(TestCase):

--- a/nautobot_ssot/tests/servicenow/test_mappings_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_mappings_servicenow.py
@@ -1,0 +1,118 @@
+"""Unit tests for the shipped ServiceNow mappings.yaml and its `match` clause rules."""
+
+from nautobot.apps.testing import TestCase
+
+from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
+
+
+def validate_mappings(mapping_data):
+    """Check that every `match` clause in a set of mappings can actually be applied.
+
+    Each of these mistakes would fail quietly in production: the clause would never narrow anything, and the
+    ambiguity it was added to prevent would come back as a per-object sync failure.
+
+    Raises:
+        ValueError: If a `match` entry names no value source, refers to a reference key that is not resolved
+            earlier in the same mapping list, or matches on a column the referenced model does not load.
+    """
+    fields_by_table = {
+        entry["table"]: ServiceNowDiffSync.fields_for_mappings(entry["mappings"]) for entry in mapping_data.values()
+    }
+    for modelname, entry in mapping_data.items():
+        resolved_keys = set()
+        for mapping in entry["mappings"]:
+            reference = mapping.get("reference", {})
+            for match in reference.get("match", []):
+                where = f"{modelname}.{mapping['field']} match on column `{match.get('column')}`"
+                if not match.get("key") and not match.get("field"):
+                    raise ValueError(f"{where} names neither a `key` nor a `field` to take its value from.")
+                if match.get("key") and match["key"] not in resolved_keys:
+                    raise ValueError(
+                        f"{where} uses key `{match['key']}`, which is not resolved by an earlier "
+                        f"mapping of `{modelname}`."
+                    )
+                referenced_fields = fields_by_table.get(reference["table"])
+                if referenced_fields is not None and match["column"] not in referenced_fields:
+                    raise ValueError(
+                        f"{where} is not among the columns loaded from table `{reference['table']}`, "
+                        "so no loaded record will ever carry it."
+                    )
+            if "key" in reference:
+                resolved_keys.add(reference["key"])
+
+
+class MappingsYamlTestCase(TestCase):
+    """Test the shipped mappings.yaml itself against the `match` clause rules."""
+
+    PRODUCT_MODEL_MAPPINGS = [
+        {"field": "manufacturer_name", "reference": {"key": "manufacturer", "table": "core_company", "column": "name"}},
+        {"field": "model_name", "column": "name"},
+    ]
+    MANUFACTURER_MAPPING = {
+        "field": "manufacturer_name",
+        "reference": {"key": "manufacturer", "table": "core_company", "column": "name"},
+    }
+
+    @classmethod
+    def _mapping_data(cls, match, product_model_mappings=None, device_mappings=None):
+        """Build a two-model mapping_data whose device.model_name reference carries `match`."""
+        model_mapping = {
+            "field": "model_name",
+            "reference": {
+                "key": "model_id",
+                "table": "cmdb_hardware_product_model",
+                "column": "name",
+                "match": match,
+            },
+        }
+        return {
+            "product_model": {
+                "table": "cmdb_hardware_product_model",
+                "mappings": cls.PRODUCT_MODEL_MAPPINGS if product_model_mappings is None else product_model_mappings,
+            },
+            "device": {
+                "table": "cmdb_ci_ip_switch",
+                "mappings": ([cls.MANUFACTURER_MAPPING, model_mapping] if device_mappings is None else device_mappings),
+            },
+        }
+
+    def test_device_model_reference_is_disambiguated_by_manufacturer(self):
+        """`cmdb_hardware_product_model.name` is not unique across manufacturers, so `name` alone collides."""
+        mapping_data = ServiceNowDiffSync.load_yaml_datafile("mappings.yaml")
+        model_mapping = next(
+            mapping for mapping in mapping_data["device"]["mappings"] if mapping["field"] == "model_name"
+        )
+        match_columns = [entry["column"] for entry in model_mapping["reference"].get("match", [])]
+        self.assertIn("manufacturer", match_columns)
+
+    def test_shipped_mappings_pass_validation(self):
+        validate_mappings(ServiceNowDiffSync.load_yaml_datafile("mappings.yaml"))
+
+    def test_match_entry_must_name_a_value_source(self):
+        """A match entry with no `key` and no `field` can never be applied, so it silently does nothing."""
+        with self.assertRaises(ValueError):
+            validate_mappings(self._mapping_data([{"column": "manufacturer"}]))
+
+    def test_match_key_must_be_resolved_earlier_in_the_mapping(self):
+        """References resolve in order, so a `key` defined later is never available when it is needed."""
+        model_mapping = {
+            "field": "model_name",
+            "reference": {
+                "key": "model_id",
+                "table": "cmdb_hardware_product_model",
+                "column": "name",
+                "match": [{"column": "manufacturer", "key": "manufacturer"}],
+            },
+        }
+        with self.assertRaises(ValueError):
+            validate_mappings(self._mapping_data(None, device_mappings=[model_mapping, self.MANUFACTURER_MAPPING]))
+
+    def test_match_column_must_be_loaded_for_the_referenced_table(self):
+        """A column the referenced model never loads is absent from every record, so it can never match."""
+        with self.assertRaises(ValueError):
+            validate_mappings(
+                self._mapping_data(
+                    [{"column": "manufacturer", "field": "manufacturer_name"}],
+                    product_model_mappings=[{"field": "model_name", "column": "name"}],
+                )
+            )

--- a/nautobot_ssot/tests/servicenow/test_models_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_models_servicenow.py
@@ -1,0 +1,417 @@
+"""Unit tests for the ServiceNow DiffSync model write path."""
+
+import json
+from base64 import b64decode
+from collections import defaultdict
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+from diffsync.enum import DiffSyncStatus
+from diffsync.exceptions import ObjectNotCreated, ObjectNotDeleted, ObjectNotUpdated
+from nautobot.apps.testing import TestCase
+
+from nautobot_ssot.integrations.servicenow.diffsync import models
+from nautobot_ssot.integrations.servicenow.diffsync.adapter_servicenow import ServiceNowDiffSync
+from nautobot_ssot.integrations.servicenow.exceptions import AmbiguousReferenceError, MissingReferenceError
+from nautobot_ssot.integrations.servicenow.third_party.pysnow.exceptions import MultipleResults
+
+MODELS_TABLE = "cmdb_hardware_product_model"
+DEVICE_TABLE = "cmdb_ci_ip_switch"
+
+CISCO_SYS_ID = "c0000000000000000000000000000001"
+ACME_SYS_ID = "c0000000000000000000000000000002"
+CISCO_MODEL_SYS_ID = "m0000000000000000000000000000001"
+ACME_MODEL_SYS_ID = "m0000000000000000000000000000002"
+
+MANUFACTURER_MATCH = [
+    {
+        "column": "manufacturer",
+        "key": "manufacturer",
+        "field": "manufacturer_name",
+        "reference": {"table": "core_company", "column": "name"},
+    }
+]
+
+
+def device_entry(match=None):
+    """Build a `device` mapping entry, optionally disambiguating the model_name reference by `match`."""
+    model_reference = {"key": "model_id", "table": "cmdb_hardware_product_model", "column": "name"}
+    if match:
+        model_reference["match"] = match
+    return {
+        "table": "cmdb_ci_ip_switch",
+        "mappings": [
+            {"field": "name", "column": "name"},
+            {
+                "field": "manufacturer_name",
+                "reference": {"key": "manufacturer", "table": "core_company", "column": "name"},
+            },
+            {"field": "model_name", "reference": model_reference},
+        ],
+    }
+
+
+def interface_entry():
+    """Build an `interface` mapping entry, whose device_name is a reference to the device table."""
+    return {
+        "table": "cmdb_ci_network_adapter",
+        "mappings": [
+            {"field": "name", "column": "name"},
+            {"field": "device_name", "reference": {"key": "cmdb_ci", "table": DEVICE_TABLE, "column": "name"}},
+        ],
+    }
+
+
+def build_adapter(entry, sys_ids=None, candidates=None, result=None):
+    """Build a ServiceNow adapter whose client returns `candidates` for every reference query.
+
+    `result` is what the mocked ServiceNow resource returns from create/update/get.
+    """
+    resource = MagicMock()
+    response = MagicMock()
+    response.one.return_value = result if result is not None else {}
+    resource.create.return_value = response
+    resource.update.return_value = response
+    resource.get.return_value = response
+    client = MagicMock()
+    client.get_all_by_query.return_value = list(candidates or [])
+    client.resource.return_value = resource
+    adapter = ServiceNowDiffSync(client=client, job=MagicMock())
+    adapter.job.debug = False
+    adapter.mapping_data = {"device": entry, "interface": interface_entry()}
+    adapter.sys_ids = sys_ids or {}
+    # objects_to_delete is a class attribute on the adapter, so shadow it to keep tests independent.
+    adapter.objects_to_delete = defaultdict(list)
+    return adapter
+
+
+class ReferenceResolutionTestCase(TestCase):
+    """Test that a reference either resolves to exactly one sys_id or raises."""
+
+    def test_unresolvable_reference_raises_instead_of_writing_null(self):
+        """A reference that matches nothing must not be silently written as a null column."""
+        adapter = build_adapter(device_entry(), candidates=[])
+        device = models.Device(name="switch1", adapter=adapter)
+        with self.assertRaises(MissingReferenceError):
+            device.map_data_to_sn_record(
+                data={"name": "switch1", "model_name": "C9300-48P"},
+                mapping_entry=adapter.mapping_data["device"],
+            )
+
+    def test_null_source_value_still_clears_the_reference(self):
+        """A genuinely null value is an intentional clear, not a resolution failure."""
+        adapter = build_adapter(device_entry())
+        device = models.Device(name="switch1", adapter=adapter)
+        record = device.map_data_to_sn_record(data={"model_name": None}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(record, {"model_id": None})
+        adapter.client.get_all_by_query.assert_not_called()
+
+    def test_single_match_resolves(self):
+        """A reference with no `match` clause and exactly one matching record still resolves."""
+        adapter = build_adapter(device_entry(), candidates=[{"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P"}])
+        device = models.Device(name="switch1", adapter=adapter)
+        record = device.map_data_to_sn_record(
+            data={"model_name": "C9300-48P"}, mapping_entry=adapter.mapping_data["device"]
+        )
+        self.assertEqual(record, {"model_id": CISCO_MODEL_SYS_ID})
+
+
+class InMemoryReferenceResolutionTestCase(TestCase):
+    """Test that references resolve from records already pulled at load time, without extra API calls."""
+
+    def test_resolves_from_loaded_records_without_querying(self):
+        """The load already fetched every candidate record; re-querying ServiceNow is wasted and ambiguous."""
+        adapter = build_adapter(
+            device_entry(),
+            sys_ids={MODELS_TABLE: {CISCO_MODEL_SYS_ID: {"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P"}}},
+        )
+        device = models.Device(name="switch1", adapter=adapter)
+        record = device.map_data_to_sn_record(
+            data={"model_name": "C9300-48P"}, mapping_entry=adapter.mapping_data["device"]
+        )
+        self.assertEqual(record, {"model_id": CISCO_MODEL_SYS_ID})
+        adapter.client.get_all_by_query.assert_not_called()
+
+    def test_duplicate_loaded_records_raise_naming_every_candidate(self):
+        """Ambiguity found in memory is reported directly; querying would only re-derive it."""
+        adapter = build_adapter(
+            device_entry(),
+            sys_ids={
+                MODELS_TABLE: {
+                    CISCO_MODEL_SYS_ID: {
+                        "sys_id": CISCO_MODEL_SYS_ID,
+                        "name": "C9300-48P",
+                        "manufacturer": CISCO_SYS_ID,
+                    },
+                    ACME_MODEL_SYS_ID: {
+                        "sys_id": ACME_MODEL_SYS_ID,
+                        "name": "C9300-48P",
+                        "manufacturer": ACME_SYS_ID,
+                    },
+                }
+            },
+        )
+        device = models.Device(name="switch1", adapter=adapter)
+        with self.assertRaises(AmbiguousReferenceError) as context:
+            device.map_data_to_sn_record(data={"model_name": "C9300-48P"}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(sorted(context.exception.candidates), sorted([ACME_MODEL_SYS_ID, CISCO_MODEL_SYS_ID]))
+        self.assertIn(CISCO_MODEL_SYS_ID, str(context.exception))
+        adapter.client.get_all_by_query.assert_not_called()
+
+    def test_api_fallback_registers_the_record_for_reuse(self):
+        """A record resolved via the API joins the loaded set, so an identical lookup does not query again."""
+        adapter = build_adapter(device_entry(), candidates=[{"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P"}])
+        device = models.Device(name="switch1", adapter=adapter)
+        for _ in range(2):
+            device.map_data_to_sn_record(data={"model_name": "C9300-48P"}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(adapter.client.get_all_by_query.call_count, 1)
+        self.assertIn(CISCO_MODEL_SYS_ID, adapter.sys_ids[MODELS_TABLE])
+
+
+class ReferenceMatchTestCase(TestCase):
+    """Test that a `match` clause disambiguates a reference whose lookup column is not unique."""
+
+    SYS_IDS = {
+        "core_company": {
+            CISCO_SYS_ID: {"sys_id": CISCO_SYS_ID, "name": "Cisco"},
+            ACME_SYS_ID: {"sys_id": ACME_SYS_ID, "name": "Acme"},
+        },
+        MODELS_TABLE: {
+            CISCO_MODEL_SYS_ID: {"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P", "manufacturer": CISCO_SYS_ID},
+            ACME_MODEL_SYS_ID: {"sys_id": ACME_MODEL_SYS_ID, "name": "C9300-48P", "manufacturer": ACME_SYS_ID},
+        },
+    }
+
+    def test_match_selects_the_model_belonging_to_the_manufacturer(self):
+        """Two manufacturers sharing a model name collide on `name` alone; `manufacturer` separates them."""
+        adapter = build_adapter(device_entry(MANUFACTURER_MATCH), sys_ids=deepcopy(self.SYS_IDS))
+        device = models.Device(name="switch1", adapter=adapter)
+        record = device.map_data_to_sn_record(
+            data={"manufacturer_name": "Acme", "model_name": "C9300-48P"},
+            mapping_entry=adapter.mapping_data["device"],
+        )
+        self.assertEqual(record, {"manufacturer": ACME_SYS_ID, "model_id": ACME_MODEL_SYS_ID})
+        adapter.client.get_all_by_query.assert_not_called()
+
+    def test_match_falls_back_to_context_when_the_sibling_key_is_not_being_written(self):
+        """On update, `data` holds only the changed attribute, so the sibling sys_id is not in the payload."""
+        adapter = build_adapter(device_entry(MANUFACTURER_MATCH), sys_ids=deepcopy(self.SYS_IDS))
+        device = models.Device(name="switch1", adapter=adapter)
+        record = device.map_data_to_sn_record(
+            data={"model_name": "C9300-48P"},
+            mapping_entry=adapter.mapping_data["device"],
+            context={"manufacturer_name": "Cisco"},
+        )
+        self.assertEqual(record, {"model_id": CISCO_MODEL_SYS_ID})
+
+    def test_ambiguity_report_names_the_field_it_could_not_narrow_by(self):
+        """When the disambiguating value is unavailable, say so: that is the actionable part."""
+        adapter = build_adapter(device_entry(MANUFACTURER_MATCH), sys_ids=deepcopy(self.SYS_IDS))
+        device = models.Device(name="switch1", adapter=adapter)
+        with self.assertRaises(AmbiguousReferenceError) as context:
+            device.map_data_to_sn_record(data={"model_name": "C9300-48P"}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(context.exception.unapplied, ["manufacturer_name"])
+        self.assertIn("manufacturer_name", str(context.exception))
+
+    def test_api_fallback_query_carries_every_match_column(self):
+        """A store miss must query on the disambiguating columns too, not just the ambiguous one."""
+        adapter = build_adapter(
+            device_entry(MANUFACTURER_MATCH),
+            sys_ids={"core_company": deepcopy(self.SYS_IDS["core_company"])},
+            candidates=[{"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P", "manufacturer": CISCO_SYS_ID}],
+        )
+        device = models.Device(name="switch1", adapter=adapter)
+        device.map_data_to_sn_record(
+            data={"manufacturer_name": "Cisco", "model_name": "C9300-48P"},
+            mapping_entry=adapter.mapping_data["device"],
+        )
+        self.assertEqual(
+            adapter.client.get_all_by_query.call_args.args,
+            (MODELS_TABLE, {"name": "C9300-48P", "manufacturer": CISCO_SYS_ID}),
+        )
+
+
+class CreateFailureTestCase(TestCase):
+    """Test that an unresolvable reference fails the create rather than writing an incomplete record."""
+
+    def test_unresolved_reference_fails_the_create_without_writing(self):
+        """Writing the record anyway would leave the reference column unset while the sync reported success."""
+        adapter = build_adapter(device_entry(), candidates=[])
+        with self.assertRaises(ObjectNotCreated):
+            models.Device.create(adapter, ids={"name": "switch1"}, attrs={"model_name": "C9300-48P"})
+        adapter.client.resource.return_value.create.assert_not_called()
+
+    def test_unresolved_reference_is_reported_and_recorded(self):
+        """The user needs to know which record, field and value were skipped, and why."""
+        adapter = build_adapter(device_entry(), candidates=[])
+        with self.assertRaises(ObjectNotCreated):
+            models.Device.create(adapter, ids={"name": "switch1"}, attrs={"model_name": "C9300-48P"})
+        self.assertEqual(len(adapter.unresolved_references), 1)
+        logged = str(adapter.job.logger.error.call_args)
+        for expected in ("device", "switch1", "model_name", "C9300-48P", MODELS_TABLE):
+            self.assertIn(expected, logged)
+
+
+class UpdateFailureTestCase(TestCase):
+    """Test that a failed update is reported as a failure, not as a silent no-op."""
+
+    def _device(self, adapter, **attrs):
+        return models.Device(name="switch1", adapter=adapter, sys_id="abc123", **attrs)
+
+    def test_unresolved_reference_fails_the_update_without_writing(self):
+        adapter = build_adapter(device_entry(), candidates=[])
+        with self.assertRaises(ObjectNotUpdated):
+            self._device(adapter).update({"model_name": "C9300-48P"})
+        adapter.client.resource.return_value.update.assert_not_called()
+        self.assertEqual(len(adapter.unresolved_references), 1)
+
+    def test_ambiguous_update_query_fails_instead_of_returning_none(self):
+        """Returning None left diffsync believing the update had succeeded."""
+        adapter = build_adapter(device_entry())
+        adapter.client.resource.return_value.update.side_effect = MultipleResults("got multiple")
+        with self.assertRaises(ObjectNotUpdated):
+            self._device(adapter).update({"asset_tag": "NEW-TAG"})
+
+    def test_context_supplies_sibling_fields_absent_from_the_payload(self):
+        """An update payload holds only the changed attribute, but the lookup still needs the manufacturer."""
+        adapter = build_adapter(
+            device_entry(MANUFACTURER_MATCH),
+            sys_ids=deepcopy(ReferenceMatchTestCase.SYS_IDS),
+            result={"sys_id": "abc123", "model_id": CISCO_MODEL_SYS_ID},
+        )
+        device = self._device(adapter, manufacturer_name="Cisco")
+        device.update({"model_name": "C9300-48P"})
+        payload = adapter.client.resource.return_value.update.call_args.kwargs["payload"]
+        self.assertEqual(payload, {"model_id": CISCO_MODEL_SYS_ID})
+
+
+class DeleteFailureTestCase(TestCase):
+    """Test that a delete that cannot be targeted is reported as a failure."""
+
+    def test_ambiguous_delete_query_raises_and_says_delete(self):
+        adapter = build_adapter(device_entry())
+        adapter.client.resource.return_value.get.return_value.one.side_effect = MultipleResults("got multiple")
+        with self.assertRaises(ObjectNotDeleted):
+            models.Device(name="switch1", adapter=adapter, sys_id="abc123").delete()
+        self.assertIn("delete", str(adapter.job.logger.error.call_args).lower())
+        self.assertNotIn("record to update", str(adapter.job.logger.error.call_args))
+
+    def test_unresolved_reference_fails_the_delete(self):
+        """A reference that will not resolve makes the delete query match the wrong records, or none."""
+        adapter = build_adapter(device_entry(), candidates=[])
+        interface = models.Interface(name="Ethernet1/1", device_name="switch1", adapter=adapter)
+        with self.assertRaises(ObjectNotDeleted):
+            interface.delete()
+        self.assertEqual(adapter.objects_to_delete["interface"], [])
+        self.assertEqual(len(adapter.unresolved_references), 1)
+
+
+class CreateRegistrationTestCase(TestCase):
+    """Test that a newly created record can be referenced by objects created later in the same run."""
+
+    RESULT = {"sys_id": "new123", "name": "switch1"}
+
+    def test_create_captures_the_new_sys_id(self):
+        """The sys_id returned by ServiceNow was discarded, leaving the model unable to identify itself."""
+        adapter = build_adapter(device_entry(), result=self.RESULT)
+        model = models.Device.create(adapter, ids={"name": "switch1"}, attrs={})
+        self.assertEqual(model.sys_id, "new123")
+        self.assertIn("new123", adapter.sys_ids[DEVICE_TABLE])
+
+    def test_interface_of_a_new_device_resolves_without_a_query(self):
+        """A device created moments ago is in hand; its interfaces should not have to look it up."""
+        adapter = build_adapter(device_entry(), result=self.RESULT)
+        models.Device.create(adapter, ids={"name": "switch1"}, attrs={})
+        interface = models.Interface(name="Ethernet1/1", device_name="switch1", adapter=adapter)
+        record = interface.map_data_to_sn_record(
+            data={"device_name": "switch1"}, mapping_entry=adapter.mapping_data["interface"]
+        )
+        self.assertEqual(record, {"cmdb_ci": "new123"})
+        adapter.client.get_all_by_query.assert_not_called()
+
+
+class BulkCreateInterfacesTestCase(TestCase):
+    """Test that interfaces are not bulk-created against a device reference that did not resolve."""
+
+    @staticmethod
+    def _adapter(known_devices):
+        """Adapter whose loaded set contains only `known_devices`; anything else fails to resolve."""
+        adapter = build_adapter(
+            device_entry(),
+            sys_ids={DEVICE_TABLE: {f"sys-{name}": {"sys_id": f"sys-{name}", "name": name} for name in known_devices}},
+            candidates=[],
+        )
+        batch_response = MagicMock()
+        batch_response.status_code = 200
+        batch_response.json.return_value = {"unserviced_requests": []}
+        # bulk_create_interfaces reads the wrapped requests.Response off the pysnow response object.
+        adapter.client.resource.return_value.request.return_value._response = batch_response  # pylint: disable=protected-access
+        return adapter
+
+    def _queue(self, adapter, device_name, *interface_names):
+        adapter.interfaces_to_create_per_device[device_name] = [
+            models.Interface(name=name, device_name=device_name, adapter=adapter) for name in interface_names
+        ]
+        return adapter.interfaces_to_create_per_device[device_name]
+
+    def test_unresolvable_device_skips_the_batch_instead_of_creating_orphans(self):
+        """Sending a null cmdb_ci would create interfaces attached to nothing."""
+        adapter = self._adapter(known_devices=[])
+        interfaces = self._queue(adapter, "switch1", "Ethernet1/1", "Ethernet1/2")
+        adapter.bulk_create_interfaces()
+        adapter.client.resource.return_value.request.assert_not_called()
+        self.assertEqual(len(adapter.unresolved_references), 2)
+        for interface in interfaces:
+            self.assertEqual(interface.get_status()[0], DiffSyncStatus.FAILURE)
+
+    def test_one_failing_device_does_not_stop_the_next(self):
+        """A batch is per device; one device's bad reference must not cancel another device's interfaces."""
+        adapter = self._adapter(known_devices=["switch2"])
+        self._queue(adapter, "switch1", "Ethernet1/1")
+        self._queue(adapter, "switch2", "Ethernet1/1")
+        adapter.bulk_create_interfaces()
+        request = adapter.client.resource.return_value.request
+        self.assertEqual(request.call_count, 1)
+        payload = json.loads(request.call_args.kwargs["data"])
+        self.assertEqual(len(payload["rest_requests"]), 1)
+        body = json.loads(b64decode(payload["rest_requests"][0]["body"]).decode("utf-8"))
+        self.assertEqual(body["cmdb_ci"], "sys-switch2")
+
+
+class SyncCompleteReportTestCase(TestCase):
+    """Test that a run which skipped reference writes does not end up looking clean."""
+
+    @staticmethod
+    def _error():
+        return MissingReferenceError(
+            table=MODELS_TABLE,
+            column="name",
+            value="C9300-48P",
+            modelname="device",
+            unique_id="switch1",
+            field="model_name",
+        )
+
+    def test_unresolved_references_are_summarized_and_attached(self):
+        adapter = build_adapter(device_entry())
+        adapter.unresolved_references = [self._error()]
+        adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+        filename, contents = adapter.job.create_file.call_args.args
+        self.assertEqual(filename, "unresolved_references.txt")
+        self.assertIn("switch1", contents)
+        self.assertIn("model_name", contents)
+        self.assertIn("1 reference", str(adapter.job.logger.error.call_args))
+
+    def test_clean_run_reports_nothing(self):
+        adapter = build_adapter(device_entry())
+        adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+        adapter.job.create_file.assert_not_called()
+        adapter.job.logger.error.assert_not_called()
+
+    def test_a_failure_to_attach_the_report_does_not_sink_the_sync(self):
+        """Losing a whole sync to a report-file size limit would be absurd."""
+        adapter = build_adapter(device_entry())
+        adapter.unresolved_references = [self._error()]
+        adapter.job.create_file.side_effect = ValueError("file too large")
+        adapter.sync_complete(source=MagicMock(), diff=MagicMock())
+        adapter.job.logger.warning.assert_called()

--- a/nautobot_ssot/tests/servicenow/test_models_servicenow.py
+++ b/nautobot_ssot/tests/servicenow/test_models_servicenow.py
@@ -415,3 +415,68 @@ class SyncCompleteReportTestCase(TestCase):
         adapter.job.create_file.side_effect = ValueError("file too large")
         adapter.sync_complete(source=MagicMock(), diff=MagicMock())
         adapter.job.logger.warning.assert_called()
+
+
+class TableQueryOnFallbackTestCase(TestCase):
+    """Test that a reference lookup respects the target table's own `table_query` filter."""
+
+    COMPANY_ENTRY = {
+        "table": "core_company",
+        "table_query": {"manufacturer": "true"},
+        "mappings": [{"field": "name", "column": "name"}],
+    }
+
+    def _adapter(self):
+        adapter = build_adapter(
+            device_entry(),
+            candidates=[{"sys_id": CISCO_SYS_ID, "name": "Cisco"}],
+        )
+        adapter.mapping_data["company"] = self.COMPANY_ENTRY
+        return adapter
+
+    def test_fallback_query_applies_the_table_query(self):
+        """The load filters the table, so a fallback that ignores the filter can resolve an excluded record."""
+        adapter = self._adapter()
+        device = models.Device(name="switch1", adapter=adapter)
+        device.map_data_to_sn_record(data={"manufacturer_name": "Cisco"}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(
+            adapter.client.get_all_by_query.call_args.args,
+            ("core_company", {"manufacturer": "true", "name": "Cisco"}),
+        )
+
+    def test_lookup_criteria_win_over_the_table_query(self):
+        """A table_query must never override the column the reference is actually keyed on."""
+        adapter = self._adapter()
+        adapter.mapping_data["company"]["table_query"] = {"name": "Ignored"}
+        device = models.Device(name="switch1", adapter=adapter)
+        device.map_data_to_sn_record(data={"manufacturer_name": "Cisco"}, mapping_entry=adapter.mapping_data["device"])
+        self.assertEqual(adapter.client.get_all_by_query.call_args.args[1]["name"], "Cisco")
+
+
+class AmbiguityRemedyTestCase(TestCase):
+    """Test that the advice attached to an ambiguity error matches what actually went wrong."""
+
+    DUPLICATE_MODELS = {
+        MODELS_TABLE: {
+            CISCO_MODEL_SYS_ID: {"sys_id": CISCO_MODEL_SYS_ID, "name": "C9300-48P", "manufacturer": CISCO_SYS_ID},
+            ACME_MODEL_SYS_ID: {"sys_id": ACME_MODEL_SYS_ID, "name": "C9300-48P", "manufacturer": ACME_SYS_ID},
+        }
+    }
+
+    def _ambiguity(self, entry, data):
+        adapter = build_adapter(entry, sys_ids=deepcopy(self.DUPLICATE_MODELS))
+        device = models.Device(name="switch1", adapter=adapter)
+        with self.assertRaises(AmbiguousReferenceError) as context:
+            device.map_data_to_sn_record(data=data, mapping_entry=adapter.mapping_data["device"])
+        return str(context.exception)
+
+    def test_unapplied_constraint_does_not_advise_adding_one(self):
+        """The mapping already has a `match` clause; telling the user to add one is misleading."""
+        message = self._ambiguity(device_entry(MANUFACTURER_MATCH), {"model_name": "C9300-48P"})
+        self.assertNotIn("Add a `match` clause", message)
+        self.assertIn("manufacturer_name", message)
+
+    def test_missing_match_clause_advises_adding_one(self):
+        """With nothing to narrow by, adding a `match` clause is the actionable advice."""
+        message = self._ambiguity(device_entry(), {"model_name": "C9300-48P"})
+        self.assertIn("Add a `match` clause", message)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Single Source of Truth! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1323

## What's Changed

This PR includes many fixes and QOL adjustments for the ServiceNow integration.

- The primary change is that device models are now paired with their manufacturer. This allows for the same model name to exist and be referenced across multiple manufacturers.
- Previously, ambiguous records would fail silently (log to module logger only). Now, they log to the JobResult and report as a failed object in the Sync. This is also now exposed better in the Dry Run so they can be observed before a true sync. It now creates and attaches a txt file to the JobResult that can be reviewed.
- Interfaces are no longer created without a parent device.
- I replaced the `sys_ids_cache` altogether. It had a few flaws and it was not able to properly look up object cross-table, so it caused multiple additional API calls. I collapsed it into the existing `sys_ids` dict instead.
- Moved multiple debug logs behind the debug conditional to cut down on log spam for normal runs.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [N/A] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

NTC-6416