### PR TITLE
Silence F601 on LibreNMS status map boolean keys

### DIFF
--- a/changes/1350.housekeeping
+++ b/changes/1350.housekeeping
@@ -1,0 +1,1 @@
+Silenced `F601` on the duplicated boolean keys of the LibreNMS `librenms_status_map`, which newer `ruff` releases flag.

--- a/nautobot_ssot/integrations/librenms/constants.py
+++ b/nautobot_ssot/integrations/librenms/constants.py
@@ -13,8 +13,8 @@ PLUGIN_CFG = settings.PLUGINS_CONFIG["nautobot_ssot"]
 librenms_status_map = {  # pylint: disable=W0109
     0: "Offline",
     1: "Active",
-    True: "Active",
-    False: "Offline",
+    True: "Active",  # noqa: F601
+    False: "Offline",  # noqa: F601
 }
 
 os_manufacturer_map = {


### PR DESCRIPTION
Closes #1350

## What's Changed

Added `# noqa: F601` to the `True` and `False` keys of `librenms_status_map` in `nautobot_ssot/integrations/librenms/constants.py`.

Since `True == 1` and `False == 0`, the four literal keys collide in pairs. That is intentional, and the dict already carries `# pylint: disable=W0109` for it. Newer `ruff` releases report the same duplication as `F601`, which `0.5.5` does not, so the rule needs to be silenced for both linters instead of just pylint.

Both collisions resolve to the same value, `True` to `"Active"` like `1` and `False` to `"Offline"` like `0`, so the mapping is unchanged and no behavior is affected.

## Why now

nautobot/cookiecutter-nautobot-app#414 bumps the cookiecutter `ruff` pin from `0.5.5` to `0.16.4`. This repository was one of the three used to test that bump, and it is the only one that needed a code change. Landing this first keeps the drift manager pull request green when it brings the new pin over.

## Testing

`ruff check` on the file passes under both `0.5.5` and `0.16.4`, and `ruff format --check` reports no change.

The bump was validated end to end on a local branch of this repository with the pin set to `0.16.4`: `invoke pylint` scores 10.00/10 and `invoke unittest` runs 1731 tests with 20 skipped and no failures.
