### PR TITLE
Exclude all SSoT models from global search when `enable_global_search` is False

### DIFF
--- a/changes/1367.fixed
+++ b/changes/1367.fixed
@@ -1,0 +1,2 @@
+Fixed `enable_global_search: False` leaving the `Sync` model included in Nautobot global search; both `Sync` and `SyncLogEntry` are now excluded, as they were before 3.10.0.
+Fixed the SSoT `searchable_models` entries using mixed-case model names, which prevented model-scoped global search requests such as `?model=nautobot_ssot.sync` from matching.

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -83,7 +83,7 @@ The app behavior can be controlled with the following list of settings:
 |----------------------|----------------|-----------|-----------------------------------------------------------------------------|
 | `hide_example_jobs`  | `True`         | `False`   | A boolean to represent whether or not to display the example job.           |
 | `enable_metadata_for`| `DataSourceJob`| *(empty)* | List of job class names for which object metadata support should be enabled.      |
-| `enable_global_search`| `False`| `True` | A boolean to represent wether or not to allow nautobot global search to include SSOT Sync logs.      |
+| `enable_global_search`| `False`        | `True`    | A boolean to represent whether or not to allow Nautobot global search to include SSoT Sync and Sync Log Entry records. When `False`, no SSoT models are searchable. |
 
 ## Integrations Configuration
 

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -145,7 +145,7 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
     }
     config_view_name = "plugins:nautobot_ssot:config"
     docs_view_name = "plugins:nautobot_ssot:docs"
-    searchable_models = ["sync"]
+    # `searchable_models` is intentionally not declared here; `ready()` assigns it from `enable_global_search`.
 
     def ready(self):
         """Trigger callback when database is ready."""
@@ -156,12 +156,12 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
         if not is_truthy(os.getenv("NAUTOBOT_SSOT_ALLOW_CONFLICTING_APPS", "False")):
             _check_for_conflicting_apps()
 
-        # Only set searchable_models if enabled in config
-        if settings.PLUGINS_CONFIG["nautobot_ssot"].get("enable_global_search", True):
-            self.searchable_models = [
-                "Sync",
-                "SyncLogEntry",
-            ]
+        # Assign in both branches so no class-level default can leak through when global search is disabled.
+        # Nautobot expects lowercase model names and compares them as plain strings (`?model=nautobot_ssot.sync`).
+        if settings.PLUGINS_CONFIG.get("nautobot_ssot", {}).get("enable_global_search", True):
+            self.searchable_models = ["sync", "synclogentry"]
+        else:
+            self.searchable_models = []
 
 
 config = NautobotSSOTAppConfig  # pylint:disable=invalid-name

--- a/nautobot_ssot/tests/test_app_config.py
+++ b/nautobot_ssot/tests/test_app_config.py
@@ -7,7 +7,9 @@ from django.test import override_settings
 from nautobot.apps.testing import TestCase
 from nautobot.extras.plugins import NautobotAppConfig
 
-from nautobot_ssot import _check_for_conflicting_apps
+import nautobot_ssot
+from nautobot_ssot import NautobotSSOTAppConfig, _check_for_conflicting_apps
+from nautobot_ssot.models import Sync, SyncLogEntry
 
 
 class TestCheckForConflictingApps(TestCase):
@@ -41,3 +43,45 @@ class TestAppConfigReady(TestCase):
         ):
             app_config.ready()
         fake_module.register_signals.assert_called_once_with(app_config)
+
+
+class TestAppConfigSearchableModels(TestCase):
+    """Tests for how `enable_global_search` drives NautobotSSOTAppConfig.searchable_models."""
+
+    @staticmethod
+    def _ready_app_config(plugin_config):
+        """Instantiate a fresh app config and run ready() under the given `nautobot_ssot` PLUGINS_CONFIG.
+
+        A fresh instance, rather than the loaded app registry entry, starts each test from the class-level
+        state. The parent ready() and integration signal loading are mocked, as in TestAppConfigReady, so
+        only this app's own ready() logic runs.
+        """
+        app_config = NautobotSSOTAppConfig("nautobot_ssot", nautobot_ssot)
+        with (
+            override_settings(PLUGINS_CONFIG={"nautobot_ssot": plugin_config}),
+            patch.object(NautobotAppConfig, "ready"),
+            patch("nautobot_ssot.each_enabled_integration_module", return_value=[]),
+        ):
+            app_config.ready()
+        return app_config
+
+    def test_enabled_or_absent_makes_sync_and_synclogentry_searchable(self):
+        """Enabled explicitly or by default, exactly Sync and SyncLogEntry are searchable, as lowercase model names."""
+        for plugin_config in ({"enable_global_search": True}, {}):
+            with self.subTest(plugin_config=plugin_config):
+                app_config = self._ready_app_config(plugin_config)
+                self.assertEqual(app_config.searchable_models, ["sync", "synclogentry"])
+                self.assertEqual(
+                    [apps.get_model("nautobot_ssot", name) for name in app_config.searchable_models],
+                    [Sync, SyncLogEntry],
+                )
+
+    def test_disabled_makes_no_models_searchable(self):
+        app_config = self._ready_app_config({"enable_global_search": False})
+        self.assertEqual(app_config.searchable_models, [])
+
+    def test_disabled_overrides_class_level_default(self):
+        """A class-level `searchable_models` default must not leak through when global search is disabled."""
+        with patch.object(NautobotSSOTAppConfig, "searchable_models", ["sync"], create=True):
+            app_config = self._ready_app_config({"enable_global_search": False})
+            self.assertEqual(app_config.searchable_models, [])


### PR DESCRIPTION
# Closes: #1367

## What's Changed

`enable_global_search: False` was meant to keep all SSoT tables out of Nautobot's global search (#933 for #913, released in 3.9.3). Since 3.10.0 it only removed `SyncLogEntry`: #970 (cookiecutter drift sync) added a class-level `searchable_models = ["sync"]` to `NautobotSSOTAppConfig`, and the existing logic in `ready()` only assigned `self.searchable_models` when the setting was `True`, so the class default leaked through when it was `False`. The result was a `LIKE '%term%'` over `Sync.diff`, a JSON blob that can be megabytes per row, on every global search.

### `nautobot_ssot/__init__.py`
- Removed the class-level `searchable_models` default.
- `ready()` now assigns `self.searchable_models` in **both** branches: `["sync", "synclogentry"]` when enabled (the default), `[]` when disabled. A future template sync that re-adds the class attribute can no longer reintroduce the regression, because the instance attribute always shadows it.
- Switched the model names to lowercase. Nautobot's app docs specify lowercase names, and core's `SearchView` (3.x) builds `f"{app_label}.{modelname}"` from these strings verbatim and compares against the request's `model` parameter. The built-in search page round-trips whatever casing the app declares, so the previous `"Sync"` / `"SyncLogEntry"` worked there, but a model-scoped request such as `/search/?q=foo&model=nautobot_ssot.sync` did not match `nautobot_ssot.Sync`. Every core app and the cookiecutter template use lowercase. `apps.get_model()` is case-insensitive, so nothing else changes.
- The logic stays in `ready()` rather than `__init__` because #1023 deliberately moved it there so it runs after Django startup.

### `docs/admin/install.md`
- The `enable_global_search` row now says the setting controls whether Sync **and** Sync Log Entry records are included in global search, and that `False` makes no SSoT models searchable. Also fixed the "wether" typo.

### Tests (`nautobot_ssot/tests/test_app_config.py`)
- Enabled explicitly, or with the key absent: `searchable_models == ["sync", "synclogentry"]`, and each name resolves to the `Sync` / `SyncLogEntry` model.
- Disabled: `searchable_models == []`.
- Disabled with a class-level `searchable_models = ["sync"]` patched onto the class: still `[]`. This is the regression test that would have caught #970's change.

### Changelog
- `changes/1367.fixed`

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example (n/a, config-only change; nbshell output above)
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
