### PR TITLE
Fix Infoblox VLAN and VLANGroup ignoring deletable models (#1371)

### DIFF
--- a/changes/1371.fixed
+++ b/changes/1371.fixed
@@ -1,0 +1,1 @@
+Fixed Infoblox SSoT sync ignoring `nautobot_deletable_models` for VLAN and VLAN Group deletions, and added a safeguard to prevent deleting non-empty VLAN Groups.

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -411,8 +411,19 @@ class NautobotVlanGroup(VlanView):
 
     def delete(self):
         """Delete VLANGroup object in Nautobot."""
-        self.adapter.job.logger.warning(f"VLAN Group {self.name} will be deleted.")
+        if NautobotDeletableModelChoices.VLAN_GROUP not in self.adapter.config.nautobot_deletable_models:
+            return super().delete()
+
         _vg = OrmVlanGroup.objects.get(id=self.pk)
+        if _vg.vlans.exists():
+            self.adapter.job.logger.warning(
+                f"VLAN Group {self.name} cannot be deleted because it still contains VLANs."
+            )
+            return super().delete()
+
+        self.adapter.job.logger.warning(f"VLAN Group {self.name} will be deleted.")
+        if self.name in self.adapter.vlangroup_map:
+            del self.adapter.vlangroup_map[self.name]
         _vg.delete()
         return super().delete()
 
@@ -474,8 +485,17 @@ class NautobotVlan(Vlan):
 
     def delete(self):
         """Delete VLAN object in Nautobot."""
+        if NautobotDeletableModelChoices.VLAN not in self.adapter.config.nautobot_deletable_models:
+            return super().delete()
+
         self.adapter.job.logger.warning(f"VLAN {self.vid} will be deleted.")
         _vlan = OrmVlan.objects.get(id=self.pk)
+        if (
+            self.vlangroup
+            and self.vlangroup in self.adapter.vlan_map
+            and self.vid in self.adapter.vlan_map[self.vlangroup]
+        ):
+            del self.adapter.vlan_map[self.vlangroup][self.vid]
         _vlan.delete()
         return super().delete()
 

--- a/nautobot_ssot/tests/infoblox/test_nautobot_models.py
+++ b/nautobot_ssot/tests/infoblox/test_nautobot_models.py
@@ -1201,16 +1201,52 @@ class TestModelNautobotVlanGroupNamespaceVlan(TestCase):
         self.assertTrue(CustomField.objects.filter(key="department").exists())
 
     def test_vlangroup_delete(self):
-        """Validate VLANGroup object is deleted when absent from source."""
+        """Validate VLANGroup object is deleted when absent from source and enabled in deletable models."""
         self._add_source_namespaces(include_dev=True)
         VLANGroup.objects.get_or_create(name="VG-To-Delete")
 
+        self.config.nautobot_deletable_models = [NautobotDeletableModelChoices.VLAN_GROUP]
         nb_adapter = NautobotAdapter(config=self.config)
         nb_adapter.job = Mock(debug=True)
         nb_adapter.load()
         self.infoblox_adapter.sync_to(nb_adapter)
 
         self.assertFalse(VLANGroup.objects.filter(name="VG-To-Delete").exists())
+
+    def test_vlangroup_delete_not_in_deletable_models(self):
+        """Validate VLANGroup object is not deleted when absent from source if not in deletable models."""
+        self._add_source_namespaces(include_dev=True)
+        VLANGroup.objects.get_or_create(name="VG-Keep")
+
+        self.config.nautobot_deletable_models = []
+        nb_adapter = NautobotAdapter(config=self.config)
+        nb_adapter.job = Mock(debug=True)
+        nb_adapter.load()
+        self.infoblox_adapter.sync_to(nb_adapter)
+
+        self.assertTrue(VLANGroup.objects.filter(name="VG-Keep").exists())
+
+    def test_vlangroup_delete_has_vlans_skips_deletion(self):
+        """Validate VLANGroup object is not deleted if it still contains VLANs."""
+        self._add_source_namespaces(include_dev=True)
+        vg, _ = VLANGroup.objects.get_or_create(name="VG-With-VLAN")
+        VLAN.objects.get_or_create(
+            vid=100,
+            name="VLAN100",
+            vlan_group=vg,
+            status=self.status_active,
+        )
+
+        self.config.nautobot_deletable_models = [NautobotDeletableModelChoices.VLAN_GROUP]
+        nb_adapter = NautobotAdapter(config=self.config)
+        nb_adapter.job = Mock(debug=True, logger=Mock())
+        nb_adapter.load()
+        self.infoblox_adapter.sync_to(nb_adapter)
+
+        self.assertTrue(VLANGroup.objects.filter(name="VG-With-VLAN").exists())
+        nb_adapter.job.logger.warning.assert_any_call(
+            "VLAN Group VG-With-VLAN cannot be deleted because it still contains VLANs."
+        )
 
     def test_namespace_update_ext_attrs(self):
         """Validate Namespace update applies ext attrs via sync."""
@@ -1275,6 +1311,46 @@ class TestModelNautobotVlanGroupNamespaceVlan(TestCase):
         self.assertEqual("Updated VLAN description", vlan.description)
         self.assertEqual("Operations", vlan.custom_field_data.get("department"))
         self.assertEqual(self.location.id, vg.location_id)
+
+    def test_vlan_delete_not_in_deletable_models(self):
+        """Validate VLAN object is not deleted when absent from source if not in deletable models."""
+        self._add_source_namespaces(include_dev=True)
+        vg, _ = VLANGroup.objects.get_or_create(name="VG-Test-Keep")
+        VLAN.objects.get_or_create(
+            vid=300,
+            name="VLAN300",
+            vlan_group=vg,
+            status=self.status_active,
+        )
+        self.infoblox_adapter.add(self.infoblox_adapter.vlangroup(name="VG-Test-Keep", description="", ext_attrs={}))
+
+        self.config.nautobot_deletable_models = []
+        nb_adapter = NautobotAdapter(config=self.config)
+        nb_adapter.job = Mock(debug=True)
+        nb_adapter.load()
+        self.infoblox_adapter.sync_to(nb_adapter)
+
+        self.assertTrue(VLAN.objects.filter(name="VLAN300", vid=300).exists())
+
+    def test_vlan_delete_success(self):
+        """Validate VLAN object is deleted when absent from source and enabled in deletable models."""
+        self._add_source_namespaces(include_dev=True)
+        vg, _ = VLANGroup.objects.get_or_create(name="VG-Test-Del")
+        VLAN.objects.get_or_create(
+            vid=301,
+            name="VLAN301",
+            vlan_group=vg,
+            status=self.status_active,
+        )
+        self.infoblox_adapter.add(self.infoblox_adapter.vlangroup(name="VG-Test-Del", description="", ext_attrs={}))
+
+        self.config.nautobot_deletable_models = [NautobotDeletableModelChoices.VLAN]
+        nb_adapter = NautobotAdapter(config=self.config)
+        nb_adapter.job = Mock(debug=True)
+        nb_adapter.load()
+        self.infoblox_adapter.sync_to(nb_adapter)
+
+        self.assertFalse(VLAN.objects.filter(name="VLAN301", vid=301).exists())
 
 
 class TestModelNautobotBranchMatrix(TestCase):


### PR DESCRIPTION
# Closes: #1371

## What's Changed

### Problem
In `nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py`, `NautobotVlanGroup.delete()` and `NautobotVlan.delete()` did not check `self.adapter.config.nautobot_deletable_models` before deleting records from the database. 

This caused two issues:
1. VLANs and VLAN Groups were unconditionally deleted from Nautobot even when excluded from `nautobot_deletable_models`.
2. In multi-source or multi-worker setups where multiple Infoblox instances or jobs manage disjoint sets of VLANs within shared VLAN groups, attempting to delete a VLAN Group that still contains child VLANs resulted in a `django.db.models.deletion.ProtectedError`.

### Solution
- **`NautobotVlanGroup.delete()`**:
  - Checks if `NautobotDeletableModelChoices.VLAN_GROUP` is in `self.adapter.config.nautobot_deletable_models`. If not, returns `super().delete()` to keep the database object intact while updating DiffSync state.
  - Adds a check for `_vg.vlans.exists()`: if child VLANs still exist in the VLAN Group, logs a warning and returns `super().delete()` to prevent a `ProtectedError`.
  - Cleans up `self.adapter.vlangroup_map` when a deletion occurs.
- **`NautobotVlan.delete()`**:
  - Checks if `NautobotDeletableModelChoices.VLAN` is in `self.adapter.config.nautobot_deletable_models`. If not, returns `super().delete()`.
  - Cleans up `self.adapter.vlan_map` when a deletion occurs.
- **Unit Tests**:
  - Updated `test_vlangroup_delete` to explicitly test deletion when `VLAN_GROUP` is enabled in `nautobot_deletable_models`.
  - Added `test_vlangroup_delete_not_in_deletable_models` (negative test).
  - Added `test_vlangroup_delete_has_vlans_skips_deletion` (verifies the non-empty VLAN Group guard and warning).
  - Added `test_vlan_delete_not_in_deletable_models` (negative test).
  - Added `test_vlan_delete_success` (positive test with cache map cleanup).
- **Changelog**:
  - Added towncrier fragment `changes/1371.fixed`.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example *(N/A - backend logic fix)*
- [x] Unit, Integration Tests
- [ ] Documentation Updates *(N/A - bugfix respecting existing documented config)*
- [x] Outline Remaining Work, Constraints from Design